### PR TITLE
Feature/enhancements

### DIFF
--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -24,6 +24,7 @@ return [
         'default' => [
             'new_section' => 'New Section',
         ],
+        'default_section_name' => 'Default',
     ],
 
     'field' => [
@@ -65,6 +66,12 @@ return [
             ],
             'add_field' => 'Add Field',
             'system_defined_cannot_delete' => 'System-defined fields cannot be deleted.',
+            'allow_multiple' => 'Allow Multiple Values',
+            'allow_multiple_help' => 'When enabled, users can enter multiple values for this field.',
+            'max_values' => 'Maximum Values',
+            'max_values_help' => 'The maximum number of values that can be entered.',
+            'unique_per_entity_type' => 'Unique Per Entity Type',
+            'unique_per_entity_type_help' => 'Each value can only be assigned to one record of this entity type.',
             'validation' => [
                 'label' => 'Validation',
                 'rules' => 'Validation Rules',
@@ -315,6 +322,7 @@ return [
         'multi_parameter_missing' => 'This validation rule requires multiple parameters. Please add all required parameters.',
         'parameter_missing' => 'This validation rule requires exactly :count parameter(s). Please add all required parameters.',
         'invalid_rule_for_field_type' => 'The selected rule is not valid for this field type.',
+        'unique_value' => 'The value ":value" is already assigned to another record.',
     ],
 
     'empty_states' => [
@@ -328,9 +336,19 @@ return [
             'description' => 'Drag and drop fields here or click the button below to add your first field.',
             'icon' => 'heroicon-o-squares-plus',
         ],
+        'fields_no_sections' => [
+            'heading' => 'No custom fields yet',
+            'description' => 'Click the button below to add your first custom field.',
+            'icon' => 'heroicon-o-squares-plus',
+        ],
     ],
 
     'common' => [
         'inactive' => 'Inactive',
     ],
+
+    'email' => [
+        'add_email_placeholder' => 'Add email address...',
+    ],
+
 ];

--- a/resources/views/filament/pages/custom-fields-management.blade.php
+++ b/resources/views/filament/pages/custom-fields-management.blade.php
@@ -9,43 +9,57 @@
     </x-filament::tabs>
 
     <div class="custom-fields-component">
-        <div
-            x-sortable
-            wire:end.stop="updateSectionsOrder($event.target.sortable.toArray())"
-            class="flex flex-col gap-y-6"
-        >
-            @foreach ($this->sections as $section)
-                @livewire('manage-custom-field-section', ['entityType' => $this->currentEntityType, 'section' => $section], key($section->id . str()->random(16)))
-            @endforeach
+        @if($this->isSectionsDisabled)
+            {{-- Sections disabled mode: show flat field list with new component --}}
+            @if($this->sections->first())
+                @livewire('manage-fields-without-sections', [
+                    'entityType' => $this->currentEntityType,
+                    'section' => $this->sections->first(),
+                ], key('fields-without-sections-' . $this->currentEntityType))
+            @endif
+        @else
+            {{-- Normal sections mode --}}
+            <div
+                x-sortable
+                wire:end.stop="updateSectionsOrder($event.target.sortable.toArray())"
+                class="flex flex-col gap-y-6"
+            >
+                @foreach ($this->sections as $section)
+                    @livewire('manage-custom-field-section', [
+                        'entityType' => $this->currentEntityType,
+                        'section' => $section,
+                    ], key($section->id . str()->random(16)))
+                @endforeach
 
-            @if(!count($this->sections))
-                <div class="fi-ta-empty-state px-6 py-16">
-                    <div class="fi-ta-empty-state-content mx-auto grid max-w-md justify-items-center text-center">
-                        <div class="fi-ta-empty-state-icon-ctn mb-6 rounded-full bg-primary-50 p-4 dark:bg-primary-950/50">
-                            <x-filament::icon
-                                icon="{{ __('custom-fields::custom-fields.empty_states.sections.icon') }}"
-                                class="fi-ta-empty-state-icon h-8 w-8 text-primary-500 dark:text-primary-400"
-                            />
-                        </div>
+                @if(!count($this->sections))
+                    <div class="px-6 py-16">
+                        <div class="mx-auto grid max-w-md justify-items-center text-center">
+                            <div class="fi-ta-empty-state-icon-ctn mb-6 rounded-full bg-primary-50 p-4 dark:bg-primary-950/50">
+                                <x-filament::icon
+                                    icon="{{ __('custom-fields::custom-fields.empty_states.sections.icon') }}"
+                                    class="fi-ta-empty-state-icon h-8 w-8 text-primary-500 dark:text-primary-400"
+                                />
+                            </div>
 
-                        <h3 class="fi-ta-empty-state-heading text-lg font-semibold leading-7 text-gray-950 dark:text-white mb-2">
-                            {{ __('custom-fields::custom-fields.empty_states.sections.heading') }}
-                        </h3>
+                            <h3 class="fi-ta-empty-state-heading text-lg font-semibold leading-7 text-gray-950 dark:text-white mb-2">
+                                {{ __('custom-fields::custom-fields.empty_states.sections.heading') }}
+                            </h3>
 
-                        <p class="fi-ta-empty-state-description text-sm text-gray-600 dark:text-gray-400 mb-6 leading-relaxed">
-                            {{ __('custom-fields::custom-fields.empty_states.sections.description') }}
-                        </p>
+                            <p class="fi-ta-empty-state-description text-sm text-gray-600 dark:text-gray-400 mb-6 leading-relaxed">
+                                {{ __('custom-fields::custom-fields.empty_states.sections.description') }}
+                            </p>
 
-                        <div class="fi-ta-empty-state-action">
-                            {{ $this->createSectionAction }}
+                            <div class="fi-ta-empty-state-action">
+                                {{ $this->createSectionAction }}
+                            </div>
                         </div>
                     </div>
-                </div>
-            @else
-                <div class="mt-6 flex justify-center">
-                    {{ $this->createSectionAction }}
-                </div>
-            @endif
-        </div>
+                @else
+                    <div class="mt-6 flex justify-center">
+                        {{ $this->createSectionAction }}
+                    </div>
+                @endif
+            </div>
+        @endif
     </div>
 </x-filament-panels::page>

--- a/resources/views/livewire/manage-custom-field-section.blade.php
+++ b/resources/views/livewire/manage-custom-field-section.blade.php
@@ -10,6 +10,8 @@
                 <x-filament::icon-button
                         icon="heroicon-m-bars-4"
                         color="gray"
+                        class="text-gray-500"
+                        size="xs"
                         x-sortable-handle
                 />
 
@@ -30,7 +32,7 @@
             x-sortable-group="fields"
             data-section-id="{{ $section->id }}"
             default="12"
-            class="fi-sc  fi-sc-has-gap fi-grid lg:fi-grid-cols"
+            class="fi-sc  fi-sc-has-gap fi-sc-dense fi-grid lg:fi-grid-cols"
             style="--cols-lg: repeat(12, minmax(0, 12fr)); --cols-default: repeat(2, minmax(0, 1fr));"
             @end.stop="$wire.updateFieldsOrder($event.to.getAttribute('data-section-id'), $event.to.sortable.toArray())"
     >

--- a/resources/views/livewire/manage-custom-field-section.blade.php
+++ b/resources/views/livewire/manage-custom-field-section.blade.php
@@ -40,8 +40,8 @@
 
         @if(!count($this->fields))
             <div class="fi-grid-col" style="--col-span-default: span 12 / span 12;">
-                <div class="fi-ta-empty-state py-12">
-                    <div class="fi-ta-empty-state-content mx-auto grid max-w-xs justify-items-center text-center">
+                <div class="py-12">
+                    <div class="mx-auto grid max-w-xs justify-items-center text-center">
                         <div class="fi-ta-empty-state-icon-ctn mb-4 rounded-full bg-gray-50 p-3 dark:bg-gray-800/50">
                             <x-filament::icon
                                 icon="{{ __('custom-fields::custom-fields.empty_states.fields.icon') }}"

--- a/resources/views/livewire/manage-custom-field-width.blade.php
+++ b/resources/views/livewire/manage-custom-field-width.blade.php
@@ -14,7 +14,7 @@
             <template x-for="(width, index) in widths" :key="index">
                 <div
                     wire:click="$parent.setWidth(fieldId, width)"
-                    class="h-6 flex-1 cursor-pointer bg-gray-200 hover:bg-gray-300 transition-colors"
+                    class="h-6 flex-1 cursor-pointer bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 transition-colors"
                     :class="{
                     'rounded-s-md': index === 0,
                     'rounded-e-md': index === widths.length - 1
@@ -26,12 +26,12 @@
                         'bg-primary-600 hover:bg-primary-600/80': isSelected(width),
                         'rounded-s-md': index === 0 && isSelected(width),
                         'rounded-e-md': index === widths.length - 1 && isSelected(width),
-                        'border-s': index !== widths.length - 1
+                        'border-s': index !== widths.length && index !== 0,
                     }"
                     ></div>
                 </div>
             </template>
         </div>
-        <div class="absolute w-full h-full font-semibold text-sm flex items-center justify-center text-black">{{ $selectedWidth }}%</div>
+        <div class="absolute w-full h-full font-semibold text-sm flex items-center justify-center text-gray-900 dark:text-white">{{ $selectedWidth }}%</div>
     </div>
 </div>

--- a/resources/views/livewire/manage-custom-field.blade.php
+++ b/resources/views/livewire/manage-custom-field.blade.php
@@ -10,11 +10,13 @@
         <x-filament::icon-button
                 icon="heroicon-m-bars-3"
                 color="gray"
+                class="ml-0.5 text-gray-500"
+                size="xs"
         />
 
         <x-filament::icon
                 :icon="$field->typeData?->icon ?? 'heroicon-o-document-text'"
-                class="h-5 w-5 text-gray-500 dark:text-gray-400"
+                class="h-4.5 w-4.5 text-neutral-700 dark:text-neutral-400 ml-2"
                 :aria-label="$field->name"
         />
 

