### PR TITLE
feat: add FieldDataType::FILE to fix file upload validation

### DIFF
--- a/src/Console/Commands/MakeFieldTypeCommand.php
+++ b/src/Console/Commands/MakeFieldTypeCommand.php
@@ -177,6 +177,7 @@ class MakeFieldTypeCommand extends GeneratorCommand
             FieldDataType::BOOLEAN => 'boolean()',
             FieldDataType::SINGLE_CHOICE => 'singleChoice()',
             FieldDataType::MULTI_CHOICE => 'multiChoice()',
+            FieldDataType::FILE => 'file()',
         };
     }
 
@@ -195,6 +196,7 @@ class MakeFieldTypeCommand extends GeneratorCommand
             FieldDataType::BOOLEAN => 'use Filament\Forms\Components\Toggle;',
             FieldDataType::SINGLE_CHOICE => 'use Filament\Forms\Components\Select;',
             FieldDataType::MULTI_CHOICE => 'use Filament\Forms\Components\CheckboxList;',
+            FieldDataType::FILE => 'use Filament\Forms\Components\FileUpload;',
         };
     }
 
@@ -238,6 +240,9 @@ class MakeFieldTypeCommand extends GeneratorCommand
                 ])
                 ->columnSpanFull();',
             FieldDataType::MULTI_CHOICE => 'return CheckboxList::make($customField->getFieldName())
+                ->label($customField->name)
+                ->columnSpanFull();',
+            FieldDataType::FILE => 'return FileUpload::make($customField->getFieldName())
                 ->label($customField->name)
                 ->columnSpanFull();',
         };

--- a/src/Enums/FieldDataType.php
+++ b/src/Enums/FieldDataType.php
@@ -18,6 +18,7 @@ enum FieldDataType: string
     case BOOLEAN = 'boolean';
     case SINGLE_CHOICE = 'single_choice';
     case MULTI_CHOICE = 'multi_choice';
+    case FILE = 'file';
 
     /**
      * Check if this category represents optionable fields.
@@ -99,6 +100,10 @@ enum FieldDataType: string
             self::MULTI_CHOICE => [
                 VisibilityOperator::CONTAINS,
                 VisibilityOperator::NOT_CONTAINS,
+                VisibilityOperator::IS_EMPTY,
+                VisibilityOperator::IS_NOT_EMPTY,
+            ],
+            self::FILE => [
                 VisibilityOperator::IS_EMPTY,
                 VisibilityOperator::IS_NOT_EMPTY,
             ],

--- a/src/FieldTypeSystem/Definitions/FileUploadFieldType.php
+++ b/src/FieldTypeSystem/Definitions/FileUploadFieldType.php
@@ -20,7 +20,7 @@ class FileUploadFieldType extends BaseFieldType
 {
     public function configure(): FieldSchema
     {
-        return FieldSchema::string()
+        return FieldSchema::file()
             ->key('file-upload')
             ->label('File Upload')
             ->icon('heroicon-o-paper-clip')

--- a/src/FieldTypeSystem/FieldSchema.php
+++ b/src/FieldTypeSystem/FieldSchema.php
@@ -107,6 +107,16 @@ class FieldSchema
     }
 
     /**
+     * Configure for file upload fields.
+     * Stores file paths in string_value but skips string column validation constraints,
+     * since validation runs against the uploaded file, not the stored path.
+     */
+    public static function file(): self
+    {
+        return new self(FieldDataType::FILE);
+    }
+
+    /**
      * Configure for numeric fields
      */
     public static function numeric(): self

