### PR TITLE
feat: add scoped management feature and section form extensibility

### DIFF
--- a/src/EntitySystem/EntityCollection.php
+++ b/src/EntitySystem/EntityCollection.php
@@ -53,6 +53,14 @@ final class EntityCollection extends Collection
     }
 
     /**
+     * Get entities with custom fields that are globally managed (not scoped to a parent record)
+     */
+    public function globallyManaged(): static
+    {
+        return $this->withCustomFields()->withoutFeature(EntityFeature::SCOPED_MANAGEMENT->value);
+    }
+
+    /**
      * Get entities that can be used as lookup sources
      */
     public function asLookupSources(): static

--- a/src/Enums/EntityFeature.php
+++ b/src/Enums/EntityFeature.php
@@ -13,12 +13,14 @@ enum EntityFeature: string implements HasLabel
 {
     case CUSTOM_FIELDS = 'custom_fields';
     case LOOKUP_SOURCE = 'lookup_source';
+    case SCOPED_MANAGEMENT = 'scoped_management';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::CUSTOM_FIELDS => 'Custom Fields',
             self::LOOKUP_SOURCE => 'Lookup Source',
+            self::SCOPED_MANAGEMENT => 'Scoped Management',
         };
     }
 
@@ -27,6 +29,7 @@ enum EntityFeature: string implements HasLabel
         return match ($this) {
             self::CUSTOM_FIELDS => 'Entity can have custom fields attached',
             self::LOOKUP_SOURCE => 'Entity can be used as a lookup source for choice fields',
+            self::SCOPED_MANAGEMENT => 'Entity custom fields are managed per-parent record, not on the global management page',
         };
     }
 }

--- a/src/Facades/Entities.php
+++ b/src/Facades/Entities.php
@@ -87,6 +87,14 @@ class Entities extends Facade
     }
 
     /**
+     * Get entities with custom fields that are globally managed
+     */
+    public static function globallyManaged(): EntityCollection
+    {
+        return static::getEntities()->globallyManaged();
+    }
+
+    /**
      * Get entities that can be used as lookup sources
      */
     public static function asLookupSources(): EntityCollection
@@ -97,11 +105,13 @@ class Entities extends Facade
     /**
      * Get entities as options array
      */
-    public static function getOptions(bool $onlyCustomFields = true, bool $usePlural = true): array
+    public static function getOptions(bool $onlyCustomFields = true, bool $usePlural = true, bool $onlyGloballyManaged = false): array
     {
-        $entities = $onlyCustomFields
-            ? static::withCustomFields()
-            : static::getEntities();
+        $entities = match (true) {
+            $onlyGloballyManaged => static::globallyManaged(),
+            $onlyCustomFields => static::withCustomFields(),
+            default => static::getEntities(),
+        };
 
         return $entities->sortedByLabel()->toOptions($usePlural);
     }

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -66,7 +66,7 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
                     filled($state)
             )
             ->required($this->validationService->isRequired($customField))
-            ->rules($this->validationService->getValidationRules($customField))
+            ->rules($this->getFieldValidationRules($customField))
             ->columnSpan($customField->width->getSpanValue())
             ->when(
                 FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY) &&
@@ -121,6 +121,12 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         return in_array($jsExpression, [null, '', '0'], true)
             ? $field
             : $field->live()->visibleJs($jsExpression);