--- a/resources/views/livewire/manage-fields-without-sections.blade.php
+++ b/resources/views/livewire/manage-fields-without-sections.blade.php
@@ -3,7 +3,7 @@
         <div
             x-sortable
             x-sortable-group="fields"
-            class="fi-sc fi-sc-has-gap fi-grid lg:fi-grid-cols"
+            class="fi-sc fi-sc-has-gap fi-sc-dense fi-grid lg:fi-grid-cols"
             style="--cols-lg: repeat(12, minmax(0, 12fr)); --cols-default: repeat(2, minmax(0, 1fr));"
             @end.stop="$wire.updateFieldsOrder($event.to.sortable.toArray())"
         >

--- a/resources/views/livewire/manage-fields-without-sections.blade.php
+++ b/resources/views/livewire/manage-fields-without-sections.blade.php
@@ -1,0 +1,44 @@
+<div class="flex flex-col gap-y-6">
+    @if(count($this->fields))
+        <div
+            x-sortable
+            x-sortable-group="fields"
+            class="fi-sc fi-sc-has-gap fi-grid lg:fi-grid-cols"
+            style="--cols-lg: repeat(12, minmax(0, 12fr)); --cols-default: repeat(2, minmax(0, 1fr));"
+            @end.stop="$wire.updateFieldsOrder($event.to.sortable.toArray())"
+        >
+            @foreach ($this->fields as $field)
+                @livewire('manage-custom-field', ['field' => $field], key($field->id . $field->width->value . str()->random(16)))
+            @endforeach
+        </div>
+
+        <div class="flex justify-center">
+            {{ $this->createFieldAction() }}
+        </div>
+    @else
+        <div class="px-6 py-16">
+            <div class="mx-auto grid max-w-md justify-items-center text-center">
+                <div class="fi-ta-empty-state-icon-ctn mb-6 rounded-full bg-primary-50 p-4 dark:bg-primary-950/50">
+                    <x-filament::icon
+                        icon="{{ __('custom-fields::custom-fields.empty_states.fields_no_sections.icon') }}"
+                        class="fi-ta-empty-state-icon h-8 w-8 text-primary-500 dark:text-primary-400"
+                    />
+                </div>
+
+                <h3 class="fi-ta-empty-state-heading text-lg font-semibold leading-7 text-gray-950 dark:text-white mb-2">
+                    {{ __('custom-fields::custom-fields.empty_states.fields_no_sections.heading') }}
+                </h3>
+
+                <p class="fi-ta-empty-state-description text-sm text-gray-600 dark:text-gray-400 mb-6 leading-relaxed">
+                    {{ __('custom-fields::custom-fields.empty_states.fields_no_sections.description') }}
+                </p>
+
+                <div class="fi-ta-empty-state-action">
+                    {{ $this->createFieldAction() }}
+                </div>
+            </div>
+        </div>
+    @endif
+
+    <x-filament-actions::modals/>
+</div>

