### PR TITLE
fix: case-insensitive validation for custom field options

### DIFF
--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -94,7 +94,27 @@ class FieldForm implements FormInterface
                         ): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_OPTION_COLORS) &&
                             $get('../../settings.enable_option_colors')
                     ),
-                TextInput::make('name')->required()->columnSpan(9)->distinct(),
+                TextInput::make('name')
+                    ->required()
+                    ->columnSpan(9)
+                    ->rules([
+                        fn (Get $get): Closure => function (string $attribute, $value, Closure $fail) use ($get) {
+                            if (blank($value)) {
+                                return;
+                            }
+
+                            $hasDuplicate = collect($get('../../options') ?? [])
+                                ->pluck('name')
+                                ->filter()
+                                ->map(fn ($name) => mb_strtolower($name))
+                                ->duplicates()
+                                ->contains(mb_strtolower($value));
+
+                            if ($hasDuplicate) {
+                                $fail(__('validation.distinct'));
+                            }
+                        },
+                    ]),
             ])
             ->columns(12)
             ->columnSpanFull()

--- a/tests/Feature/Admin/Pages/CustomFieldsValidationTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsValidationTest.php
@@ -79,6 +79,21 @@ describe('CustomFieldsPage - Field Validation Testing', function (): void {
         ])->assertHasFormErrors(['code']);
     });
 
+    it('validates option names are unique case-insensitively', function (): void {
+        livewire(ManageCustomFieldSection::class, [
+            'section' => $this->section,
+            'entityType' => $this->userEntityType,
+        ])->callAction('createField', [
+            'name' => 'Status',
+            'code' => 'status',
+            'type' => 'select',
+            'options' => [
+                ['name' => 'Active'],
+                ['name' => 'active'],
+            ],
+        ])->assertHasFormErrors(['options.1.name']);
+    });
+
     it('validates field type compatibility with validation rules', function (string $fieldType, array $allowedRules, array $disallowedRules): void {
         // Test that allowed rules work
         foreach ($allowedRules as $rule) {


### PR DESCRIPTION
Replace Filament's distinct() with custom closure rule using Collection duplicates() for case-insensitive comparison. Prevents database unique constraint violations when adding options like "AB" and "ab".