### PR TITLE
feat: add support for saving values to original model

### DIFF
--- a/database/migrations/add_entity_column_support.php
+++ b/database/migrations/add_entity_column_support.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add uses_entity_column flag to custom_fields table
+        Schema::table(config('custom-fields.database.table_names.custom_fields'), function (Blueprint $table): void {
+            $table->boolean('uses_entity_column')->default(false)->after('system_defined');
+        });
+
+        // Add value column to custom_field_options table
+        Schema::table(config('custom-fields.database.table_names.custom_field_options'), function (Blueprint $table): void {
+            $table->string('value')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table(config('custom-fields.database.table_names.custom_fields'), function (Blueprint $table): void {
+            $table->dropColumn('uses_entity_column');
+        });
+
+        Schema::table(config('custom-fields.database.table_names.custom_field_options'), function (Blueprint $table): void {
+            $table->dropColumn('value');
+        });
+    }
+};

--- a/src/Data/CustomFieldData.php
+++ b/src/Data/CustomFieldData.php
@@ -27,6 +27,7 @@ final class CustomFieldData extends Data
         public CustomFieldSectionData $section,
         public bool $active = true,
         public bool $systemDefined = false,
+        public bool $usesEntityColumn = false,
         public CustomFieldWidth $width = CustomFieldWidth::_100,
         public ?string $entityType = null,
         public ?array $options = null,