--- a/src/Console/Commands/MigrateEmailFieldValuesCommand.php
+++ b/src/Console/Commands/MigrateEmailFieldValuesCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Migrates email field values from string_value to json_value format.
+ *
+ * This command is needed after the EmailFieldType was changed from STRING
+ * data type to MULTI_CHOICE, which stores values in json_value as an array.
+ */
+class MigrateEmailFieldValuesCommand extends Command
+{
+    protected $signature = 'custom-fields:migrate-email-values
+                            {--dry-run : Show what would be migrated without making changes}
+                            {--force : Run without confirmation in production}';
+
+    protected $description = 'Migrate email field values from string_value to json_value array format';
+
+    public function handle(): int
+    {
+        $isDryRun = $this->option('dry-run');
+
+        if (app()->isProduction() && ! $isDryRun && ! $this->option('force')) {
+            if (! $this->confirm('You are running in production. Are you sure you want to continue?')) {
+                $this->info('Migration cancelled.');
+
+                return self::SUCCESS;
+            }
+        }
+
+        $fieldTable = config('custom-fields.database.table_names.custom_fields');
+        $valueTable = config('custom-fields.database.table_names.custom_field_values');
+
+        // Find all email type custom fields
+        $emailFields = DB::table($fieldTable)
+            ->where('type', 'email')
+            ->pluck('id');
+
+        if ($emailFields->isEmpty()) {
+            $this->info('No email fields found. Nothing to migrate.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Found %d email field(s).', $emailFields->count()));
+
+        // Find values that need migration (have string_value but no json_value)
+        $valuesToMigrate = DB::table($valueTable)
+            ->whereIn('custom_field_id', $emailFields)
+            ->whereNotNull('string_value')
+            ->where('string_value', '!=', '')
+            ->where(function ($query) {
+                $query->whereNull('json_value')
+                    ->orWhere('json_value', '=', '[]')
+                    ->orWhere('json_value', '=', 'null');
+            })
+            ->get();
+
+        if ($valuesToMigrate->isEmpty()) {
+            $this->info('No email values need migration. All values are already in the correct format.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf('Found %d email value(s) to migrate.', $valuesToMigrate->count()));
+
+        if ($isDryRun) {
+            $this->warn('Dry run mode - no changes will be made.');
+            $this->newLine();
+
+            $this->table(
+                ['ID', 'Entity Type', 'Entity ID', 'Current Value', 'New Format'],
+                $valuesToMigrate->map(fn ($value) => [
+                    $value->id,
+                    $value->entity_type,
+                    $value->entity_id,
+                    $value->string_value,
+                    json_encode([$value->string_value]),
+                ])->toArray()
+            );
+
+            return self::SUCCESS;
+        }
+
+        $bar = $this->output->createProgressBar($valuesToMigrate->count());
+        $bar->start();
+
+        $migrated = 0;
+        $errors = 0;
+
+        foreach ($valuesToMigrate as $value) {
+            try {
+                DB::table($valueTable)
+                    ->where('id', $value->id)
+                    ->update([
+                        'json_value' => json_encode([$value->string_value]),
+                        'string_value' => null,
+                    ]);
+
+                $migrated++;
+            } catch (\Throwable $e) {
+                $this->newLine();
+                $this->error(sprintf('Failed to migrate value ID %d: %s', $value->id, $e->getMessage()));
+                $errors++;
+            }
+
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine(2);
+
+        $this->info(sprintf('Migration complete. Migrated: %d, Errors: %d', $migrated, $errors));
+
+        return $errors > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/MigrateEmailFieldValuesCommand.php
+++ b/src/Console/Commands/MigrateEmailFieldValuesCommand.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 /**
  * Migrates email field values from string_value to json_value format.
@@ -25,12 +26,10 @@ class MigrateEmailFieldValuesCommand extends Command
     {
         $isDryRun = $this->option('dry-run');
 
-        if (app()->isProduction() && ! $isDryRun && ! $this->option('force')) {
-            if (! $this->confirm('You are running in production. Are you sure you want to continue?')) {
-                $this->info('Migration cancelled.');
+        if (app()->isProduction() && ! $isDryRun && ! $this->option('force') && ! $this->confirm('You are running in production. Are you sure you want to continue?')) {
+            $this->info('Migration cancelled.');
 
-                return self::SUCCESS;
-            }
+            return self::SUCCESS;
         }
 
         $fieldTable = config('custom-fields.database.table_names.custom_fields');
@@ -54,7 +53,7 @@ class MigrateEmailFieldValuesCommand extends Command
             ->whereIn('custom_field_id', $emailFields)
             ->whereNotNull('string_value')
             ->where('string_value', '!=', '')
-            ->where(function ($query) {
+            ->where(function ($query): void {
                 $query->whereNull('json_value')
                     ->orWhere('json_value', '=', '[]')
                     ->orWhere('json_value', '=', 'null');
@@ -75,7 +74,7 @@ class MigrateEmailFieldValuesCommand extends Command
 
             $this->table(
                 ['ID', 'Entity Type', 'Entity ID', 'Current Value', 'New Format'],
-                $valuesToMigrate->map(fn ($value) => [
+                $valuesToMigrate->map(fn ($value): array => [
                     $value->id,
                     $value->entity_type,
                     $value->entity_id,
@@ -103,7 +102,7 @@ class MigrateEmailFieldValuesCommand extends Command
                     ]);
 
                 $migrated++;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $this->newLine();
                 $this->error(sprintf('Failed to migrate value ID %d: %s', $value->id, $e->getMessage()));
                 $errors++;

--- a/src/CustomFieldsServiceProvider.php
+++ b/src/CustomFieldsServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Filesystem\Filesystem;
 use Livewire\Livewire;
 use Relaticle\CustomFields\Console\Commands\MakeCustomFieldsMigrationCommand;
 use Relaticle\CustomFields\Console\Commands\MakeFieldTypeCommand;
+use Relaticle\CustomFields\Console\Commands\MigrateEmailFieldValuesCommand;
 use Relaticle\CustomFields\Contracts\CustomsFieldsMigrators;
 use Relaticle\CustomFields\Contracts\ValueResolvers;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
@@ -168,6 +169,7 @@ final class CustomFieldsServiceProvider extends PackageServiceProvider
         return [
             MakeCustomFieldsMigrationCommand::class,
             MakeFieldTypeCommand::class,
+            MigrateEmailFieldValuesCommand::class,
         ];
     }
 

--- a/src/CustomFieldsServiceProvider.php
+++ b/src/CustomFieldsServiceProvider.php
@@ -23,6 +23,7 @@ use Relaticle\CustomFields\Filament\Integration\Migrations\CustomFieldsMigrator;
 use Relaticle\CustomFields\Livewire\ManageCustomField;
 use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Livewire\ManageCustomFieldWidth;
+use Relaticle\CustomFields\Livewire\ManageFieldsWithoutSections;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Providers\EntityServiceProvider;
@@ -73,6 +74,7 @@ final class CustomFieldsServiceProvider extends PackageServiceProvider
         Livewire::component('manage-custom-field-section', ManageCustomFieldSection::class);
         Livewire::component('manage-custom-field', ManageCustomField::class);
         Livewire::component('manage-custom-field-width', ManageCustomFieldWidth::class);
+        Livewire::component('manage-fields-without-sections', ManageFieldsWithoutSections::class);
     }
 
     public function configurePackage(Package $package): void

--- a/src/Data/CustomFieldSettingsData.php
+++ b/src/Data/CustomFieldSettingsData.php
@@ -20,6 +20,9 @@ class CustomFieldSettingsData extends Data
         public bool $searchable = false,
         public bool $encrypted = false,
         public bool $enable_option_colors = false,
+        public bool $allow_multiple = false,
+        public int $max_values = 1,
+        public bool $unique_per_entity_type = false,
         public VisibilityData $visibility = new VisibilityData,
         public array $additional = [],
     ) {

--- a/src/Data/FieldTypeData.php
+++ b/src/Data/FieldTypeData.php
@@ -27,6 +27,7 @@ final class FieldTypeData extends Data implements Stringable
         public bool $encryptable = false,
         public bool $withoutUserOptions = false,
         public bool $acceptsArbitraryValues = false,
+        public bool $supportsMultiValue = false,
         public array $validationRules = [],
         public ?string $settingsDataClass = null,
         public string|Closure|null $settingsSchema = null,

--- a/src/Data/FieldTypeData.php
+++ b/src/Data/FieldTypeData.php
@@ -28,6 +28,7 @@ final class FieldTypeData extends Data implements Stringable
         public bool $withoutUserOptions = false,
         public bool $acceptsArbitraryValues = false,
         public bool $supportsMultiValue = false,
+        public bool $supportsUniqueConstraint = false,
         public array $validationRules = [],
         public ?string $settingsDataClass = null,
         public string|Closure|null $settingsSchema = null,

--- a/src/Enums/CustomFieldsFeature.php
+++ b/src/Enums/CustomFieldsFeature.php
@@ -14,6 +14,9 @@ enum CustomFieldsFeature: string
     case FIELD_CONDITIONAL_VISIBILITY = 'field_conditional_visibility';
     case FIELD_ENCRYPTION = 'field_encryption';
     case FIELD_OPTION_COLORS = 'field_option_colors';
+    case FIELD_CODE_AUTO_GENERATE = 'field_code_auto_generate';
+    case FIELD_MULTI_VALUE = 'field_multi_value';
+    case FIELD_UNIQUE_VALUE = 'field_unique_value';
 
     // Table/UI integration features
     case UI_TABLE_COLUMNS = 'ui_table_columns';
@@ -24,4 +27,5 @@ enum CustomFieldsFeature: string
     // System-level features
     case SYSTEM_MANAGEMENT_INTERFACE = 'system_management_interface';
     case SYSTEM_MULTI_TENANCY = 'system_multi_tenancy';
+    case SYSTEM_SECTIONS_DISABLED = 'system_sections_disabled';
 }

--- a/src/Enums/CustomFieldsFeature.php
+++ b/src/Enums/CustomFieldsFeature.php
@@ -23,9 +23,9 @@ enum CustomFieldsFeature: string
     case UI_TABLE_FILTERS = 'ui_table_filters';
     case UI_TOGGLEABLE_COLUMNS = 'ui_toggleable_columns';
     case UI_TOGGLEABLE_COLUMNS_HIDDEN_DEFAULT = 'ui_toggleable_columns_hidden_default';
+    case UI_FLAT_FIELD_LAYOUT = 'ui_flat_field_layout';
 
     // System-level features
     case SYSTEM_MANAGEMENT_INTERFACE = 'system_management_interface';
     case SYSTEM_MULTI_TENANCY = 'system_multi_tenancy';
-    case SYSTEM_SECTIONS_DISABLED = 'system_sections_disabled';
 }

--- a/src/FieldTypeSystem/Definitions/EmailFieldType.php
+++ b/src/FieldTypeSystem/Definitions/EmailFieldType.php
@@ -30,6 +30,7 @@ class EmailFieldType extends BaseFieldType
             ->searchable()
             ->sortable()
             ->supportsMultiValue()
+            ->supportsUniqueConstraint()
             ->withArbitraryValues()
             ->withoutUserOptions()
             ->availableValidationRules([

--- a/src/FieldTypeSystem/Definitions/EmailFieldType.php
+++ b/src/FieldTypeSystem/Definitions/EmailFieldType.php
@@ -19,7 +19,7 @@ class EmailFieldType extends BaseFieldType
 {
     public function configure(): FieldSchema
     {
-        return FieldSchema::string()
+        return FieldSchema::multiChoice()
             ->key('email')
             ->label('Email')
             ->icon('heroicon-o-envelope')
@@ -27,18 +27,15 @@ class EmailFieldType extends BaseFieldType
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
             ->priority(15)
-            ->encryptable()
-            ->searchable()
             ->sortable()
-            ->defaultValidationRules([ValidationRule::EMAIL])
+            ->supportsMultiValue()
+            ->withArbitraryValues()
+            ->withoutUserOptions()
             ->availableValidationRules([
                 ValidationRule::REQUIRED,
-                ValidationRule::EMAIL,
                 ValidationRule::MIN,
                 ValidationRule::MAX,
-                ValidationRule::REGEX,
                 ValidationRule::UNIQUE,
-                ValidationRule::EXISTS,
             ]);
     }
 }

--- a/src/FieldTypeSystem/Definitions/EmailFieldType.php
+++ b/src/FieldTypeSystem/Definitions/EmailFieldType.php
@@ -27,6 +27,7 @@ class EmailFieldType extends BaseFieldType
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
             ->priority(15)
+            ->searchable()
             ->sortable()
             ->supportsMultiValue()
             ->withArbitraryValues()

--- a/src/FieldTypeSystem/Definitions/LinkFieldType.php
+++ b/src/FieldTypeSystem/Definitions/LinkFieldType.php
@@ -26,6 +26,7 @@ class LinkFieldType extends BaseFieldType
             ->formComponent(LinkComponent::class)
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
+            ->supportsUniqueConstraint()
             ->priority(60)
             ->availableValidationRules([
                 ValidationRule::REQUIRED,

--- a/src/FieldTypeSystem/Definitions/NumberFieldType.php
+++ b/src/FieldTypeSystem/Definitions/NumberFieldType.php
@@ -26,6 +26,7 @@ class NumberFieldType extends BaseFieldType
             ->formComponent(NumberComponent::class)
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
+            ->supportsUniqueConstraint()
             ->priority(20)
             ->availableValidationRules([
                 ValidationRule::REQUIRED,

--- a/src/FieldTypeSystem/Definitions/TextFieldType.php
+++ b/src/FieldTypeSystem/Definitions/TextFieldType.php
@@ -27,6 +27,7 @@ class TextFieldType extends BaseFieldType
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
             ->encryptable()
+            ->supportsUniqueConstraint()
             ->priority(10)
             ->availableValidationRules([
                 ValidationRule::REQUIRED,

--- a/src/FieldTypeSystem/Definitions/TextareaFieldType.php
+++ b/src/FieldTypeSystem/Definitions/TextareaFieldType.php
@@ -26,6 +26,7 @@ final class TextareaFieldType extends BaseFieldType
             ->formComponent(TextareaFormComponent::class)
             ->tableColumn(TextColumn::class)
             ->infolistEntry(TextEntry::class)
+            ->supportsUniqueConstraint()
             ->priority(15)
             ->availableValidationRules([
                 ValidationRule::REQUIRED,

--- a/src/FieldTypeSystem/FieldSchema.php
+++ b/src/FieldTypeSystem/FieldSchema.php
@@ -55,6 +55,8 @@ class FieldSchema
 
     private bool $supportsMultiValue = false;
 
+    private bool $supportsUniqueConstraint = false;
+
     protected bool $withoutUserOptions = false;
 
     private ?string $settingsDataClass = null;
@@ -323,6 +325,16 @@ class FieldSchema
         return $this;
     }
 
+    /**
+     * Configure whether field supports unique value constraint per entity type
+     */
+    public function supportsUniqueConstraint(bool $supports = true): self
+    {
+        $this->supportsUniqueConstraint = $supports;
+
+        return $this;
+    }
+
     // ========== Data Type Specific Methods (from DataTypeConfigurators) ==========
 
     /**
@@ -555,6 +567,7 @@ class FieldSchema
             withoutUserOptions: $this->withoutUserOptions,
             acceptsArbitraryValues: $this->acceptsArbitraryValues,
             supportsMultiValue: $this->supportsMultiValue,
+            supportsUniqueConstraint: $this->supportsUniqueConstraint,
             validationRules: $this->availableValidationRules,
             settingsDataClass: $this->settingsDataClass,
             settingsSchema: $this->settingsSchema

--- a/src/FieldTypeSystem/FieldSchema.php
+++ b/src/FieldTypeSystem/FieldSchema.php
@@ -53,6 +53,8 @@ class FieldSchema
 
     private bool $acceptsArbitraryValues = false;
 
+    private bool $supportsMultiValue = false;
+
     protected bool $withoutUserOptions = false;
 
     private ?string $settingsDataClass = null;
@@ -311,6 +313,16 @@ class FieldSchema
         return $this;
     }
 
+    /**
+     * Configure whether field supports multiple values (e.g., multiple emails, phones)
+     */
+    public function supportsMultiValue(bool $supports = true): self
+    {
+        $this->supportsMultiValue = $supports;
+
+        return $this;
+    }
+
     // ========== Data Type Specific Methods (from DataTypeConfigurators) ==========
 
     /**
@@ -542,6 +554,7 @@ class FieldSchema
             encryptable: $this->encryptable,
             withoutUserOptions: $this->withoutUserOptions,
             acceptsArbitraryValues: $this->acceptsArbitraryValues,
+            supportsMultiValue: $this->supportsMultiValue,
             validationRules: $this->availableValidationRules,
             settingsDataClass: $this->settingsDataClass,
             settingsSchema: $this->settingsSchema

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -66,7 +66,12 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
                     filled($state)
             )
             ->required($this->validationService->isRequired($customField))
-            ->rules($this->validationService->getValidationRules($customField))
+            ->rules(
+                fn (Field $component): array => $this->validationService->getValidationRules(
+                    $customField,
+                    $component->getRecord()?->getKey()
+                )
+            )
             ->columnSpan($customField->width->getSpanValue())
             ->when(
                 FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY) &&

--- a/src/Filament/Integration/Builders/FormBuilder.php
+++ b/src/Filament/Integration/Builders/FormBuilder.php
@@ -14,15 +14,21 @@ use Relaticle\CustomFields\Models\CustomFieldSection;
 
 class FormBuilder extends BaseBuilder
 {
-    private bool $withoutSections = false;
+    private ?bool $withoutSections = null;
 
     public function build(): Grid
     {
-        return FormContainer::make()
+        $container = FormContainer::make()
             ->forModel($this->explicitModel ?? null)
-            ->withoutSections($this->withoutSections)
             ->only($this->only)
             ->except($this->except);
+
+        // Only set withoutSections if explicitly configured
+        if ($this->withoutSections !== null) {
+            $container->withoutSections($this->withoutSections);
+        }
+
+        return $container;
     }
 
     public function withoutSections(bool $withoutSections = true): static

--- a/src/Filament/Integration/Builders/FormContainer.php
+++ b/src/Filament/Integration/Builders/FormContainer.php
@@ -4,6 +4,8 @@ namespace Relaticle\CustomFields\Filament\Integration\Builders;
 
 use Filament\Schemas\Components\Grid;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 
 final class FormContainer extends Grid
 {
@@ -13,7 +15,7 @@ final class FormContainer extends Grid
 
     private array $only = [];
 
-    private bool $withoutSections = false;
+    private ?bool $withoutSections = null;
 
     public static function make(array|int|null $columns = 12): static
     {
@@ -62,11 +64,15 @@ final class FormContainer extends Grid
             return []; // Graceful fallback
         }
 
+        // Use explicit setting if provided, otherwise check feature flag
+        $withoutSections = $this->withoutSections
+            ?? FeatureManager::isEnabled(CustomFieldsFeature::UI_FLAT_FIELD_LAYOUT);
+
         $builder = app(FormBuilder::class);
 
         return $builder
             ->forModel($model)
-            ->withoutSections($this->withoutSections)
+            ->withoutSections($withoutSections)
             ->only($this->only)
             ->except($this->except)
             ->values()

--- a/src/Filament/Integration/Builders/InfolistBuilder.php
+++ b/src/Filament/Integration/Builders/InfolistBuilder.php
@@ -21,17 +21,23 @@ final class InfolistBuilder extends BaseBuilder
 
     private bool $visibleWhenFilled = false;
 
-    private bool $withoutSections = false;
+    private ?bool $withoutSections = null;
 
     public function build(): Component
     {
-        return InfolistContainer::make()
+        $container = InfolistContainer::make()
             ->forModel($this->explicitModel ?? null)
             ->hiddenLabels($this->hiddenLabels)
             ->visibleWhenFilled($this->visibleWhenFilled)
-            ->withoutSections($this->withoutSections)
             ->only($this->only)
             ->except($this->except);
+
+        // Only set withoutSections if explicitly configured
+        if ($this->withoutSections !== null) {
+            $container->withoutSections($this->withoutSections);
+        }
+
+        return $container;
     }
 
     /**

--- a/src/Filament/Integration/Builders/InfolistContainer.php
+++ b/src/Filament/Integration/Builders/InfolistContainer.php
@@ -5,6 +5,8 @@ namespace Relaticle\CustomFields\Filament\Integration\Builders;
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Grid;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 
 final class InfolistContainer extends Grid
 {
@@ -18,7 +20,7 @@ final class InfolistContainer extends Grid
 
     private bool $visibleWhenFilled = false;
 
-    private bool $withoutSections = false;
+    private ?bool $withoutSections = null;
 
     public static function make(array|int|null $columns = 12): static
     {
@@ -84,13 +86,17 @@ final class InfolistContainer extends Grid
             return []; // Graceful fallback
         }
 
+        // Use explicit setting if provided, otherwise check feature flag
+        $withoutSections = $this->withoutSections
+            ?? FeatureManager::isEnabled(CustomFieldsFeature::UI_FLAT_FIELD_LAYOUT);
+
         $builder = app(InfolistBuilder::class)
             ->forModel($model)
             ->only($this->only)
             ->except($this->except)
             ->hiddenLabels($this->hiddenLabels)
             ->visibleWhenFilled($this->visibleWhenFilled)
-            ->withoutSections($this->withoutSections);
+            ->withoutSections($withoutSections);
 
         return $builder->values()->toArray();
     }

--- a/src/Filament/Integration/Components/Forms/EmailComponent.php
+++ b/src/Filament/Integration/Components/Forms/EmailComponent.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Filament\Integration\Components\Forms;
 
 use Filament\Forms\Components\Field;
-use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TagsInput;
 use Relaticle\CustomFields\Filament\Integration\Base\AbstractFormComponent;
 use Relaticle\CustomFields\Models\CustomField;
 
@@ -13,16 +13,15 @@ final readonly class EmailComponent extends AbstractFormComponent
 {
     public function create(CustomField $customField): Field
     {
-        $defaults = [
-            'email' => true, // Client-side validation for UX
-            'maxLength' => 255,
-            'suffixIcon' => 'heroicon-m-envelope',
-            'autocomplete' => 'email',
-            'type' => 'email',
-        ];
+        $maxValues = $customField->settings->allow_multiple
+            ? $customField->settings->max_values
+            : 1;
 
-        $component = TextInput::make($customField->getFieldName());
-
-        return $this->applySettingsToComponent($component, $defaults);
+        return TagsInput::make($customField->getFieldName())
+            ->placeholder(__('custom-fields::custom-fields.email.add_email_placeholder'))
+            ->splitKeys(['Tab', ',', 'Enter'])
+            ->nestedRecursiveRules(['email'])
+            ->rules(['array', 'max:'.$maxValues])
+            ->reorderable();
     }
 }

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -24,7 +24,9 @@ use Relaticle\CustomFields\Facades\Entities;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\DefaultSectionService;
 use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Support\CodeGenerator;
 use Relaticle\CustomFields\Support\Utils;
 
 class CustomFieldsManagementPage extends Page
@@ -46,6 +48,20 @@ class CustomFieldsManagementPage extends Page
             $firstEntity = Entities::withCustomFields()->first();
             $this->setCurrentEntityType($firstEntity?->getAlias() ?? '');
         }
+
+        // When sections are disabled, ensure a default hidden section exists
+        if ($this->isSectionsDisabled() && filled($this->currentEntityType)) {
+            app(DefaultSectionService::class)->getOrCreateDefaultSection($this->currentEntityType);
+        }
+    }
+
+    /**
+     * Check if sections are disabled (single hidden section mode).
+     */
+    #[Computed]
+    public function isSectionsDisabled(): bool
+    {
+        return FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_SECTIONS_DISABLED);
     }
 
     #[Computed]
@@ -97,6 +113,11 @@ class CustomFieldsManagementPage extends Page
     public function setCurrentEntityType(?string $entityType): void
     {
         $this->currentEntityType = $entityType;
+
+        // When sections are disabled, ensure a default hidden section exists for the new entity type
+        if ($this->isSectionsDisabled() && filled($entityType)) {
+            app(DefaultSectionService::class)->getOrCreateDefaultSection($entityType);
+        }
     }
 
     public function createSectionAction(): Action
@@ -108,6 +129,7 @@ class CustomFieldsManagementPage extends Page
             ->color('gray')
             ->button()
             ->outlined()
+            ->visible(fn (): bool => ! $this->isSectionsDisabled())
             ->extraAttributes([
                 'class' => 'flex justify-center items-center rounded-lg border-gray-300 hover:border-gray-400 border-dashed',
             ])
@@ -141,6 +163,14 @@ class CustomFieldsManagementPage extends Page
 
         $data['type'] ??= CustomFieldSectionType::SECTION->value;
         $data['entity_type'] = $this->currentEntityType;
+
+        // Auto-generate code if feature is enabled and code is empty
+        if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
+            $data['code'] = CodeGenerator::generateUniqueSectionCode(
+                $data['name'],
+                $this->currentEntityType
+            );
+        }
 
         return CustomFieldsModel::newSectionModel()->create($data);
     }

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -61,7 +61,7 @@ class CustomFieldsManagementPage extends Page
     #[Computed]
     public function isSectionsDisabled(): bool
     {
-        return FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_SECTIONS_DISABLED);
+        return FeatureManager::isEnabled(CustomFieldsFeature::UI_FLAT_FIELD_LAYOUT);
     }
 
     #[Computed]

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -26,7 +26,6 @@ use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Facades\Entities;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
-use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\CustomFieldValidationComponent;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\TypeField;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
@@ -42,8 +41,6 @@ class FieldForm implements FormInterface
      */
     private static function getTypeSettingsSchema(): array
     {
-        $fieldManager = app(FieldManager::class);
-
         $components = [];
 
         foreach (CustomFieldsType::toCollection() as $fieldTypeData) {

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\Utilities\Get;
@@ -131,157 +132,89 @@ class FieldForm implements FormInterface
                     Tab::make(
                         __('custom-fields::custom-fields.field.form.general')
                     )->schema([
-                        Select::make('entity_type')
-                            ->label(
-                                __(
-                                    'custom-fields::custom-fields.field.form.entity_type'
-                                )
-                            )
-                            ->options(Entities::getOptions(onlyCustomFields: true))
-                            ->disabled()
+                        Hidden::make('entity_type')
                             ->default(
                                 fn () => request(
                                     'entityType',
                                     (Entities::withCustomFields()->first()?->getAlias()) ?? ''
                                 )
-                            )
-                            ->required(),
-                        TypeField::make('type')
-                            ->label(
-                                __(
-                                    'custom-fields::custom-fields.field.form.type'
-                                )
-                            )
-                            ->disabled(
-                                fn (
-                                    ?CustomField $record
-                                ): bool => (bool) $record?->exists
-                            )
-                            ->live()
-                            ->afterStateHydrated(function (
-                                Select $component,
-                                mixed $state,
-                                ?CustomField $record
-                            ): void {
-                                if (blank($state)) {
-                                    $component->state(
-                                        $record->type ?? CustomFieldsType::toCollection()->first()->key
-                                    );
-                                }
-                            })
-                            ->required(),
-                        TextInput::make('name')
-                            ->label(
-                                __(
-                                    'custom-fields::custom-fields.field.form.name'
-                                )
-                            )
-                            ->helperText(
-                                __(
-                                    'custom-fields::custom-fields.field.form.name_helper_text'
-                                )
-                            )
-                            ->live(onBlur: true)
-                            ->required()
-                            ->maxLength(50)
-                            ->disabled(
-                                fn (
-                                    ?CustomField $record
-                                ): bool => (bool) $record?->system_defined
-                            )
-                            ->unique(
-                                table: CustomFields::customFieldModel(),
-                                column: 'name',
-                                ignoreRecord: true,
-                                modifyRuleUsing: fn (
-                                    Unique $rule,
-                                    Get $get
-                                ) => $rule
-                                    ->where('entity_type', $get('entity_type'))
-                                    ->when(
-                                        FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                        fn (Unique $rule) => $rule->where(
-                                            config(
-                                                'custom-fields.database.column_names.tenant_foreign_key'
-                                            ),
-                                            TenantContextService::getCurrentTenantId()
-                                        )
+                            ),
+                        Grid::make()
+                            ->columns(fn (): int => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) ? 2 : 3)
+                            ->columnSpanFull()
+                            ->schema([
+                                TypeField::make('type')
+                                    ->label(__('custom-fields::custom-fields.field.form.type'))
+                                    ->disabled(fn (?CustomField $record): bool => (bool) $record?->exists)
+                                    ->live()
+                                    ->afterStateHydrated(function (
+                                        Select $component,
+                                        mixed $state,
+                                        ?CustomField $record
+                                    ): void {
+                                        if (blank($state)) {
+                                            $component->state(
+                                                $record->type ?? CustomFieldsType::toCollection()->first()->key
+                                            );
+                                        }
+                                    })
+                                    ->required(),
+                                TextInput::make('name')
+                                    ->label(__('custom-fields::custom-fields.field.form.name'))
+                                    ->live(onBlur: true)
+                                    ->required()
+                                    ->maxLength(50)
+                                    ->disabled(fn (?CustomField $record): bool => (bool) $record?->system_defined)
+                                    ->unique(
+                                        table: CustomFields::customFieldModel(),
+                                        column: 'name',
+                                        ignoreRecord: true,
+                                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
+                                            ->where('entity_type', $get('entity_type'))
+                                            ->when(
+                                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
+                                                fn (Unique $rule) => $rule->where(
+                                                    config('custom-fields.database.column_names.tenant_foreign_key'),
+                                                    TenantContextService::getCurrentTenantId()
+                                                )
+                                            )
                                     )
-                            )
-                            ->afterStateUpdated(function (
-                                Get $get,
-                                Set $set,
-                                ?string $old,
-                                ?string $state
-                            ): void {
-                                $old ??= '';
-                                $state ??= '';
+                                    ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state): void {
+                                        $old ??= '';
+                                        $state ??= '';
 
-                                if (
-                                    ($get('code') ?? '') !==
-                                    Str::of($old)->slug('_')->toString()
-                                ) {
-                                    return;
-                                }
+                                        if (($get('code') ?? '') !== Str::of($old)->slug('_')->toString()) {
+                                            return;
+                                        }
 
-                                $set(
-                                    'code',
-                                    Str::of($state)->slug('_')->toString()
-                                );
-                            }),
-                        TextInput::make('code')
-                            ->label(
-                                __(
-                                    'custom-fields::custom-fields.field.form.code'
-                                )
-                            )
-                            ->helperText(
-                                __(
-                                    'custom-fields::custom-fields.field.form.code_helper_text'
-                                )
-                            )
-                            ->live(onBlur: true)
-                            ->required(
-                                fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
-                            )
-                            ->alphaDash()
-                            ->maxLength(50)
-                            ->disabled(
-                                fn (
-                                    ?CustomField $record
-                                ): bool => (bool) $record?->system_defined
-                            )
-                            ->visible(
-                                fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
-                            )
-                            ->unique(
-                                table: CustomFields::customFieldModel(),
-                                column: 'code',
-                                ignoreRecord: true,
-                                modifyRuleUsing: fn (
-                                    Unique $rule,
-                                    Get $get
-                                ) => $rule
-                                    ->where('entity_type', $get('entity_type'))
-                                    ->when(
-                                        FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                        fn (Unique $rule) => $rule->where(
-                                            config(
-                                                'custom-fields.database.column_names.tenant_foreign_key'
-                                            ),
-                                            TenantContextService::getCurrentTenantId()
-                                        )
+                                        $set('code', Str::of($state)->slug('_')->toString());
+                                    }),
+                                TextInput::make('code')
+                                    ->label(__('custom-fields::custom-fields.field.form.code'))
+                                    ->live(onBlur: true)
+                                    ->required(fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE))
+                                    ->alphaDash()
+                                    ->maxLength(50)
+                                    ->disabled(fn (?CustomField $record): bool => (bool) $record?->system_defined)
+                                    ->visible(fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE))
+                                    ->unique(
+                                        table: CustomFields::customFieldModel(),
+                                        column: 'code',
+                                        ignoreRecord: true,
+                                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
+                                            ->where('entity_type', $get('entity_type'))
+                                            ->when(
+                                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
+                                                fn (Unique $rule) => $rule->where(
+                                                    config('custom-fields.database.column_names.tenant_foreign_key'),
+                                                    TenantContextService::getCurrentTenantId()
+                                                )
+                                            )
                                     )
-                            )
-                            ->afterStateUpdated(function (
-                                Set $set,
-                                ?string $state
-                            ): void {
-                                $set(
-                                    'code',
-                                    Str::of($state)->slug('_')->toString()
-                                );
-                            }),
+                                    ->afterStateUpdated(function (Set $set, ?string $state): void {
+                                        $set('code', Str::of($state)->slug('_')->toString());
+                                    }),
+                            ]),
                         Fieldset::make(
                             __(
                                 'custom-fields::custom-fields.field.form.settings'

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -26,6 +26,7 @@ use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Facades\Entities;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\CustomFieldValidationComponent;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\TypeField;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
@@ -34,6 +35,36 @@ use Relaticle\CustomFields\Services\TenantContextService;
 
 class FieldForm implements FormInterface
 {
+    /**
+     * Get type-specific settings schema components.
+     *
+     * @return array<int, Component>
+     */
+    private static function getTypeSettingsSchema(): array
+    {
+        $fieldManager = app(FieldManager::class);
+
+        $components = [];
+
+        foreach (CustomFieldsType::toCollection() as $fieldTypeData) {
+            if ($fieldTypeData->settingsSchema === null) {
+                continue;
+            }
+
+            $schema = is_callable($fieldTypeData->settingsSchema)
+                ? ($fieldTypeData->settingsSchema)()
+                : $fieldTypeData->settingsSchema;
+
+            foreach ($schema as $component) {
+                $components[] = $component->visible(
+                    fn (Get $get): bool => $get('type') === $fieldTypeData->key
+                );
+            }
+        }
+
+        return $components;
+    }
+
     /**
      * @return array<int, Component>
      *
@@ -213,13 +244,18 @@ class FieldForm implements FormInterface
                                 )
                             )
                             ->live(onBlur: true)
-                            ->required()
+                            ->required(
+                                fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
+                            )
                             ->alphaDash()
                             ->maxLength(50)
                             ->disabled(
                                 fn (
                                     ?CustomField $record
                                 ): bool => (bool) $record?->system_defined
+                            )
+                            ->visible(
+                                fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
                             )
                             ->unique(
                                 table: CustomFields::customFieldModel(),
@@ -387,7 +423,70 @@ class FieldForm implements FormInterface
                                                 'multi_select',
                                             ])
                                     ),
+                                // Multi-value settings
+                                Toggle::make('settings.allow_multiple')
+                                    ->inline(false)
+                                    ->live()
+                                    ->label(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.allow_multiple'
+                                        )
+                                    )
+                                    ->helperText(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.allow_multiple_help'
+                                        )
+                                    )
+                                    ->visible(
+                                        fn (
+                                            Get $get
+                                        ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_MULTI_VALUE) &&
+                                            CustomFieldsType::getFieldType($get('type'))?->supportsMultiValue === true
+                                    )
+                                    ->default(false),
+                                TextInput::make('settings.max_values')
+                                    ->label(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.max_values'
+                                        )
+                                    )
+                                    ->helperText(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.max_values_help'
+                                        )
+                                    )
+                                    ->numeric()
+                                    ->minValue(1)
+                                    ->maxValue(20)
+                                    ->default(5)
+                                    ->visible(
+                                        fn (
+                                            Get $get
+                                        ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_MULTI_VALUE) &&
+                                            CustomFieldsType::getFieldType($get('type'))?->supportsMultiValue === true &&
+                                            $get('settings.allow_multiple') === true
+                                    ),
+                                // Uniqueness constraint
+                                Toggle::make('settings.unique_per_entity_type')
+                                    ->inline(false)
+                                    ->label(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.unique_per_entity_type'
+                                        )
+                                    )
+                                    ->helperText(
+                                        __(
+                                            'custom-fields::custom-fields.field.form.unique_per_entity_type_help'
+                                        )
+                                    )
+                                    ->visible(
+                                        fn (): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_UNIQUE_VALUE)
+                                    )
+                                    ->default(false),
                             ]),
+
+                        // Dynamic type-specific settings from field type definition
+                        ...self::getTypeSettingsSchema(),
 
                         Select::make('options_lookup_type')
                             ->label(

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -405,7 +405,8 @@ class FieldForm implements FormInterface
                                         )
                                     )
                                     ->visible(
-                                        fn (): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_UNIQUE_VALUE)
+                                        fn (Get $get): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_UNIQUE_VALUE) &&
+                                            CustomFieldsType::getFieldType($get('type'))?->supportsUniqueConstraint === true
                                     )
                                     ->default(false),
                             ]),

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -357,22 +357,17 @@ class FieldForm implements FormInterface
                                 Toggle::make('settings.allow_multiple')
                                     ->inline(false)
                                     ->live()
-                                    ->label(
-                                        __(
-                                            'custom-fields::custom-fields.field.form.allow_multiple'
-                                        )
-                                    )
-                                    ->helperText(
-                                        __(
-                                            'custom-fields::custom-fields.field.form.allow_multiple_help'
-                                        )
-                                    )
+                                    ->label(__('custom-fields::custom-fields.field.form.allow_multiple'))
+                                    ->helperText(__('custom-fields::custom-fields.field.form.allow_multiple_help'))
                                     ->visible(
-                                        fn (
-                                            Get $get
-                                        ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_MULTI_VALUE) &&
+                                        fn (Get $get): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_MULTI_VALUE) &&
                                             CustomFieldsType::getFieldType($get('type'))?->supportsMultiValue === true
                                     )
+                                    ->afterStateUpdated(function (Set $set, bool $state): void {
+                                        if ($state) {
+                                            $set('settings.max_values', 2);
+                                        }
+                                    })
                                     ->default(false),
                                 TextInput::make('settings.max_values')
                                     ->label(

--- a/src/Filament/Management/Schemas/SectionForm.php
+++ b/src/Filament/Management/Schemas/SectionForm.php
@@ -78,14 +78,21 @@ class SectionForm implements FormInterface, SectionFormInterface
 
                         $set('code', Str::of($state)->slug('_')->toString());
                     })
-                    ->columnSpan(6),
+                    ->columnSpan(
+                        fn (): int => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) ? 12 : 6
+                    ),
                 TextInput::make('code')
                     ->label(
                         __('custom-fields::custom-fields.section.form.code')
                     )
-                    ->required()
+                    ->required(
+                        fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
+                    )
                     ->alphaDash()
                     ->maxLength(50)
+                    ->visible(
+                        fn (): bool => ! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE)
+                    )
                     ->unique(
                         table: CustomFields::sectionModel(),
                         column: 'code',

--- a/src/Livewire/Concerns/CreatesCustomFields.php
+++ b/src/Livewire/Concerns/CreatesCustomFields.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Livewire\Concerns;
+
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Support\CodeGenerator;
+
+/**
+ * Shared logic for creating custom fields from Livewire components.
+ */
+trait CreatesCustomFields
+{
+    protected function mutateFieldData(array $data, string $entityType, int|string $sectionId): array
+    {
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+        }
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
+            $data['code'] = CodeGenerator::generateUniqueFieldCode($data['name'], $entityType);
+        }
+
+        return [
+            ...$data,
+            'entity_type' => $entityType,
+            'custom_field_section_id' => $sectionId,
+        ];
+    }
+
+    protected function storeField(array $data): void
+    {
+        $options = collect($data['options'] ?? [])
+            ->filter()
+            ->map(function (array $option): array {
+                if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+                    $option[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+                }
+
+                return $option;
+            })
+            ->values();
+
+        unset($data['options']);
+
+        $customField = CustomFields::newCustomFieldModel()->create($data);
+
+        $customField->options()->createMany($options);
+    }
+}

--- a/src/Livewire/Concerns/ManagesFields.php
+++ b/src/Livewire/Concerns/ManagesFields.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Livewire\Concerns;
+
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Relaticle\CustomFields\CustomFields;
+
+/**
+ * Shared logic for managing custom fields in Livewire components.
+ */
+trait ManagesFields
+{
+    #[Computed]
+    public function fields(): Collection
+    {
+        return $this->section->fields()->withDeactivated()->orderBy('sort_order')->get();
+    }
+
+    #[On('field-width-updated')]
+    public function fieldWidthUpdated(int|string $fieldId, int $width): void
+    {
+        $model = CustomFields::newCustomFieldModel();
+        $model->where($model->getKeyName(), $fieldId)->update(['width' => $width]);
+
+        $this->section->refresh();
+    }
+
+    #[On('field-deleted')]
+    public function fieldDeleted(): void
+    {
+        $this->section->refresh();
+    }
+
+    #[On('fields-reordered')]
+    public function fieldsReordered(): void
+    {
+        unset($this->fields);
+    }
+}

--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -13,14 +13,12 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\Computed;
-use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
+use Relaticle\CustomFields\Livewire\Concerns\ManagesFields;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 final class ManageCustomFieldSection extends Component implements HasActions, HasForms
@@ -28,39 +26,11 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
     use CreatesCustomFields;
     use InteractsWithActions;
     use InteractsWithForms;
+    use ManagesFields;
 
     public string $entityType;
 
     public CustomFieldSection $section;
-
-    #[Computed]
-    public function fields(): Collection
-    {
-        return $this->section->fields()->withDeactivated()->orderBy('sort_order')->get();
-    }
-
-    #[On('field-width-updated')]
-    public function fieldWidthUpdated(int|string $fieldId, int $width): void
-    {
-        // Update the width
-        $model = CustomFields::newCustomFieldModel();
-        $model->where($model->getKeyName(), $fieldId)->update(['width' => $width]);
-
-        // Re-fetch the fields
-        $this->section->refresh();
-    }
-
-    #[On('field-deleted')]
-    public function fieldDeleted(): void
-    {
-        $this->section->refresh();
-    }
-
-    #[On('fields-reordered')]
-    public function fieldsReordered(): void
-    {
-        unset($this->fields);
-    }
 
     public function updateFieldsOrder(int|string $sectionId, array $fields): void
     {

--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -18,16 +18,14 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
-use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
+use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
 use Relaticle\CustomFields\Models\CustomFieldSection;
-use Relaticle\CustomFields\Services\TenantContextService;
-use Relaticle\CustomFields\Support\CodeGenerator;
 
 final class ManageCustomFieldSection extends Component implements HasActions, HasForms
 {
+    use CreatesCustomFields;
     use InteractsWithActions;
     use InteractsWithForms;
 
@@ -163,46 +161,9 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
             ->label(__('custom-fields::custom-fields.field.form.add_field'))
             ->model(CustomFields::customFieldModel())
             ->schema(FieldForm::schema(withOptionsRelationship: false))
-            ->fillForm([
-                'entity_type' => $this->entityType,
-            ])
-            ->mutateDataUsing(function (array $data): array {
-                if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
-                    $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
-                }
-
-                // Auto-generate code if feature is enabled and code is empty
-                if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
-                    $data['code'] = CodeGenerator::generateUniqueFieldCode(
-                        $data['name'],
-                        $this->entityType
-                    );
-                }
-
-                return [
-                    ...$data,
-                    'entity_type' => $this->entityType,
-                    'custom_field_section_id' => $this->section->getKey(),
-                ];
-            })
-            ->action(function (array $data): void {
-                $options = collect($data['options'] ?? [])
-                    ->filter()
-                    ->map(function (array $option): array {
-                        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
-                            $option[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
-                        }
-
-                        return $option;
-                    })
-                    ->values();
-
-                unset($data['options']);
-
-                $customField = CustomFields::newCustomFieldModel()->create($data);
-
-                $customField->options()->createMany($options);
-            })
+            ->fillForm(['entity_type' => $this->entityType])
+            ->mutateDataUsing(fn (array $data): array => $this->mutateFieldData($data, $this->entityType, $this->section->getKey()))
+            ->action(fn (array $data) => $this->storeField($data))
             ->modalWidth(Width::ScreenLarge)
             ->slideOver();
     }

--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -24,6 +24,7 @@ use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Support\CodeGenerator;
 
 final class ManageCustomFieldSection extends Component implements HasActions, HasForms
 {
@@ -168,6 +169,14 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
             ->mutateDataUsing(function (array $data): array {
                 if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
                     $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+                }
+
+                // Auto-generate code if feature is enabled and code is empty
+                if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
+                    $data['code'] = CodeGenerator::generateUniqueFieldCode(
+                        $data['name'],
+                        $this->entityType
+                    );
                 }
 
                 return [

--- a/src/Livewire/ManageFieldsWithoutSections.php
+++ b/src/Livewire/ManageFieldsWithoutSections.php
@@ -17,21 +17,16 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
-use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
+use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
 use Relaticle\CustomFields\Models\CustomFieldSection;
-use Relaticle\CustomFields\Services\TenantContextService;
-use Relaticle\CustomFields\Support\CodeGenerator;
 
 /**
  * Livewire component for managing custom fields when sections are disabled.
- *
- * This component displays fields in a flat grid without any section wrapper,
- * while the default hidden section is managed in the background.
  */
 final class ManageFieldsWithoutSections extends Component implements HasActions, HasForms
 {
+    use CreatesCustomFields;
     use InteractsWithActions;
     use InteractsWithForms;
 
@@ -96,45 +91,9 @@ final class ManageFieldsWithoutSections extends Component implements HasActions,
             ])
             ->model(CustomFields::customFieldModel())
             ->schema(FieldForm::schema(withOptionsRelationship: false))
-            ->fillForm([
-                'entity_type' => $this->entityType,
-            ])
-            ->mutateDataUsing(function (array $data): array {
-                if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
-                    $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
-                }
-
-                if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
-                    $data['code'] = CodeGenerator::generateUniqueFieldCode(
-                        $data['name'],
-                        $this->entityType
-                    );
-                }
-
-                return [
-                    ...$data,
-                    'entity_type' => $this->entityType,
-                    'custom_field_section_id' => $this->section->getKey(),
-                ];
-            })
-            ->action(function (array $data): void {
-                $options = collect($data['options'] ?? [])
-                    ->filter()
-                    ->map(function (array $option): array {
-                        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
-                            $option[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
-                        }
-
-                        return $option;
-                    })
-                    ->values();
-
-                unset($data['options']);
-
-                $customField = CustomFields::newCustomFieldModel()->create($data);
-
-                $customField->options()->createMany($options);
-            })
+            ->fillForm(['entity_type' => $this->entityType])
+            ->mutateDataUsing(fn (array $data): array => $this->mutateFieldData($data, $this->entityType, $this->section->getKey()))
+            ->action(fn (array $data) => $this->storeField($data))
             ->modalWidth(Width::ScreenLarge)
             ->slideOver();
     }