--- a/src/Models/CustomFieldValue.php
+++ b/src/Models/CustomFieldValue.php
@@ -83,7 +83,7 @@ class CustomFieldValue extends Model
         $dataType = $fieldType->dataType;
 
         return match ($dataType) {
-            FieldDataType::STRING => 'string_value',
+            FieldDataType::STRING, FieldDataType::FILE => 'string_value',
             FieldDataType::TEXT => 'text_value',
             FieldDataType::NUMERIC => 'integer_value',
             FieldDataType::SINGLE_CHOICE => CustomFields::optionModelUsesStringKeys() ? 'string_value' : 'integer_value',

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Services;
 
 use Relaticle\CustomFields\Contracts\ValidationCapability;
+use Relaticle\CustomFields\Enums\FieldDataType;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
@@ -104,6 +106,13 @@ final class ValidationService
      */
     public function getDatabaseValidationRules(string $fieldType, bool $isEncrypted = false): array
     {
+        // File types validate the uploaded file, not the stored path
+        $fieldTypeData = CustomFieldsType::getFieldType($fieldType);
+
+        if ($fieldTypeData?->dataType === FieldDataType::FILE) {
+            return [];
+        }
+
         // Determine the database column for this field type
         $columnName = CustomFieldValue::getValueColumn($fieldType);
 
@@ -234,6 +243,13 @@ final class ValidationService
 
         // Add user rules (can override or supplement defaults)
         $mergedRules = $this->combineRules($mergedRules, $userRules);
+
+        // File types validate the uploaded file, not the stored path — skip DB constraints
+        $fieldTypeData = CustomFieldsType::getFieldType($fieldType);
+
+        if ($fieldTypeData?->dataType === FieldDataType::FILE) {
+            return $mergedRules;
+        }
 
         // Apply database constraint rules using existing logic
         $columnName = CustomFieldValue::getValueColumn($fieldType);

--- a/tests/Feature/Integration/FileUploadValidationTest.php
+++ b/tests/Feature/Integration/FileUploadValidationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\FieldDataType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldTypeConfigurator;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Models\CustomFieldValue;
+use Relaticle\CustomFields\Services\ValidationService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    config()->set('custom-fields.field_type_configuration', FieldTypeConfigurator::configure()
+        ->enabled([])
+        ->disabled([])
+        ->discover(true)
+        ->cache(enabled: false));
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create();
+});
+
+it('resolves FILE data type to string_value column', function (): void {
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'document',
+        'type' => 'file-upload',
+    ]);
+
+    $column = CustomFieldValue::getValueColumn($field->type);
+
+    expect($column)->toBe('string_value');
+});
+
+it('does not apply string database constraints to file upload fields', function (): void {
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'attachment',
+        'type' => 'file-upload',
+    ]);
+
+    $service = app(ValidationService::class);
+    $rules = $service->getValidationRules($field);
+
+    expect($rules)
+        ->toContain('file')
+        ->not->toContain('string')
+        ->not->toContain('max:255');
+});
+
+it('applies max file size from capability rules instead of database constraints', function (): void {
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'sized_upload',
+        'type' => 'file-upload',
+        'validation_rules' => ['max_size_kb' => 10240],
+    ]);
+
+    $service = app(ValidationService::class);
+    $rules = $service->getValidationRules($field);
+
+    expect($rules)
+        ->toContain('file')
+        ->toContain('max:10240')
+        ->not->toContain('string')
+        ->not->toContain('max:255');
+});
+
+it('returns empty database validation rules for file types', function (): void {
+    $service = app(ValidationService::class);
+    $dbRules = $service->getDatabaseValidationRules('file-upload');
+
+    expect($dbRules)->toBe([]);
+});
+
+it('has FILE case in FieldDataType enum', function (): void {
+    $file = FieldDataType::FILE;
+
+    expect($file->value)->toBe('file')
+        ->and($file->isChoiceField())->toBeFalse()
+        ->and($file->isMultiChoiceField())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Adds `FieldDataType::FILE` enum case with `FieldSchema::file()` factory method
- FILE maps to `string_value` for storage but skips database column constraints in validation
- Fixes file upload fields rejecting files >255 KB due to `string_value` column's `max:255` being interpreted as kilobytes when combined with the `file` validation rule

## Problem

File upload custom fields use `FieldSchema::string()` which stores file paths in `string_value` (VARCHAR 255). `DatabaseFieldConstraints` adds `string` + `max:255` rules for that column. When combined with the `file` default validation rule, Laravel interprets `max:255` as 255 KB file size limit instead of 255 characters — causing valid file uploads (e.g., a 608 KB PDF) to fail validation.

## Solution

Introduces `FieldDataType::FILE` as a first-class data type that:
- Maps to `string_value` for storage (file paths fit in VARCHAR 255)
- Returns empty database validation rules (the column constraints are irrelevant — validation runs against the uploaded file, not the stored path)
- Provides `FieldSchema::file()` factory for semantic clarity
- Updates `FileUploadFieldType` to use `FieldSchema::file()` instead of `FieldSchema::string()`

## Files changed

| File | Change |
|------|--------|
| `FieldDataType` | Add `FILE = 'file'` case with visibility operators |
| `FieldSchema` | Add `file()` factory method |
| `FileUploadFieldType` | Use `FieldSchema::file()` |
| `CustomFieldValue` | Map `FILE` to `string_value` |
| `ValidationService` | Skip DB constraints for `FILE` data type |
| `MakeFieldTypeCommand` | Handle `FILE` in scaffolding |

## Test plan

- [x] New `FileUploadValidationTest` with 5 tests covering:
  - FILE resolves to `string_value` column
  - No `string` or `max:255` rules applied to file uploads
  - Capability-based `max_size_kb` works correctly
  - `getDatabaseValidationRules` returns empty for file types
  - `FieldDataType::FILE` enum behavior
- [x] Full test suite passes (396 tests, 2103 assertions)