### PR TITLE
fix: prevent type field from being deselected to null

### DIFF
--- a/src/Filament/Management/Forms/Components/TypeField.php
+++ b/src/Filament/Management/Forms/Components/TypeField.php
@@ -21,6 +21,7 @@ class TypeField extends Select
         $this->native(false)
             ->allowHtml()
             ->searchable()
+            ->selectablePlaceholder(false)
             ->searchDebounce(300)
             ->searchPrompt(__('Search field types...'))
             ->noSearchResultsMessage(__('No field types found'))


### PR DESCRIPTION
## Summary
- Adds `selectablePlaceholder(false)` to `TypeField` select component to prevent users from clearing the field type back to null
- Fixes production `ErrorException: Attempt to read property "encryptable" on null` in `FieldForm.php:379` when `$get('type')` returns null

## Context
The `FieldForm` schema has multiple `visible()` closures that call `CustomFieldsType::getFieldType($get('type'))` and access properties on the result. When a user deselects the type field, `getFieldType()` returns `null`, causing the error.

## Test plan
- [x] Open custom field create/edit form
- [x] Verify type field cannot be cleared once selected
- [x] Verify all field type switches work correctly without errors