--- a/src/Filament/Integration/Migrations/CustomFieldsMigrator.php
+++ b/src/Filament/Integration/Migrations/CustomFieldsMigrator.php
@@ -264,10 +264,24 @@ class CustomFieldsMigrator implements CustomsFieldsMigrators
         $customField->options()->createMany(
             collect($options)
                 ->map(function (mixed $value, mixed $key) {
-                    $data = [
-                        'name' => $value,
-                        'sort_order' => $key,
-                    ];
+                    // Handle both formats:
+                    // 1. Simple: ['M' => 'Male', 'F' => 'Female']
+                    // 2. Detailed: [['value' => 'M', 'label' => 'Male'], ...]
+                    if (is_array($value) && isset($value['value'], $value['label'])) {
+                        // Detailed format
+                        $data = [
+                            'name' => $value['label'],
+                            'value' => $value['value'],
+                            'sort_order' => is_int($key) ? $key : 0,
+                        ];
+                    } else {
+                        // Simple format: key => value
+                        $data = [
+                            'name' => $value,
+                            'value' => is_string($key) ? $key : null,
+                            'sort_order' => is_int($key) ? $key : 0,
+                        ];
+                    }
 
                     if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
                         $data[config(

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -42,22 +42,57 @@ class FieldForm implements FormInterface
     public static function schema(bool $withOptionsRelationship = true): array
     {
         $optionsRepeater = Repeater::make('options')
-            ->table([
-                TableColumn::make('Color')->width('150px')->hiddenHeaderLabel(),
-                TableColumn::make('Name')->hiddenHeaderLabel(),
-            ])
-            ->schema([
-                ColorPicker::make('settings.color')
-                    ->columnSpan(3)
-                    ->hexColor()
-                    ->visible(
-                        fn (
-                            Get $get
-                        ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
-                            $get('../../settings.enable_option_colors')
-                    ),
-                TextInput::make('name')->required()->columnSpan(9)->distinct(),
-            ])
+            ->table(function (Get $get): array {
+                $hasColors = FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
+                    $get('settings.enable_option_colors');
+
+                $columns = [];
+
+                if ($hasColors) {
+                    $columns[] = TableColumn::make('Color')->width('100px');
+                }
+
+                if (! $hasColors) {
+                    $columns[] = TableColumn::make('Value')->width('150px');
+                }
+
+                $columns[] = TableColumn::make('Name');
+
+                return $columns;
+            })
+            ->schema(function (Get $get): array {
+                $hasColors = FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
+                    $get('settings.enable_option_colors');
+
+                $fields = [];
+
+                if ($hasColors) {
+                    $fields[] = ColorPicker::make('settings.color')
+                        ->hexColor()
+                        ->label('Color')
+                        ->columnSpan(2)
+                    ;
+                } else {
+                    $fields[] = TextInput::make('value')
+                        ->label('Value')
+                        ->placeholder('M')
+                        ->distinct()
+                        ->disabled(fn (Get $get): bool => (bool) $get('../../uses_entity_column'))
+                        ->columnSpan(3)
+                    ;
+                }
+
+                $fields[] = TextInput::make('name')
+                    ->required()
+                    ->label('Name')
+                    ->placeholder('Male')
+                    ->distinct()
+                    ->disabled(fn (Get $get): bool => (bool) $get('../../uses_entity_column'))
+                    ->columnSpan($hasColors ? 10 : 9)
+                ;
+
+                return $fields;
+            })
             ->columns(12)
             ->columnSpanFull()
             ->requiredUnless('type', function (callable $get) {
@@ -81,6 +116,7 @@ class FieldForm implements FormInterface
                     && CustomFieldsType::getFieldType($get('type'))->dataType->isChoiceField()
                     && ! CustomFieldsType::getFieldType($get('type'))->withoutUserOptions
             )
+            ->disabled(fn (Get $get): bool => (bool) $get('uses_entity_column'))
             ->mutateRelationshipDataBeforeCreateUsing(function (
                 array $data
             ): array {
@@ -89,7 +125,8 @@ class FieldForm implements FormInterface
                 }
 
                 return $data;
-            });
+            })
+        ;
 
         if ($withOptionsRelationship) {
             $optionsRepeater = $optionsRepeater->relationship();
@@ -156,11 +193,6 @@ class FieldForm implements FormInterface
                             ->live(onBlur: true)
                             ->required()
                             ->maxLength(50)
-                            ->disabled(
-                                fn (
-                                    ?CustomField $record
-                                ): bool => (bool) $record?->system_defined
-                            )
                             ->unique(
                                 table: CustomFields::customFieldModel(),
                                 column: 'name',
@@ -257,38 +289,21 @@ class FieldForm implements FormInterface
                             ->columnSpanFull()
                             ->columns(2)
                             ->schema([
-                                // Visibility settings
-                                Toggle::make('settings.visible_in_list')
+                                // Storage settings
+                                Toggle::make('uses_entity_column')
                                     ->inline(false)
                                     ->live()
-                                    ->label(
-                                        __(
-                                            'custom-fields::custom-fields.field.form.visible_in_list'
-                                        )
+                                    ->label('Store in Entity Column')
+                                    ->helperText('When enabled, this field will store its value directly in a column on the entity model instead of the custom_field_values table. The column name must match the field code.')
+                                    ->visible(
+                                        fn (Get $get): bool => $get('type') !== null
                                     )
-                                    ->afterStateHydrated(function (
-                                        Toggle $component,
-                                        ?Model $record
-                                    ): void {
-                                        if (is_null($record)) {
-                                            $component->state(true);
-                                        }
-                                    }),
-                                Toggle::make('settings.visible_in_view')
-                                    ->inline(false)
-                                    ->label(
-                                        __(
-                                            'custom-fields::custom-fields.field.form.visible_in_view'
-                                        )
+                                    ->disabled(
+                                        fn (
+                                            ?CustomField $record
+                                        ): bool => (bool) $record?->exists
                                     )
-                                    ->afterStateHydrated(function (
-                                        Toggle $component,
-                                        ?Model $record
-                                    ): void {
-                                        if (is_null($record)) {
-                                            $component->state(true);
-                                        }
-                                    }),
+                                    ->default(false),
                                 Toggle::make('settings.list_toggleable_hidden')
                                     ->inline(false)
                                     ->label(
@@ -311,10 +326,42 @@ class FieldForm implements FormInterface
                                         Toggle $component,
                                         ?Model $record
                                     ): void {
-                                        if (is_null($record)) {
+                                        if ($record === null) {
                                             $component->state(
                                                 FeatureManager::isEnabled(CustomFieldsFeature::UI_TOGGLEABLE_COLUMNS_HIDDEN_DEFAULT)
                                             );
+                                        }
+                                    }),
+                                // Visibility settings
+                                Toggle::make('settings.visible_in_list')
+                                    ->inline(false)
+                                    ->live()
+                                    ->label(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.visible_in_list'
+                                        )
+                                    )
+                                    ->afterStateHydrated(function (
+                                        Toggle $component,
+                                        ?Model $record
+                                    ): void {
+                                        if ($record === null) {
+                                            $component->state(true);
+                                        }
+                                    }),
+                                Toggle::make('settings.visible_in_view')
+                                    ->inline(false)
+                                    ->label(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.visible_in_view'
+                                        )
+                                    )
+                                    ->afterStateHydrated(function (
+                                        Toggle $component,
+                                        ?Model $record
+                                    ): void {
+                                        if ($record === null) {
+                                            $component->state(true);
                                         }
                                     }),
                                 // Data settings
@@ -339,7 +386,7 @@ class FieldForm implements FormInterface
                                         Toggle $component,
                                         mixed $state
                                     ): void {
-                                        if (is_null($state)) {
+                                        if ($state === null) {
                                             $component->state(false);
                                         }
                                     }),
@@ -381,7 +428,8 @@ class FieldForm implements FormInterface
                                     ->visible(
                                         fn (
                                             Get $get
-                                        ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
+                                        ): bool => ! $get('uses_entity_column') &&
+                                            FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
                                             in_array((string) $get('type'), [
                                                 'select',
                                                 'multi_select',
@@ -410,7 +458,7 @@ class FieldForm implements FormInterface
                                 'options' => __(
                                     'custom-fields::custom-fields.field.form.options_lookup_type.options'
                                 ),
-                                'lookup' => __(
+                                'lookup'  => __(
                                     'custom-fields::custom-fields.field.form.options_lookup_type.lookup'
                                 ),
                             ])

--- a/src/Models/Concerns/UsesCustomFields.php
+++ b/src/Models/Concerns/UsesCustomFields.php
@@ -98,9 +98,20 @@ trait UsesCustomFields
 
     public function getCustomFieldValue(CustomField $customField): mixed
     {
+        // If field uses entity column, read directly from model
+        if ($customField->usesEntityColumn()) {
+            $value = $this->getAttribute($customField->code);
+
+            // For choice fields with options, we need to return the value as-is
+            // since the form components will use it with pluck('name', 'id')
+            // where 'id' is actually the 'value' thanks to our accessor
+            return $value;
+        }
+
         $fieldValue = $this->customFieldValues
             ->firstWhere('custom_field_id', $customField->getKey())
-            ?->getValue();
+            ?->getValue()
+        ;
 
         if (empty($fieldValue)) {
             return $fieldValue;
@@ -117,6 +128,11 @@ trait UsesCustomFields
 
     public function saveCustomFieldValue(CustomField $customField, mixed $value, ?Model $tenant = null): void
     {
+        // Entity column fields should not use this method
+        if ($customField->usesEntityColumn()) {
+            return;
+        }
+
         $data = ['custom_field_id' => $customField->getKey()];
 
         if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
@@ -163,7 +179,11 @@ trait UsesCustomFields
     {
         $this->customFields()->each(function (CustomField $customField) use ($customFields, $tenant): void {
             $value = $customFields[$customField->code] ?? null;
-            $this->saveCustomFieldValue($customField, $value, $tenant);
+
+            // Skip entity column fields - they're already saved as regular model attributes
+            if (! $customField->usesEntityColumn()) {
+                $this->saveCustomFieldValue($customField, $value, $tenant);
+            }
         });
     }
 }

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -39,6 +39,7 @@ use Spatie\LaravelData\DataCollection;
  * @property int $sort_order
  * @property bool $active
  * @property bool $system_defined
+ * @property bool $uses_entity_column
  * @property FieldTypeData $typeData
  * @property CustomFieldWidth $width
  *
@@ -115,6 +116,7 @@ class CustomField extends Model
             'validation_rules' => DataCollection::class.':'.ValidationRuleData::class.',default',
             'active' => 'boolean',
             'system_defined' => 'boolean',
+            'uses_entity_column' => 'boolean',
             'settings' => CustomFieldSettingsData::class.':default',
         ];
     }
@@ -161,6 +163,14 @@ class CustomField extends Model
         return $this->system_defined === true;
     }
 
+    /**
+     * Determine if the field saves to entity column instead of custom_field_values.
+     */
+    public function usesEntityColumn(): bool
+    {
+        return $this->uses_entity_column === true;
+    }
+
     public function getValueColumn(): string
     {
         return CustomFields::newValueModel()::getValueColumn($this->type);
@@ -168,6 +178,11 @@ class CustomField extends Model
 
     public function getFieldName(): string
     {
+        // Entity column fields are saved directly to model columns, not under custom_fields
+        if ($this->usesEntityColumn()) {
+            return $this->code;
+        }
+
         return 'custom_fields.'.$this->code;
     }
 }

--- a/src/Models/CustomFieldOption.php
+++ b/src/Models/CustomFieldOption.php
@@ -20,6 +20,7 @@ use Relaticle\CustomFields\Models\Scopes\TenantScope;
 /**
  * @property int $id
  * @property ?string $name
+ * @property ?string $value
  * @property ?int $sort_order
  * @property CustomFieldOptionSettingsData $settings
  * @property int $custom_field_id
@@ -72,6 +73,7 @@ class CustomFieldOption extends Model
     protected $visible = [
         'id',
         'name',
+        'value',
         'settings',
         'sort_order',
         'custom_field_id',
@@ -101,6 +103,17 @@ class CustomFieldOption extends Model
                 // Value is not encrypted, return as-is
                 return Crypt::decryptString($value);
             }
+        );
+    }
+
+    /**
+     * Return value if it exists, otherwise fallback to id for backward compatibility.
+     * This allows pluck('name', 'id') to work with value-based options.
+     */
+    protected function id(): Attribute
+    {
+        return Attribute::make(
+            get: fn (int $value): int|string => $this->attributes['value'] ?? $value
         );
     }
 

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -34,10 +34,16 @@ final class ValidationService
         $userRules = $this->convertUserRulesToValidatorFormat($customField->validation_rules, $customField);
 
         // Get field type default rules (always applied for data integrity)
-        $fieldTypeDefaultRules = $this->getFieldTypeDefaultRules($customField->type);
+        $fieldTypeDefaultRules = $this->getFieldTypeDefaultRules($customField->type, $customField);
+
+        // For fields that use entity column, skip database constraint rules
+        // since they save to model columns with their own types
+        if ($customField->usesEntityColumn()) {
+            return $this->combineRules($fieldTypeDefaultRules, $userRules);
+        }
 
         // Get database constraint rules based on storage column
-        $isEncrypted = $customField->settings->encrypted ?? false;
+        $isEncrypted   = $customField->settings->encrypted ?? false;
         $databaseRules = $this->getDatabaseValidationRules($customField->type, $isEncrypted);
 
         // Merge all rule types: field defaults + user rules + database constraints
@@ -53,7 +59,8 @@ final class ValidationService
     public function isRequired(CustomField $customField): bool
     {
         return $customField->validation_rules->toCollection()
-            ->contains('name', ValidationRule::REQUIRED->value);
+            ->contains('name', ValidationRule::REQUIRED->value)
+        ;
     }
 
     /**
@@ -70,21 +77,31 @@ final class ValidationService
         }
 
         return $rules->toCollection()
+            ->filter(function (ValidationRuleData $ruleData) use ($customField): bool {
+                // For choice fields using entity columns, filter out numeric/integer rules
+                // since these fields store enum values (strings) not integer IDs
+                if ($customField->usesEntityColumn() && $customField->isChoiceField()) {
+                    return ! in_array($ruleData->name, ['numeric', 'integer']);
+                }
+
+                return true;
+            })
             ->map(function (ValidationRuleData $ruleData) use ($customField): string {
                 if ($ruleData->parameters === []) {
                     return $ruleData->name;
                 }
 
-                // For choice fields with IN or NOT_IN rules, convert option names to IDs
+                // For choice fields with IN or NOT_IN rules, convert option names to IDs/values
                 if ($customField->isChoiceField() && in_array($ruleData->name, ['in', 'not_in'])) {
                     $parameters = $this->convertOptionNamesToIds($ruleData->parameters, $customField);
 
-                    return $ruleData->name.':'.implode(',', $parameters);
+                    return $ruleData->name . ':' . implode(',', $parameters);
                 }
 
-                return $ruleData->name.':'.implode(',', $ruleData->parameters);
+                return $ruleData->name . ':' . implode(',', $ruleData->parameters);
             })
-            ->toArray();
+            ->toArray()
+        ;
     }
 
     /**
@@ -120,7 +137,7 @@ final class ValidationService
      * @param  array<int, string>  $secondaryRules  Rules that are overridden by primary rules
      * @return array<int, string> Combined rules
      */
-    private function combineRules(array $primaryRules, array $secondaryRules): array
+    protected function combineRules(array $primaryRules, array $secondaryRules): array
     {
         // Extract rule names (without parameters) from primary rules
         $primaryRuleNames = array_map(fn (string $rule): string => explode(':', $rule, 2)[0], $primaryRules);
@@ -166,18 +183,25 @@ final class ValidationService
      * 2. Field type definition's defaultValidationRules
      *
      * @param  string  $fieldType  The field type
+     * @param  CustomField  $customField  The custom field for context
      * @return array<int, string> Array of default validation rules
      */
-    private function getFieldTypeDefaultRules(string $fieldType): array
+    private function getFieldTypeDefaultRules(string $fieldType, CustomField $customField): array
     {
         // Get from field type definition's defaultValidationRules
-        $fieldTypeManager = app(FieldManager::class);
+        $fieldTypeManager  = app(FieldManager::class);
         $fieldTypeInstance = $fieldTypeManager->getFieldTypeInstance($fieldType);
 
         if ($fieldTypeInstance) {
             $configurator = $fieldTypeInstance->configure();
+            $rules        = $configurator->getDefaultValidationRules();
 
-            return $configurator->getDefaultValidationRules();
+            // For choice fields using entity columns, filter out numeric/integer rules
+            if ($customField->usesEntityColumn() && $customField->isChoiceField()) {
+                $rules = array_filter($rules, fn (string $rule): bool => ! in_array(explode(':', $rule, 2)[0], ['numeric', 'integer']));
+            }
+
+            return $rules;
         }
 
         return [];
@@ -203,7 +227,7 @@ final class ValidationService
         $mergedRules = $this->combineRules($mergedRules, $userRules);
 
         // Apply database constraint rules using existing logic
-        $columnName = CustomFieldValue::getValueColumn($fieldType);
+        $columnName    = CustomFieldValue::getValueColumn($fieldType);
         $dbConstraints = DatabaseFieldConstraints::getConstraintsForColumn($columnName);
 
         if ($dbConstraints !== null && $dbConstraints !== []) {


### PR DESCRIPTION
This PR adds support for storing custom field values directly in entity model columns instead of the `custom_field_values` table. This is particularly useful for system-defined fields that map to existing database columns while maintaining the custom fields UI for managing field metadata.

## Features Added

##### 1. Entity Column Storage Flag

  - Added `uses_entity_column` boolean flag to `custom_fields` table
  - When enabled, field values are stored directly in the entity model's column (matching the field `code`)
  - Regular custom fields continue to use the `custom_field_values` table

##### 2. Option Value/Label Separation

  - Added `value` column to `custom_field_options` table
  - Allows storing distinct values (e.g., 'M') and labels (e.g., 'Male') for select/choice fields
  - Backward compatible: falls back to option `id` when `value` is null
  - Particularly useful for enum-based fields with specific database values

##### 4. UI Enhancements

  - Added "Store in Entity Column" toggle in field management form
  - Dynamic options table showing either "Value" or "Color" columns based on settings
  - System-defined fields can now have their label edited (while keeping code/type locked)

<img width="1342" height="1554" alt="image" src="https://github.com/user-attachments/assets/76356fa6-a374-4f0b-827d-fb7a2843dca3" />

## Use Case Example

```php
  // Create a system-defined field that maps to the 'sex' column on Patient model
  $field = $this->migrator->new(
      model: Patient::class,
      fieldData: new CustomFieldData(
          name: 'Sex',
          code: 'sex',
          type: 'select',
          section: $section,
          systemDefined: true,
          usesEntityColumn: true,  // ← Stores in patients.sex column
      )
  );

  $field->options([
      ['value' => 'M', 'label' => 'Male'],
      ['value' => 'F', 'label' => 'Female'],
  ]);

  $field->create();
```

## Breaking Changes

None - this is a fully backward-compatible addition. Existing fields without `uses_entity_column` set will continue working as before.