--- a/src/Livewire/ManageFieldsWithoutSections.php
+++ b/src/Livewire/ManageFieldsWithoutSections.php
@@ -12,26 +12,65 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
-use Relaticle\CustomFields\Livewire\Concerns\ManagesFields;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 /**
  * Livewire component for managing custom fields when sections are disabled.
+ *
+ * Shows ALL fields for the entity type regardless of which section they belong to.
+ * New fields are created in the default section.
  */
 final class ManageFieldsWithoutSections extends Component implements HasActions, HasForms
 {
     use CreatesCustomFields;
     use InteractsWithActions;
     use InteractsWithForms;
-    use ManagesFields;
 
     public string $entityType;
 
+    /** The default section used for creating new fields */
     public CustomFieldSection $section;
+
+    /**
+     * Get ALL fields for the entity type, regardless of section.
+     */
+    #[Computed]
+    public function fields(): Collection
+    {
+        return CustomFields::newCustomFieldModel()
+            ->newQuery()
+            ->withDeactivated()
+            ->where('entity_type', $this->entityType)
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    #[On('field-width-updated')]
+    public function fieldWidthUpdated(int|string $fieldId, int $width): void
+    {
+        $model = CustomFields::newCustomFieldModel();
+        $model->where($model->getKeyName(), $fieldId)->update(['width' => $width]);
+        unset($this->fields);
+    }
+
+    #[On('field-deleted')]
+    public function fieldDeleted(): void
+    {
+        unset($this->fields);
+    }
+
+    #[On('fields-reordered')]
+    public function fieldsReordered(): void
+    {
+        unset($this->fields);
+    }
 
     public function updateFieldsOrder(array $fields): void
     {

--- a/src/Livewire/ManageFieldsWithoutSections.php
+++ b/src/Livewire/ManageFieldsWithoutSections.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Livewire;
+
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Support\Enums\Size;
+use Filament\Support\Enums\Width;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Support\CodeGenerator;
+
+/**
+ * Livewire component for managing custom fields when sections are disabled.
+ *
+ * This component displays fields in a flat grid without any section wrapper,
+ * while the default hidden section is managed in the background.
+ */
+final class ManageFieldsWithoutSections extends Component implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public string $entityType;
+
+    public CustomFieldSection $section;
+
+    #[Computed]
+    public function fields(): Collection
+    {
+        return $this->section->fields()->withDeactivated()->orderBy('sort_order')->get();
+    }
+
+    #[On('field-width-updated')]
+    public function fieldWidthUpdated(int|string $fieldId, int $width): void
+    {
+        $model = CustomFields::newCustomFieldModel();
+        $model->where($model->getKeyName(), $fieldId)->update(['width' => $width]);
+
+        $this->section->refresh();
+    }
+
+    #[On('field-deleted')]
+    public function fieldDeleted(): void
+    {
+        $this->section->refresh();
+    }
+
+    #[On('fields-reordered')]
+    public function fieldsReordered(): void
+    {
+        unset($this->fields);
+    }
+
+    public function updateFieldsOrder(array $fields): void
+    {
+        $model = CustomFields::newCustomFieldModel();
+        foreach ($fields as $index => $field) {
+            $model->query()
+                ->withDeactivated()
+                ->where($model->getKeyName(), $field)
+                ->update([
+                    'custom_field_section_id' => $this->section->getKey(),
+                    'sort_order' => $index,
+                ]);
+        }
+
+        $this->dispatch('fields-reordered')->self();
+    }
+
+    public function createFieldAction(): Action
+    {
+        return Action::make('createField')
+            ->size(Size::Small)
+            ->label(__('custom-fields::custom-fields.field.form.add_field'))
+            ->icon('heroicon-s-plus')
+            ->color('gray')
+            ->button()
+            ->outlined()
+            ->extraAttributes([
+                'class' => 'flex justify-center items-center rounded-lg border-gray-300 hover:border-gray-400 border-dashed',
+            ])
+            ->model(CustomFields::customFieldModel())
+            ->schema(FieldForm::schema(withOptionsRelationship: false))
+            ->fillForm([
+                'entity_type' => $this->entityType,
+            ])
+            ->mutateDataUsing(function (array $data): array {
+                if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+                    $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+                }
+
+                if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
+                    $data['code'] = CodeGenerator::generateUniqueFieldCode(
+                        $data['name'],
+                        $this->entityType
+                    );
+                }
+
+                return [
+                    ...$data,
+                    'entity_type' => $this->entityType,
+                    'custom_field_section_id' => $this->section->getKey(),
+                ];
+            })
+            ->action(function (array $data): void {
+                $options = collect($data['options'] ?? [])
+                    ->filter()
+                    ->map(function (array $option): array {
+                        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+                            $option[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+                        }
+
+                        return $option;
+                    })
+                    ->values();
+
+                unset($data['options']);
+
+                $customField = CustomFields::newCustomFieldModel()->create($data);
+
+                $customField->options()->createMany($options);
+            })
+            ->modalWidth(Width::ScreenLarge)
+            ->slideOver();
+    }
+
+    public function render(): View
+    {
+        return view('custom-fields::livewire.manage-fields-without-sections');
+    }
+}

