### PR TITLE
feat: add FieldDataType::FILE to fix file upload validation

### DIFF
--- a/src/Console/Commands/MakeFieldTypeCommand.php
+++ b/src/Console/Commands/MakeFieldTypeCommand.php
@@ -183,6 +183,7 @@ class MakeFieldTypeCommand extends GeneratorCommand
             FieldDataType::BOOLEAN => 'boolean()',
             FieldDataType::SINGLE_CHOICE => 'singleChoice()',
             FieldDataType::MULTI_CHOICE => 'multiChoice()',
+            FieldDataType::FILE => 'file()',
         };
     }
 
@@ -201,6 +202,7 @@ class MakeFieldTypeCommand extends GeneratorCommand
             FieldDataType::BOOLEAN => 'use Filament\Forms\Components\Toggle;',
             FieldDataType::SINGLE_CHOICE => 'use Filament\Forms\Components\Select;',
             FieldDataType::MULTI_CHOICE => 'use Filament\Forms\Components\CheckboxList;',
+            FieldDataType::FILE => 'use Filament\Forms\Components\FileUpload;',
         };
     }
 
@@ -244,6 +246,9 @@ class MakeFieldTypeCommand extends GeneratorCommand
                 ])
                 ->columnSpanFull();',
             FieldDataType::MULTI_CHOICE => 'return CheckboxList::make($customField->getFieldName())
+                ->label($customField->name)
+                ->columnSpanFull();',
+            FieldDataType::FILE => 'return FileUpload::make($customField->getFieldName())
                 ->label($customField->name)
                 ->columnSpanFull();',
         };

--- a/src/Enums/FieldDataType.php
+++ b/src/Enums/FieldDataType.php
@@ -18,6 +18,7 @@ enum FieldDataType: string
     case BOOLEAN = 'boolean';
     case SINGLE_CHOICE = 'single_choice';
     case MULTI_CHOICE = 'multi_choice';
+    case FILE = 'file';
 
     /**
      * Check if this category represents optionable fields.
@@ -73,6 +74,10 @@ enum FieldDataType: string
             self::MULTI_CHOICE => [
                 VisibilityOperator::CONTAINS,
                 VisibilityOperator::NOT_CONTAINS,
+                VisibilityOperator::IS_EMPTY,
+                VisibilityOperator::IS_NOT_EMPTY,
+            ],
+            self::FILE => [
                 VisibilityOperator::IS_EMPTY,
                 VisibilityOperator::IS_NOT_EMPTY,
             ],

--- a/src/FieldTypeSystem/Definitions/FileUploadFieldType.php
+++ b/src/FieldTypeSystem/Definitions/FileUploadFieldType.php
@@ -19,7 +19,7 @@ class FileUploadFieldType extends BaseFieldType
 {
     public function configure(): FieldSchema
     {
-        return FieldSchema::string()
+        return FieldSchema::file()
             ->key('file-upload')
             ->label('File Upload')
             ->icon('heroicon-o-paper-clip')

--- a/src/FieldTypeSystem/FieldSchema.php
+++ b/src/FieldTypeSystem/FieldSchema.php
@@ -97,6 +97,16 @@ class FieldSchema
     }
 
     /**
+     * Configure for file upload fields.
+     * Stores file paths in string_value but skips string column validation constraints,
+     * since validation runs against the uploaded file, not the stored path.
+     */
+    public static function file(): self
+    {
+        return new self(FieldDataType::FILE);
+    }
+
+    /**
      * Configure for numeric fields
      */
     public static function numeric(): self

--- a/src/Models/CustomFieldValue.php
+++ b/src/Models/CustomFieldValue.php
@@ -83,7 +83,7 @@ class CustomFieldValue extends Model
         $dataType = $fieldType->dataType;
 
         return match ($dataType) {
-            FieldDataType::STRING => 'string_value',
+            FieldDataType::STRING, FieldDataType::FILE => 'string_value',
             FieldDataType::TEXT => 'text_value',
             FieldDataType::NUMERIC, FieldDataType::SINGLE_CHOICE => 'integer_value',
             FieldDataType::FLOAT => 'float_value',

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Services;
 
 use Relaticle\CustomFields\Data\ValidationRuleData;
+use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Enums\ValidationRule;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
@@ -97,6 +99,13 @@ final class ValidationService
      */
     public function getDatabaseValidationRules(string $fieldType, bool $isEncrypted = false): array
     {
+        // File types validate the uploaded file, not the stored path
+        $fieldTypeData = CustomFieldsType::getFieldType($fieldType);
+
+        if ($fieldTypeData?->dataType === FieldDataType::FILE) {
+            return [];
+        }
+
         // Determine the database column for this field type
         $columnName = CustomFieldValue::getValueColumn($fieldType);
 
@@ -201,6 +210,13 @@ final class ValidationService
 
         // Add user rules (can override or supplement defaults)
         $mergedRules = $this->combineRules($mergedRules, $userRules);
+
+        // File types validate the uploaded file, not the stored path — skip DB constraints
+        $fieldTypeData = CustomFieldsType::getFieldType($fieldType);
+
+        if ($fieldTypeData?->dataType === FieldDataType::FILE) {
+            return $mergedRules;
+        }
 
         // Apply database constraint rules using existing logic
         $columnName = CustomFieldValue::getValueColumn($fieldType);

--- a/tests/Feature/Integration/FileUploadValidationTest.php
+++ b/tests/Feature/Integration/FileUploadValidationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\FieldDataType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldTypeConfigurator;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Models\CustomFieldValue;
+use Relaticle\CustomFields\Services\ValidationService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    config()->set('custom-fields.field_type_configuration', FieldTypeConfigurator::configure()
+        ->enabled([])
+        ->disabled([])
+        ->discover(true)
+        ->cache(enabled: false));
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create();
+});
+
+it('resolves FILE data type to string_value column', function (): void {
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'document',
+        'type' => 'file-upload',
+    ]);
+
+    $column = CustomFieldValue::getValueColumn($field->type);
+
+    expect($column)->toBe('string_value');
+});
+
+it('does not apply string database constraints to file upload fields', function (): void {
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'attachment',
+        'type' => 'file-upload',
+    ]);
+
+    $service = app(ValidationService::class);
+    $rules = $service->getValidationRules($field);
+
+    expect($rules)
+        ->toContain('file')
+        ->not->toContain('string')
+        ->not->toContain('max:255');
+});
+
+it('returns empty database validation rules for file types', function (): void {
+    $service = app(ValidationService::class);
+    $dbRules = $service->getDatabaseValidationRules('file-upload');
+
+    expect($dbRules)->toBe([]);
+});
+
+it('has FILE case in FieldDataType enum', function (): void {
+    $file = FieldDataType::FILE;
+
+    expect($file->value)->toBe('file')
+        ->and($file->isChoiceField())->toBeFalse()
+        ->and($file->isMultiChoiceField())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Backport of #100 to 2.x.

- Adds `FieldDataType::FILE` enum case with `FieldSchema::file()` factory method
- FILE maps to `string_value` for storage but skips database column constraints in validation
- Fixes file upload fields rejecting files >255 KB due to `string_value` column's `max:255` being interpreted as kilobytes when combined with the `file` validation rule

## Test plan

- [x] New `FileUploadValidationTest` with 4 tests
- [x] No test regressions (pre-existing 2.x failures unchanged)