### PR TITLE
fix: refresh field list after duplicating a custom field

### DIFF
--- a/src/Livewire/Concerns/ManagesFields.php
+++ b/src/Livewire/Concerns/ManagesFields.php
@@ -29,8 +29,8 @@ trait ManagesFields
         $this->section->refresh();
     }
 
-    #[On('field-deleted')]
-    public function fieldDeleted(): void
+    #[On(['field-created', 'field-deleted'])]
+    public function refreshSection(): void
     {
         $this->section->refresh();
     }

--- a/src/Livewire/ManageFieldsTable.php
+++ b/src/Livewire/ManageFieldsTable.php
@@ -163,8 +163,7 @@ final class ManageFieldsTable extends Component implements HasActions, HasForms
         $this->resetFieldsCache();
     }
 
-    #[On('field-deleted')]
-    #[On('fields-reordered')]
+    #[On(['field-created', 'field-deleted', 'fields-reordered'])]
     public function refreshFields(): void
     {
         $this->resetFieldsCache();

--- a/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Data\CustomFieldOptionSettingsData;
 use Relaticle\CustomFields\Livewire\ManageCustomField;
 use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Models\CustomField;
@@ -397,8 +398,8 @@ describe('ManageCustomField - Field Actions', function (): void {
                 'code' => 'color_picker',
             ]);
 
-        $field->options->first()->update(['settings' => new \Relaticle\CustomFields\Data\CustomFieldOptionSettingsData(color: '#ff0000')]);
-        $field->options->last()->update(['settings' => new \Relaticle\CustomFields\Data\CustomFieldOptionSettingsData(color: '#0000ff')]);
+        $field->options->first()->update(['settings' => new CustomFieldOptionSettingsData(color: '#ff0000')]);
+        $field->options->last()->update(['settings' => new CustomFieldOptionSettingsData(color: '#0000ff')]);
 
         livewire(ManageCustomField::class, [
             'field' => $field->fresh(),


### PR DESCRIPTION
## Summary

- Listen for `field-created` event in `ManagesFields` trait and `ManageFieldsTable` so the UI updates without a page reload after duplicating
- Rename `fieldDeleted()` to `refreshSection()` since it now handles both events
- Use array syntax for `#[On]` attributes instead of stacking
- Fix rector: import `CustomFieldOptionSettingsData` instead of using FQCN

## Test plan

- [x] All 28 related tests pass (duplicate, delete, activate, reorder)
- [x] Rector, PHPStan, Pint all clean