--- a/src/Livewire/ManageFieldsWithoutSections.php
+++ b/src/Livewire/ManageFieldsWithoutSections.php
@@ -12,13 +12,11 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\Computed;
-use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
+use Relaticle\CustomFields\Livewire\Concerns\ManagesFields;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 /**
@@ -29,37 +27,11 @@ final class ManageFieldsWithoutSections extends Component implements HasActions,
     use CreatesCustomFields;
     use InteractsWithActions;
     use InteractsWithForms;
+    use ManagesFields;
 
     public string $entityType;
 
     public CustomFieldSection $section;
-
-    #[Computed]
-    public function fields(): Collection
-    {
-        return $this->section->fields()->withDeactivated()->orderBy('sort_order')->get();
-    }
-
-    #[On('field-width-updated')]
-    public function fieldWidthUpdated(int|string $fieldId, int $width): void
-    {
-        $model = CustomFields::newCustomFieldModel();
-        $model->where($model->getKeyName(), $fieldId)->update(['width' => $width]);
-
-        $this->section->refresh();
-    }
-
-    #[On('field-deleted')]
-    public function fieldDeleted(): void
-    {
-        $this->section->refresh();
-    }
-
-    #[On('fields-reordered')]
-    public function fieldsReordered(): void
-    {
-        unset($this->fields);
-    }
 
     public function updateFieldsOrder(array $fields): void
     {

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -26,7 +26,6 @@ use Relaticle\CustomFields\Models\Scopes\SortOrderScope;
 use Relaticle\CustomFields\Models\Scopes\TenantScope;
 use Relaticle\CustomFields\Observers\CustomFieldObserver;
 use Relaticle\CustomFields\QueryBuilders\CustomFieldQueryBuilder;
-use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 
 /**
@@ -172,33 +171,5 @@ class CustomField extends Model
     public function getFieldName(): string
     {
         return 'custom_fields.'.$this->code;
-    }
-
-    /**
-     * Get field-type-specific settings as a typed Data object.
-     *
-     * This retrieves settings from the `settings.additional.type_settings` path
-     * and deserializes them using the field type's configured settings data class.
-     *
-     * @return Data|null The typed settings data object, or null if not configured
-     */
-    public function getTypeSettings(): ?Data
-    {
-        $typeData = $this->typeData;
-
-        if ($typeData === null || $typeData->settingsDataClass === null) {
-            return null;
-        }
-
-        $typeSettingsData = $this->settings->additional['type_settings'] ?? [];
-
-        if ($typeSettingsData === []) {
-            return null;
-        }
-
-        /** @var class-string<Data> $dataClass */
-        $dataClass = $typeData->settingsDataClass;
-
-        return $dataClass::from($typeSettingsData);
     }
 }

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -26,6 +26,7 @@ use Relaticle\CustomFields\Models\Scopes\SortOrderScope;
 use Relaticle\CustomFields\Models\Scopes\TenantScope;
 use Relaticle\CustomFields\Observers\CustomFieldObserver;
 use Relaticle\CustomFields\QueryBuilders\CustomFieldQueryBuilder;
