### PR TITLE
[WIP] feat: add regex validator

### DIFF
--- a/src/Enums/ValidationRule.php
+++ b/src/Enums/ValidationRule.php
@@ -130,7 +130,8 @@ enum ValidationRule: string implements HasLabel
             self::SIZE, self::MAX, self::MIN, self::DIGITS, self::DATE_EQUALS,
             self::DATE_FORMAT, self::AFTER, self::AFTER_OR_EQUAL, self::BEFORE,
             self::BEFORE_OR_EQUAL, self::EXISTS, self::UNIQUE, self::GT, self::GTE,
-            self::LT, self::LTE, self::MAX_DIGITS, self::MIN_DIGITS, self::MULTIPLE_OF => 1,
+            self::LT, self::LTE, self::MAX_DIGITS, self::MIN_DIGITS, self::MULTIPLE_OF,
+            self::REGEX, self::NOT_REGEX => 1,
 
             // Default case for any unspecified rules
             default => 0

--- a/src/FieldTypeSystem/Definitions/ColorPickerFieldType.php
+++ b/src/FieldTypeSystem/Definitions/ColorPickerFieldType.php
@@ -29,6 +29,7 @@ class ColorPickerFieldType extends BaseFieldType
             ->priority(90)
             ->availableValidationRules([
                 ValidationRule::REQUIRED,
+                ValidationRule::REGEX,
                 ValidationRule::STARTS_WITH,
             ]);
     }

--- a/src/FieldTypeSystem/Definitions/LinkFieldType.php
+++ b/src/FieldTypeSystem/Definitions/LinkFieldType.php
@@ -30,6 +30,7 @@ class LinkFieldType extends BaseFieldType
             ->availableValidationRules([
                 ValidationRule::REQUIRED,
                 ValidationRule::URL,
+                ValidationRule::REGEX,
                 ValidationRule::STARTS_WITH,
             ]);
     }

--- a/src/FieldTypeSystem/Definitions/MarkdownEditorFieldType.php
+++ b/src/FieldTypeSystem/Definitions/MarkdownEditorFieldType.php
@@ -31,6 +31,7 @@ class MarkdownEditorFieldType extends BaseFieldType
                 ValidationRule::REQUIRED,
                 ValidationRule::MIN,
                 ValidationRule::MAX,
+                ValidationRule::REGEX,
             ]);
     }
 }

--- a/src/FieldTypeSystem/Definitions/RichEditorFieldType.php
+++ b/src/FieldTypeSystem/Definitions/RichEditorFieldType.php
@@ -31,6 +31,7 @@ final class RichEditorFieldType extends BaseFieldType
                 ValidationRule::REQUIRED,
                 ValidationRule::MIN,
                 ValidationRule::MAX,
+                ValidationRule::REGEX,
             ]);
     }
 }

--- a/src/FieldTypeSystem/Definitions/TextFieldType.php
+++ b/src/FieldTypeSystem/Definitions/TextFieldType.php
@@ -36,6 +36,7 @@ class TextFieldType extends BaseFieldType
                 ValidationRule::ALPHA_NUM,
                 ValidationRule::ALPHA_DASH,
                 ValidationRule::EMAIL,
+                ValidationRule::REGEX,
                 ValidationRule::STARTS_WITH,
                 ValidationRule::ENDS_WITH,
             ]);

--- a/src/FieldTypeSystem/Definitions/TextareaFieldType.php
+++ b/src/FieldTypeSystem/Definitions/TextareaFieldType.php
@@ -31,6 +31,7 @@ final class TextareaFieldType extends BaseFieldType
                 ValidationRule::REQUIRED,
                 ValidationRule::MIN,
                 ValidationRule::MAX,
