### PR TITLE
feat: add field description/help text support

### DIFF
--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -54,6 +54,7 @@ return [
             CustomFieldsFeature::UI_TABLE_COLUMNS,
             CustomFieldsFeature::UI_TOGGLEABLE_COLUMNS,
             CustomFieldsFeature::UI_TABLE_FILTERS,
+            CustomFieldsFeature::FIELD_DESCRIPTION,
             CustomFieldsFeature::UI_FIELD_WIDTH_CONTROL,
             CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
             CustomFieldsFeature::SYSTEM_SECTIONS,

--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -37,6 +37,7 @@ return [
             'name_helper_text' => "The field's label shown in the table's and form's.",
             'code' => 'Code',
             'code_helper_text' => 'Unique code to identify this field throughout the resource.',
+            'description' => 'Description',
             'settings' => 'Settings',
             'encrypted' => 'Encrypted',
             'encrypted_help' => 'When enabled, this field\'s values will be stored securely using encryption.',

--- a/src/Data/CustomFieldSettingsData.php
+++ b/src/Data/CustomFieldSettingsData.php
@@ -23,6 +23,7 @@ class CustomFieldSettingsData extends Data
         public bool $allow_multiple = false,
         public int $max_values = 1,
         public bool $unique_per_entity_type = false,
+        public ?string $description = null,
         public VisibilityData $visibility = new VisibilityData,
         public array $additional = [],
     ) {

--- a/src/Enums/CustomFieldsFeature.php
+++ b/src/Enums/CustomFieldsFeature.php
@@ -18,6 +18,7 @@ enum CustomFieldsFeature: string
     case FIELD_MULTI_VALUE = 'field_multi_value';
     case FIELD_UNIQUE_VALUE = 'field_unique_value';
     case FIELD_VALIDATION_RULES = 'field_validation_rules';
+    case FIELD_DESCRIPTION = 'field_description';
 
     // Table/UI integration features
     case UI_TABLE_COLUMNS = 'ui_table_columns';

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -55,6 +55,11 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         $field
             ->name($customField->getFieldName())
             ->label($customField->name)
+            ->helperText(
+                FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION)
+                    ? ($customField->settings->description ?? null)
+                    : null
+            )
             ->afterStateHydrated(
                 fn (mixed $component, mixed $state, mixed $record): mixed => $component->state(
                     $this->transformHydratedValue(

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Component;
@@ -268,6 +269,12 @@ class FieldForm implements FormInterface
                             $set('code', Str::of($state)->slug('_')->toString());
                         }),
                 ]),
+            Textarea::make('settings.description')
+                ->label(__('custom-fields::custom-fields.field.form.description'))
+                ->maxLength(255)
+                ->rows(2)
+                ->columnSpanFull()
+                ->visible(fn (): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION)),
             Fieldset::make(
                 __(
                     'custom-fields::custom-fields.field.form.settings'


### PR DESCRIPTION
## Summary

- Adds optional `description` property to custom field settings DTO (stored in existing `settings` JSON column -- no migration needed)
- Renders as `helperText` below fields in end-user Filament forms
- Adds `Textarea` description input to the management form for admins
- Gated behind `FIELD_DESCRIPTION` feature flag (enabled by default)

Closes #70

## Test plan

- [x] PHPStan: 0 errors
- [x] Pint: formatted
- [x] All 383 existing tests pass
- [x] Manual: create a custom field with description, verify helper text appears in end-user form