+use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
 
 /**
@@ -171,5 +172,33 @@ class CustomField extends Model
     public function getFieldName(): string
     {
         return 'custom_fields.'.$this->code;
+    }
+
+    /**
+     * Get field-type-specific settings as a typed Data object.
+     *
+     * This retrieves settings from the `settings.additional.type_settings` path
+     * and deserializes them using the field type's configured settings data class.
+     *
+     * @return Data|null The typed settings data object, or null if not configured
+     */
+    public function getTypeSettings(): ?Data
+    {
+        $typeData = $this->typeData;
+
+        if ($typeData === null || $typeData->settingsDataClass === null) {
+            return null;
+        }
+
+        $typeSettingsData = $this->settings->additional['type_settings'] ?? [];
+
+        if ($typeSettingsData === []) {
+            return null;
+        }
+
+        /** @var class-string<Data> $dataClass */
+        $dataClass = $typeData->settingsDataClass;
+
+        return $dataClass::from($typeSettingsData);
     }
 }

--- a/src/Rules/UniqueCustomFieldValue.php
+++ b/src/Rules/UniqueCustomFieldValue.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+/**
+ * Validation rule that ensures a custom field value is unique per entity type.
+ *
+ * This rule checks if any other entity of the same type already has the given value
+ * for this custom field. Works with any field type that has uniqueness enabled.
+ * For multi-value fields (arrays stored in json_value), each value is checked.
+ */
+final class UniqueCustomFieldValue implements ValidationRule
+{
+    public function __construct(
+        private readonly CustomField $customField,
+        private readonly ?int $ignoreEntityId = null,
+    ) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (blank($value)) {
+            return;
+        }
+
+        // Handle both single values and arrays (for multi-value fields)
+        $values = is_array($value) ? $value : [$value];
+
+        $valueModel = CustomFields::newValueModel();
+        $valueColumn = $this->customField->getValueColumn();
+
+        foreach ($values as $singleValue) {
+            if (blank($singleValue)) {
+                continue;
+            }
+
+            $query = $valueModel->newQuery()
+                ->where('custom_field_id', $this->customField->getKey())
+                ->where('entity_type', $this->customField->entity_type);
+
+            // Check the appropriate value column based on field type's storage column
+            if ($valueColumn === 'json_value') {
+                // For JSON columns, search within the array
+                $query->whereJsonContains('json_value', $singleValue);
+            } else {
+                // For scalar columns (string_value, integer_value, etc.)
+                $query->where($valueColumn, $singleValue);
+            }
+
+            // Apply tenant scope if multi-tenancy is enabled
+            if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+                $tenantFk = config('custom-fields.database.column_names.tenant_foreign_key');
+                $query->where($tenantFk, TenantContextService::getCurrentTenantId());
+            }
+
+            // Exclude the current entity if updating
+            if ($this->ignoreEntityId !== null) {
+                $query->where('entity_id', '!=', $this->ignoreEntityId);
+            }
+
+            if ($query->exists()) {
+                $fail(__('custom-fields::custom-fields.validation.unique_value', [
+                    'value' => $singleValue,
+                ]));
+
+                return;
+            }
+        }
+    }
+}