+                ValidationRule::REGEX,
             ]);
     }
 }

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -29,7 +29,7 @@ use Relaticle\CustomFields\Support\Utils;
 
 class CustomFieldsManagementPage extends Page
 {
-    protected static string|BackedEnum|null $navigationIcon = 'heroicon-m-document-text';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-document-text';
 
     protected string $view = 'custom-fields::filament.pages.custom-fields-management';
 

--- a/tests/Datasets/ValidationRulesDataset.php
+++ b/tests/Datasets/ValidationRulesDataset.php
@@ -536,6 +536,16 @@ dataset('field_type_validation_compatibility', fn (): array => [
         'allowedRules' => ['required', 'min', 'max', 'between', 'regex', 'alpha', 'alpha_num', 'alpha_dash', 'string', 'email', 'starts_with'],
         'disallowedRules' => ['numeric', 'integer', 'boolean', 'array', 'date'],
     ],
+    'textarea_field_rules' => [
+        'fieldType' => 'textarea',
+        'allowedRules' => ['required', 'min', 'max', 'regex'],
+        'disallowedRules' => ['numeric', 'integer', 'boolean', 'array', 'date', 'email'],
+    ],
+    'markdown_editor_field_rules' => [
+        'fieldType' => 'markdown-editor',
+        'allowedRules' => ['required', 'min', 'max', 'regex'],
+        'disallowedRules' => ['numeric', 'integer', 'boolean', 'array', 'date', 'email'],
+    ],
     'number_field_rules' => [
         'fieldType' => 'number',
         'allowedRules' => ['required', 'numeric', 'min', 'max', 'between', 'integer', 'starts_with'],
@@ -573,12 +583,17 @@ dataset('field_type_validation_compatibility', fn (): array => [
     ],
     'rich-editor_field_rules' => [
         'fieldType' => 'rich-editor',
-        'allowedRules' => ['required', 'string', 'min', 'max', 'between', 'starts_with'],
+        'allowedRules' => ['required', 'string', 'min', 'max', 'between', 'regex', 'starts_with'],
         'disallowedRules' => ['numeric', 'alpha', 'boolean', 'array', 'date', 'integer'],
     ],
     'url_field_rules' => [
         'fieldType' => 'link',
-        'allowedRules' => ['required', 'url', 'starts_with'],
+        'allowedRules' => ['required', 'url', 'regex', 'starts_with'],
         'disallowedRules' => ['numeric', 'alpha', 'boolean', 'array', 'date', 'integer'],
+    ],
+    'color_picker_field_rules' => [
+        'fieldType' => 'color-picker',
+        'allowedRules' => ['required', 'regex', 'starts_with'],
+        'disallowedRules' => ['numeric', 'integer', 'boolean', 'array', 'date', 'email'],
     ],
 ]);

--- a/tests/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/Fixtures/Resources/Posts/PostResource.php
@@ -28,7 +28,7 @@ class PostResource extends Resource
 
     protected static string|UnitEnum|null $navigationGroup = 'Blog';
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
 
     protected static ?string $recordTitleAttribute = 'title';
 


### PR DESCRIPTION
This pull request adds support for the `regex` validation rule to several field types and ensures it is properly handled throughout the codebase. The changes update both the validation rule definitions and the field type configurations, as well as the associated tests and type hints.

**Validation Rule Support**

* Added `REGEX` and `NOT_REGEX` to the list of validation rules that accept a single parameter in the `ValidationRule` enum (`src/Enums/ValidationRule.php`).

**Field Type Configuration**

* Enabled the `REGEX` validation rule for the following field types: `ColorPickerFieldType`, `LinkFieldType`, `MarkdownEditorFieldType`, `RichEditorFieldType`, `TextFieldType`, and `TextareaFieldType` (`src/FieldTypeSystem/Definitions/*.php`). [[1]](diffhunk://#diff-97d2b99111b98d1c8b40bb11b0b8e0be5cbddc3f120ae44db58d47f18d65bf47R32) [[2]](diffhunk://#diff-c5db1ad5977433bf521a038129e7f153e62605d9f74c51e4353d29d2d8811088R33) [[3]](diffhunk://#diff-7b9f9742de5f8a0e4a67986136604dcf0eb6d213a7e8c950d207151df1243185R34) [[4]](diffhunk://#diff-9d7899c3728be6e13b9e8956097cbd0eaa3009a26f755aee7ab7d872d3a3baf7R34) [[5]](diffhunk://#diff-e0c53a642c150135cfeeed3264b762a7eea5de315796c5db649cc5b348f9047aR39) [[6]](diffhunk://#diff-6f1041857cbc7357ab463ed910595dc8ea52f6028e1f0f35f4eb0fa425802005R34)

**Testing Updates**

* Updated the validation rules dataset to include `regex` as an allowed rule for the affected field types and added new test cases for `color-picker`, `textarea`, and `markdown-editor` field types (`tests/Datasets/ValidationRulesDataset.php`). [[1]](diffhunk://#diff-ad36298e79b0f7a49589b5e6c601ca3d019548d1980e2f7d9bbca54f330ffc4dR539-R548) [[2]](diffhunk://#diff-ad36298e79b0f7a49589b5e6c601ca3d019548d1980e2f7d9bbca54f330ffc4dL576-R598)

**Type Hinting**

* Fixed type hints for `navigationIcon` properties in `CustomFieldsManagementPage` and `PostResource` to use fully qualified `\BackedEnum` (`src/Filament/Management/Pages/CustomFieldsManagementPage.php`, `tests/Fixtures/Resources/Posts/PostResource.php`). [[1]](diffhunk://#diff-23814a6edc17e942e3a68b8af8cbd8673d5c9a0b58307b36f4bbe7a4b78ae9aaL32-R32) [[2]](diffhunk://#diff-c1df6b9e4d0694e0041c2c49ebde4b770df83e87132e651d8e089181f2034f93L31-R31)
[Copilot is generating a summary...]