### PR TITLE
fix: close other action dropdowns when opening a new one

### DIFF
--- a/resources/views/filament/pages/custom-fields-management.blade.php
+++ b/resources/views/filament/pages/custom-fields-management.blade.php
@@ -8,7 +8,25 @@
         @endforeach
     </x-filament::tabs>
 
-    <div class="custom-fields-component">
+    <div class="custom-fields-component"
+         x-data="{
+            handleDropdownClick(e) {
+                if (!this.$el.contains(e.target)) return;
+
+                const trigger = e.target.closest('.fi-dropdown-trigger');
+                if (!trigger) return;
+
+                this.$el.querySelectorAll('.fi-dropdown').forEach(dropdown => {
+                    if (!dropdown.contains(trigger)) {
+                        const panel = dropdown.querySelector('[x-ref=panel]');
+                        if (panel && typeof panel.close === 'function') {
+                            panel.close();
+                        }
+                    }
+                });
+            }
+         }"
+         @mousedown.window="handleDropdownClick($event)">
         <div
             x-sortable
             wire:end.stop="updateSectionsOrder($event.target.sortable.toArray())"


### PR DESCRIPTION
## Summary
- Fixes overlapping ActionGroup dropdowns on the custom fields management page
- When clicking one dropdown, any previously opened dropdown now closes automatically

## Problem
When clicking the action group (3 dots) for a field, then clicking on the action group for a section above, both dropdowns remained open and overlapped.

## Solution
Added Alpine.js coordination that:
- Listens for mousedown events within the component
- Closes any open dropdown panels when a new dropdown trigger is clicked
- Uses scoped selectors (`this.$el`) to avoid affecting other page dropdowns
- Leverages Alpine's lifecycle for automatic cleanup (no memory leaks)
- Avoids private Alpine APIs for stability

## Test plan
- [ ] Click field dropdown → opens; Click section dropdown → field closes, section opens
- [ ] Click section dropdown → opens; Click field dropdown → section closes, field opens
- [ ] Click outside any dropdown → closes normally
- [ ] Edit/Deactivate/Delete actions still work correctly
- [ ] User menu and other page dropdowns are NOT affected