--- a/src/Services/DefaultSectionService.php
+++ b/src/Services/DefaultSectionService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Services;
+
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Enums\CustomFieldSectionType;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+
+/**
+ * Service for managing the default hidden section when sections are disabled.
+ */
+final class DefaultSectionService
+{
+    /**
+     * The code used for the default hidden section.
+     */
+    public const DEFAULT_SECTION_CODE = '_default';
+
+    /**
+     * Get or create the default hidden section for an entity type.
+     */
+    public function getOrCreateDefaultSection(string $entityType): CustomFieldSection
+    {
+        $sectionModel = CustomFields::newSectionModel();
+
+        $query = $sectionModel->newQuery()
+            ->withDeactivated()
+            ->where('code', self::DEFAULT_SECTION_CODE)
+            ->where('entity_type', $entityType);
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $query->where(
+                config('custom-fields.database.column_names.tenant_foreign_key'),
+                TenantContextService::getCurrentTenantId()
+            );
+        }
+
+        $section = $query->first();
+
+        if ($section instanceof CustomFieldSection) {
+            return $section;
+        }
+
+        return $this->createDefaultSection($entityType);
+    }
+
+    /**
+     * Check if a section is the default hidden section.
+     */
+    public function isDefaultSection(CustomFieldSection $section): bool
+    {
+        return $section->code === self::DEFAULT_SECTION_CODE;
+    }
+
+    /**
+     * Create the default hidden section for an entity type.
+     */
+    private function createDefaultSection(string $entityType): CustomFieldSection
+    {
+        $data = [
+            'name' => __('custom-fields::custom-fields.section.default_section_name'),
+            'code' => self::DEFAULT_SECTION_CODE,
+            'type' => CustomFieldSectionType::HEADLESS->value,
+            'entity_type' => $entityType,
+            'sort_order' => 0,
+            'active' => true,
+        ];
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $data[config('custom-fields.database.column_names.tenant_foreign_key')] = TenantContextService::getCurrentTenantId();
+        }
+
+        return CustomFields::newSectionModel()->create($data);
+    }
+}

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -9,6 +9,7 @@ use Relaticle\CustomFields\Enums\ValidationRule;
 use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
