### PR TITLE
fix: refresh field list after duplicating a custom field

### DIFF
--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -51,8 +51,8 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
         $this->section->refresh();
     }
 
-    #[On('field-deleted')]
-    public function fieldDeleted(): void
+    #[On(['field-created', 'field-deleted'])]
+    public function refreshSection(): void
     {
         $this->section->refresh();
     }


### PR DESCRIPTION
## Summary

- Listen for `field-created` event in `ManageCustomFieldSection` so the UI updates without a page reload after duplicating
- Rename `fieldDeleted()` to `refreshSection()` since it now handles both events
- Use array syntax for `#[On]` attribute

Backport of #98 for 2.x.

## Test plan

- [x] All 19 related tests pass (duplicate, delete, activate, reorder)
- [x] Pint clean