+    }
+
+    /** @return array<int, mixed> */
+    protected function getFieldValidationRules(CustomField $customField): array
+    {
+        return $this->validationService->getValidationRules($customField);
     }
 
     /**

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -43,7 +43,7 @@ class CustomFieldsManagementPage extends Page
     public function mount(): void
     {
         if (blank($this->currentEntityType)) {
-            $firstEntity = Entities::withCustomFields()->first();
+            $firstEntity = Entities::globallyManaged()->first();
             $this->setCurrentEntityType($firstEntity?->getAlias() ?? '');
         }
     }
@@ -91,7 +91,7 @@ class CustomFieldsManagementPage extends Page
     #[Computed]
     public function entityTypes(): Collection
     {
-        return collect(Entities::getOptions(onlyCustomFields: true));
+        return collect(Entities::getOptions(onlyGloballyManaged: true));
     }
 
     public function setCurrentEntityType(?string $entityType): void

--- a/src/Filament/Management/Schemas/SectionForm.php
+++ b/src/Filament/Management/Schemas/SectionForm.php
@@ -17,17 +17,46 @@ use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\TenantContextService;
 
 class SectionForm implements FormInterface, SectionFormInterface
 {
     private static string $entityType;
 
+    /** @var ?\Closure(Unique, Get): Unique */
+    private static ?\Closure $modifyUniqueRuleUsing = null;
+
     public static function entityType(string $entityType): self
     {
         self::$entityType = $entityType;
+        self::$modifyUniqueRuleUsing = null;
 
         return new self;
+    }
+
+    public function modifyUniqueRuleUsing(\Closure $callback): self
+    {
+        self::$modifyUniqueRuleUsing = $callback;
+
+        return $this;
+    }
+
+    private static function buildUniqueRule(Unique $rule, Get $get): Unique
+    {
+        $rule = $rule->when(
+            FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
+            fn (Unique $rule) => $rule->where(
+                config('custom-fields.database.column_names.tenant_foreign_key'),
+                TenantContextService::getCurrentTenantId()
+            )
+        )->where('entity_type', self::$entityType);
+
+        if (self::$modifyUniqueRuleUsing) {
+            $rule = (self::$modifyUniqueRuleUsing)($rule, $get);
+        }
+
+        return $rule;
     }
 
     /**
@@ -47,18 +76,8 @@ class SectionForm implements FormInterface, SectionFormInterface
                     ->unique(
                         table: CustomFields::sectionModel(),
                         column: 'name',
-                        ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
-                            ->when(
-                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                fn (Unique $rule) => $rule->where(
-                                    config(
-                                        'custom-fields.database.column_names.tenant_foreign_key'
-                                    ),
-                                    TenantContextService::getCurrentTenantId()
-                                )
-                            )
-                            ->where('entity_type', self::$entityType)
+                        ignorable: fn (TextInput $component) => ($record = $component->getRecord()) instanceof CustomFieldSection ? $record : null,
+                        modifyRuleUsing: fn (Unique $rule, Get $get) => self::buildUniqueRule($rule, $get),
                     )
                     ->afterStateUpdated(function (
                         Get $get,
@@ -89,18 +108,8 @@ class SectionForm implements FormInterface, SectionFormInterface
                     ->unique(
                         table: CustomFields::sectionModel(),
                         column: 'code',
-                        ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
-                            ->when(
-                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                fn (Unique $rule) => $rule->where(
-                                    config(
-                                        'custom-fields.database.column_names.tenant_foreign_key'
-                                    ),
-                                    TenantContextService::getCurrentTenantId()
-                                )
-                            )
-                            ->where('entity_type', self::$entityType)
+                        ignorable: fn (TextInput $component) => ($record = $component->getRecord()) instanceof CustomFieldSection ? $record : null,
+                        modifyRuleUsing: fn (Unique $rule, Get $get) => self::buildUniqueRule($rule, $get),
                     )
                     ->afterStateUpdated(function (
                         Set $set,


### PR DESCRIPTION
Add SCOPED_MANAGEMENT entity feature for entities whose custom fields are managed per-parent record instead of the global management page.

- Add EntityFeature::SCOPED_MANAGEMENT enum case
- Add EntityCollection::globallyManaged() using withoutFeature()
- Add Entities::globallyManaged() facade method
- Add onlyGloballyManaged parameter to Entities::getOptions()
- Update CustomFieldsManagementPage to use globallyManaged()
- Fix SectionForm ignoreRecord bug when embedded in non-section ViewRecord
- Add SectionForm::modifyUniqueRuleUsing() for custom unique constraints
- Extract buildUniqueRule() to eliminate duplication