+use Relaticle\CustomFields\Rules\UniqueCustomFieldValue;
 use Relaticle\CustomFields\Support\DatabaseFieldConstraints;
 use Spatie\LaravelData\DataCollection;
 
@@ -21,14 +22,16 @@ final class ValidationService
      * Get all validation rules for a custom field, applying both:
      * - User-defined validation rules from the field configuration
      * - Database field constraints based on field type
+     * - Type-specific settings (e.g., unique per entity type for email fields)
      * - Special handling for numeric values to prevent database errors
      *
      * Returns a combined array of validation rules in Laravel validator format.
      *
      * @param  CustomField  $customField  The custom field to get validation rules for
-     * @return array<int, string> Combined array of validation rules
+     * @param  int|null  $ignoreEntityId  Entity ID to ignore for unique checks (when updating)
+     * @return array<int, mixed> Combined array of validation rules
      */
-    public function getValidationRules(CustomField $customField): array
+    public function getValidationRules(CustomField $customField, ?int $ignoreEntityId = null): array
     {
         // Convert user rules to Laravel validator format
         $userRules = $this->convertUserRulesToValidatorFormat($customField->validation_rules, $customField);
@@ -41,7 +44,12 @@ final class ValidationService
         $databaseRules = $this->getDatabaseValidationRules($customField->type, $isEncrypted);
 
         // Merge all rule types: field defaults + user rules + database constraints
-        return $this->mergeAllValidationRules($fieldTypeDefaultRules, $userRules, $databaseRules, $customField->type);
+        $rules = $this->mergeAllValidationRules($fieldTypeDefaultRules, $userRules, $databaseRules, $customField->type);
+
+        // Add type-specific rules based on settings
+        $typeSpecificRules = $this->getTypeSpecificRules($customField, $ignoreEntityId);
+
+        return array_merge($rules, $typeSpecificRules);
     }
 
     /**
@@ -181,6 +189,25 @@ final class ValidationService
         }
 
         return [];
+    }
+
+    /**
+     * Get type-specific validation rules based on field settings.
+     *
+     * @param  CustomField  $customField  The custom field
+     * @param  int|null  $ignoreEntityId  Entity ID to ignore for unique checks
+     * @return array<int, mixed> Type-specific validation rules
+     */
+    private function getTypeSpecificRules(CustomField $customField, ?int $ignoreEntityId = null): array
+    {
+        $rules = [];
+
+        // Handle unique per entity type setting (available for any field type)
+        if ($customField->settings->unique_per_entity_type) {
+            $rules[] = new UniqueCustomFieldValue($customField, $ignoreEntityId);
+        }
+
+        return $rules;
     }
 
     /**

--- a/src/Support/CodeGenerator.php
+++ b/src/Support/CodeGenerator.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Support;
+
+use Illuminate\Support\Str;
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+/**
+ * Helper class for generating unique codes for custom fields and sections.
+ */
+final class CodeGenerator
+{
+    /**
+     * Generate a slug-style code from a name.
+     */
+    public static function generateFromName(string $name): string
+    {
+        return Str::of($name)->slug('_')->toString();
+    }
+
+    /**
+     * Generate a unique code for a custom field within an entity type.
+     */
+    public static function generateUniqueFieldCode(string $name, string $entityType, ?int $ignoreId = null): string
+    {
+        $baseCode = self::generateFromName($name);
+
+        return self::ensureUniqueCode(
+            $baseCode,
+            $entityType,
+            'field',
+            $ignoreId
+        );
+    }
+
+    /**
+     * Generate a unique code for a section within an entity type.
+     */
+    public static function generateUniqueSectionCode(string $name, string $entityType, ?int $ignoreId = null): string
+    {
+        $baseCode = self::generateFromName($name);
+
+        return self::ensureUniqueCode(
+            $baseCode,
+            $entityType,
+            'section',
+            $ignoreId
+        );
+    }
+
+    /**
+     * Check if a code already exists and append a counter if needed.
+     */
+    private static function ensureUniqueCode(
+        string $baseCode,
+        string $entityType,
+        string $type,
+        ?int $ignoreId = null
+    ): string {
+        $code = $baseCode;
+        $counter = 1;
+
+        while (self::codeExists($code, $entityType, $type, $ignoreId)) {
+            $code = "{$baseCode}_{$counter}";
+            $counter++;
+        }
+
+        return $code;
+    }
+
+    /**
+     * Check if a code exists in the database.
+     */
+    private static function codeExists(
+        string $code,
+        string $entityType,
+        string $type,
+        ?int $ignoreId = null
+    ): bool {
+        $model = $type === 'field'
+            ? CustomFields::newCustomFieldModel()
+            : CustomFields::newSectionModel();
+
+        $query = $model->newQuery()
+            ->withDeactivated()
+            ->where('code', $code)
+            ->where('entity_type', $entityType);
+
+        if ($ignoreId !== null) {
+            $query->where($model->getKeyName(), '!=', $ignoreId);
+        }
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $query->where(
+                config('custom-fields.database.column_names.tenant_foreign_key'),
+                TenantContextService::getCurrentTenantId()
+            );
+        }
+
+        return $query->exists();
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces several enhancements to the custom fields system:

### New Features

- **Multi-value field support** - Fields like email can now store multiple values (array format)
- **Unique value validation** - New `unique_per_entity_type` setting ensures values are unique across records
- **Auto-code generation** - Field codes can be auto-generated from names (controlled by `FIELD_CODE_AUTO_GENERATE` feature flag)
- **Sections disabled mode** - Flat field list without section grouping (controlled by `SYSTEM_SECTIONS_DISABLED` feature flag)

### Email Field Changes

The email field type has been refactored to use `TagsInput` for multi-value support:
- Stores values in `json_value` column as an array
- Supports multiple email addresses when `allow_multiple` is enabled
- Includes migration command for existing data

### Migration Required

If you have existing email field values, run the migration command:

```bash
# Preview changes (safe)
php artisan custom-fields:migrate-email-values --dry-run

# Run migration
php artisan custom-fields:migrate-email-values
```

### New Feature Flags

Add to your `config/custom-fields.php` features array as needed:

```php
CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE,
CustomFieldsFeature::FIELD_MULTI_VALUE,
CustomFieldsFeature::FIELD_UNIQUE_VALUE,
CustomFieldsFeature::SYSTEM_SECTIONS_DISABLED,
```

### Code Quality Improvements

- Extracted shared Livewire methods into `ManagesFields` trait (DRY)
- Extracted field creation logic into `CreatesCustomFields` trait
- Removed unused imports and variables
- Simplified field form layout (entity type now hidden, cleaner grid layout)

### Breaking Changes

- Email field values are now stored as JSON arrays instead of strings
- Run migration command before deploying to production