### PR TITLE
docs: update field types and data model for validation capabilities

### DIFF
--- a/docs/content/2.essentials/3.field-types.md
+++ b/docs/content/2.essentials/3.field-types.md
@@ -68,10 +68,11 @@ namespace App\Filament\FieldTypes;
 use Filament\Forms\Components\Select;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Tables\Columns\TextColumn;
-use Relaticle\CustomFields\Enums\ValidationRule;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Validation\Capabilities\MaxValueCapability;
+use Relaticle\CustomFields\Validation\Capabilities\MinValueCapability;
 
 class StarRatingFieldType extends BaseFieldType
 {
@@ -109,11 +110,10 @@ class StarRatingFieldType extends BaseFieldType
                     });
             })
             ->priority(45)
-            ->availableValidationRules([
-                ValidationRule::REQUIRED,
-                ValidationRule::MIN,
-                ValidationRule::MAX,
-            ]);
+            ->withValidationCapabilities(
+                MinValueCapability::class,
+                MaxValueCapability::class,
+            );
     }
 }
 ```
@@ -193,7 +193,7 @@ FieldSchema::multiChoice()   // For MULTI_CHOICE data type
 ->tableColumn($column)               // Table column component
 ->tableFilter($filter)               // Table filter component
 ->infolistEntry($entry)             // Read-only display component
-->availableValidationRules($rules)  // Validation rules users can toggle per field
+->withValidationCapabilities(...)   // Validation capabilities users can configure per field
 ->defaultValidationRules($rules)    // Validation rules always applied to this field type
 ->searchable()                      // Enable globally-searchable in tables (default: true)
 ->sortable()                        // Enable column sorting in tables (default: true)

--- a/docs/content/2.essentials/6.data-model.md
+++ b/docs/content/2.essentials/6.data-model.md
@@ -50,7 +50,7 @@ The Custom Fields plugin employs a **Hybrid Entity-Attribute-Value (EAV) with Ty
   | `lookup_type` | string | For lookup fields |
   | `width` | string | Layout width |
   | `sort_order` | int | Display order |
-  | `validation_rules` | json | Laravel validation rules |
+  | `validation_rules` | json | Capability-driven validation config (e.g. `required`, `min_value`, `decimal_places`) |
   | `active` | bool | Enabled flag |
   | `system_defined` | bool | Protected from user deletion |
   | `settings` | json | Type-specific configuration |


### PR DESCRIPTION
Replace deprecated availableValidationRules/ValidationRule enum with withValidationCapabilities in the StarRating example and API reference. Clarify validation_rules column stores capability-driven config.