### PR TITLE
feat: scoped management and validation extensibility (3.x)

### DIFF
--- a/src/EntitySystem/EntityCollection.php
+++ b/src/EntitySystem/EntityCollection.php
@@ -53,6 +53,14 @@ final class EntityCollection extends Collection
     }
 
     /**
+     * Get entities with custom fields that are globally managed (not scoped to a parent record)
+     */
+    public function globallyManaged(): static
+    {
+        return $this->withCustomFields()->withoutFeature(EntityFeature::SCOPED_MANAGEMENT->value);
+    }
+
+    /**
      * Get entities that can be used as lookup sources
      */
     public function asLookupSources(): static

--- a/src/Enums/EntityFeature.php
+++ b/src/Enums/EntityFeature.php
@@ -13,12 +13,14 @@ enum EntityFeature: string implements HasLabel
 {
     case CUSTOM_FIELDS = 'custom_fields';
     case LOOKUP_SOURCE = 'lookup_source';
+    case SCOPED_MANAGEMENT = 'scoped_management';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::CUSTOM_FIELDS => 'Custom Fields',
             self::LOOKUP_SOURCE => 'Lookup Source',
+            self::SCOPED_MANAGEMENT => 'Scoped Management',
         };
     }
 
@@ -27,6 +29,7 @@ enum EntityFeature: string implements HasLabel
         return match ($this) {
             self::CUSTOM_FIELDS => 'Entity can have custom fields attached',
             self::LOOKUP_SOURCE => 'Entity can be used as a lookup source for choice fields',
+            self::SCOPED_MANAGEMENT => 'Entity custom fields are managed per-parent record, not on the global management page',
         };
     }
 }

--- a/src/Facades/Entities.php
+++ b/src/Facades/Entities.php
@@ -87,6 +87,14 @@ class Entities extends Facade
     }
 
     /**
+     * Get entities with custom fields that are globally managed
+     */
+    public static function globallyManaged(): EntityCollection
+    {
+        return static::getEntities()->globallyManaged();
+    }
+
+    /**
      * Get entities that can be used as lookup sources
      */
     public static function asLookupSources(): EntityCollection
@@ -97,11 +105,13 @@ class Entities extends Facade
     /**
      * Get entities as options array
      */
-    public static function getOptions(bool $onlyCustomFields = true, bool $usePlural = true): array
+    public static function getOptions(bool $onlyCustomFields = true, bool $usePlural = true, bool $onlyGloballyManaged = false): array
     {
-        $entities = $onlyCustomFields
-            ? static::withCustomFields()
-            : static::getEntities();
+        $entities = match (true) {
+            $onlyGloballyManaged => static::globallyManaged(),
+            $onlyCustomFields => static::withCustomFields(),
+            default => static::getEntities(),
+        };
 
         return $entities->sortedByLabel()->toOptions($usePlural);
     }

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -69,12 +69,7 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
                     filled($state)
             )
             ->required($this->validationService->isRequired($customField))
-            ->rules(
-                fn (Field $component): array => $this->validationService->getValidationRules(
-                    $customField,
-                    $component->getRecord()?->getKey()
-                )
-            )
+            ->rules($this->getFieldValidationRules($customField))
             ->columnSpan(
                 FeatureManager::isEnabled(CustomFieldsFeature::UI_FIELD_WIDTH_CONTROL)
                     ? $customField->width->getSpanValue()
@@ -144,6 +139,12 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         return in_array($jsExpression, [null, '', '0'], true)
             ? $field
             : $field->live()->visibleJs($jsExpression);
+    }
+
+    /** @return array<int, mixed> */
+    protected function getFieldValidationRules(CustomField $customField): array
+    {
+        return $this->validationService->getValidationRules($customField);
     }
 
     /**

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -46,7 +46,7 @@ class CustomFieldsManagementPage extends Page
     public function mount(): void
     {
         if (blank($this->currentEntityType)) {
-            $firstEntity = Entities::withCustomFields()->sortedByPriority()->first();
+            $firstEntity = Entities::globallyManaged()->sortedByPriority()->first();
             $this->setCurrentEntityType($firstEntity?->getAlias() ?? '');
         }
     }
@@ -108,7 +108,7 @@ class CustomFieldsManagementPage extends Page
     #[Computed]
     public function entityTypes(): Collection
     {
-        return Entities::withCustomFields()
+        return Entities::globallyManaged()
             ->sortedByPriority()
             ->mapWithKeys(fn (EntityConfigurationData $entity): array => [
                 $entity->getAlias() => $entity->getLabelPlural(),

--- a/src/Filament/Management/Schemas/SectionForm.php
+++ b/src/Filament/Management/Schemas/SectionForm.php
@@ -17,17 +17,46 @@ use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\TenantContextService;
 
 class SectionForm implements FormInterface, SectionFormInterface
 {
     private static string $entityType;
 
+    /** @var ?\Closure(Unique, Get): Unique */
+    private static ?\Closure $modifyUniqueRuleUsing = null;
+
     public static function entityType(string $entityType): self
     {
         self::$entityType = $entityType;
+        self::$modifyUniqueRuleUsing = null;
 
         return new self;
+    }
+
+    public function modifyUniqueRuleUsing(\Closure $callback): self
+    {
+        self::$modifyUniqueRuleUsing = $callback;
+
+        return $this;
+    }
+
+    private static function buildUniqueRule(Unique $rule, Get $get): Unique
+    {
+        $rule = $rule->when(
+            FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
+            fn (Unique $rule) => $rule->where(
+                config('custom-fields.database.column_names.tenant_foreign_key'),
+                TenantContextService::getCurrentTenantId()
+            )
+        )->where('entity_type', self::$entityType);
+
+        if (self::$modifyUniqueRuleUsing) {
+            $rule = (self::$modifyUniqueRuleUsing)($rule, $get);
+        }
+
+        return $rule;
     }
 
     /**
@@ -47,18 +76,8 @@ class SectionForm implements FormInterface, SectionFormInterface
                     ->unique(
                         table: CustomFields::sectionModel(),
                         column: 'name',
-                        ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
-                            ->when(
-                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                fn (Unique $rule) => $rule->where(
-                                    config(
-                                        'custom-fields.database.column_names.tenant_foreign_key'
-                                    ),
-                                    TenantContextService::getCurrentTenantId()
-                                )
-                            )
-                            ->where('entity_type', self::$entityType)
+                        ignorable: fn (TextInput $component) => ($record = $component->getRecord()) instanceof CustomFieldSection ? $record : null,
+                        modifyRuleUsing: fn (Unique $rule, Get $get) => self::buildUniqueRule($rule, $get),
                     )
                     ->afterStateUpdated(function (
                         Get $get,
@@ -96,18 +115,8 @@ class SectionForm implements FormInterface, SectionFormInterface
                     ->unique(
                         table: CustomFields::sectionModel(),
                         column: 'code',
-                        ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
-                            ->when(
-                                FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                fn (Unique $rule) => $rule->where(
-                                    config(
-                                        'custom-fields.database.column_names.tenant_foreign_key'
-                                    ),
-                                    TenantContextService::getCurrentTenantId()
-                                )
-                            )
-                            ->where('entity_type', self::$entityType)
+                        ignorable: fn (TextInput $component) => ($record = $component->getRecord()) instanceof CustomFieldSection ? $record : null,
+                        modifyRuleUsing: fn (Unique $rule, Get $get) => self::buildUniqueRule($rule, $get),
                     )
                     ->afterStateUpdated(function (
                         Set $set,


### PR DESCRIPTION
## Summary
- Cherry-pick of improvements from 2.x `feat/scoped-management-feature` branch
- Adds `globallyManaged()` scope for entity filtering in management page
- Extracts `getFieldValidationRules()` as protected method on `AbstractFormComponent` for subclass override
- Adds `SectionForm::entityType()` static constructor for section form extensibility
- Adds `modifyUniqueRuleUsing()` API for scoped unique validation

## Test plan
- [ ] Verify management page loads with correct entity types
- [ ] Verify custom field creation with scoped unique validation
- [ ] Verify subclass override of `getFieldValidationRules()` works