### PR TITLE
fix: visibility crash on withoutUserOptions fields + operator overrides

### DIFF
--- a/src/Data/FieldTypeData.php
+++ b/src/Data/FieldTypeData.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Data;
 
 use Closure;
 use Relaticle\CustomFields\Enums\FieldDataType;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Spatie\LaravelData\Data;
 use Stringable;
 
@@ -30,7 +31,27 @@ final class FieldTypeData extends Data implements Stringable
         public array $validationRules = [],
         public ?string $settingsDataClass = null,
         public string|Closure|null $settingsSchema = null,
+        /** @var array<int, VisibilityOperator>|null */
+        public ?array $visibilityOperators = null,
     ) {}
+
+    /**
+     * @return array<int, VisibilityOperator>
+     */
+    public function getCompatibleOperators(): array
+    {
+        return $this->visibilityOperators ?? $this->dataType->getCompatibleOperators();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getCompatibleOperatorOptions(): array
+    {
+        return collect($this->getCompatibleOperators())
+            ->mapWithKeys(fn (VisibilityOperator $operator): array => [$operator->value => $operator->getLabel()])
+            ->toArray();
+    }
 
     public function __toString(): string
     {

--- a/src/Enums/VisibilityOperator.php
+++ b/src/Enums/VisibilityOperator.php
@@ -176,6 +176,6 @@ enum VisibilityOperator: string
         // For string field types, use the new field type system
         $fieldTypeData = CustomFieldsType::getFieldType($fieldType);
 
-        return $fieldTypeData->dataType->getCompatibleOperatorOptions();
+        return $fieldTypeData->getCompatibleOperatorOptions();
     }
 }

--- a/src/FieldTypeSystem/FieldSchema.php
+++ b/src/FieldTypeSystem/FieldSchema.php
@@ -55,6 +55,9 @@ class FieldSchema
 
     protected bool $withoutUserOptions = false;
 
+    /** @var array<int, \Relaticle\CustomFields\Enums\VisibilityOperator>|null */
+    private ?array $visibilityOperators = null;
+
     private ?string $settingsDataClass = null;
 
     private string|Closure|null $settingsSchema = null;
@@ -362,6 +365,18 @@ class FieldSchema
         return $this;
     }
 
+    /**
+     * Override the default visibility operators derived from the data type.
+     *
+     * @param  array<int, \Relaticle\CustomFields\Enums\VisibilityOperator>  $operators
+     */
+    public function visibilityOperators(array $operators): self
+    {
+        $this->visibilityOperators = $operators;
+
+        return $this;
+    }
+
     // ========== Export Configuration ==========
 
     /**
@@ -554,7 +569,8 @@ class FieldSchema
             acceptsArbitraryValues: $this->acceptsArbitraryValues,
             validationRules: $this->availableValidationRules,
             settingsDataClass: $this->settingsDataClass,
-            settingsSchema: $this->settingsSchema
+            settingsSchema: $this->settingsSchema,
+            visibilityOperators: $this->visibilityOperators
         );
     }
 }

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -322,7 +322,7 @@ final class VisibilityComponent extends Component
         $fieldData = $this->getFieldTypeData($get);
 
         return $fieldData
-            ? $fieldData->dataType->getCompatibleOperatorOptions()
+            ? $fieldData->getCompatibleOperatorOptions()
             : VisibilityOperator::options();
     }
 

--- a/src/Services/Visibility/BackendVisibilityService.php
+++ b/src/Services/Visibility/BackendVisibilityService.php
@@ -166,7 +166,8 @@ final readonly class BackendVisibilityService
         if (
             $value === null ||
             $value === '' ||
-            ! $field->isChoiceField()
+            ! $field->isChoiceField() ||
+            $field->typeData->withoutUserOptions
         ) {
             return $value;
         }

--- a/src/Services/Visibility/CoreVisibilityLogicService.php
+++ b/src/Services/Visibility/CoreVisibilityLogicService.php
@@ -201,7 +201,7 @@ final readonly class CoreVisibilityLogicService
             return false;
         }
 
-        $compatibleOperators = $typeData->dataType->getCompatibleOperators();
+        $compatibleOperators = $typeData->getCompatibleOperators();
 
         return in_array($operator, $compatibleOperators, true);
     }
@@ -239,7 +239,7 @@ final readonly class CoreVisibilityLogicService
             'category' => $typeData->dataType->value,
             'is_optionable' => $typeData->dataType->isChoiceField(),
             'has_multiple_values' => $typeData->dataType->isMultiChoiceField(),
-            'compatible_operators' => $typeData->dataType->getCompatibleOperators(),
+            'compatible_operators' => $typeData->getCompatibleOperators(),
             'has_visibility_conditions' => $this->hasVisibilityConditions($field),
             'visibility_mode' => $this->getVisibilityMode($field)->value,
             'visibility_logic' => $this->getVisibilityLogic($field)->value,

--- a/tests/Feature/UnifiedVisibilityConsistencyTest.php
+++ b/tests/Feature/UnifiedVisibilityConsistencyTest.php
@@ -6,11 +6,15 @@ use Relaticle\CustomFields\Data\VisibilityData;
 use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 
 beforeEach(function (): void {
@@ -318,3 +322,84 @@ test('empty and null value handling is consistent', function (): void {
     $jsExpression = $this->frontendService->buildVisibilityExpression($this->conditionalField, $fields);
     expect($jsExpression)->toBeString(); // Should generate valid expression even with null comparison
 });
+
+test('withoutUserOptions multi-choice fields do not crash during value extraction', function (): void {
+    CustomFieldsType::register([
+        'test-repeater' => TestRepeaterFieldType::class,
+    ]);
+
+    $section = CustomFieldSection::factory()->create([
+        'name' => 'Repeater Section',
+        'entity_type' => Post::class,
+        'active' => true,
+    ]);
+
+    $repeaterField = CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Repeater',
+        'code' => 'repeater',
+        'type' => 'test-repeater',
+        'active' => true,
+    ]);
+
+    $post = Post::factory()->create();
+    $post->saveCustomFieldValue($repeaterField, [
+        ['value' => 'item 1'],
+        ['value' => 'item 2'],
+    ]);
+    $post->load('customFieldValues.customField');
+
+    $backendService = app(BackendVisibilityService::class);
+
+    $result = $backendService->extractFieldValues($post, collect([$repeaterField]));
+
+    expect($result)
+        ->toHaveKey('repeater')
+        ->and($result['repeater'])->toBe([
+            ['value' => 'item 1'],
+            ['value' => 'item 2'],
+        ]);
+
+    $visibleFields = $backendService->getVisibleFields($post, collect([$repeaterField]));
+
+    expect($visibleFields)->toHaveCount(1);
+});
+
+test('field types can override compatible visibility operators', function (): void {
+    CustomFieldsType::register([
+        'test-repeater' => TestRepeaterFieldType::class,
+    ]);
+
+    $fieldTypeData = CustomFieldsType::getFieldType('test-repeater');
+
+    expect($fieldTypeData->getCompatibleOperators())->toBe([
+        VisibilityOperator::IS_EMPTY,
+        VisibilityOperator::IS_NOT_EMPTY,
+    ]);
+});
+
+test('field types without operator override use dataType defaults', function (): void {
+    $fieldTypeData = CustomFieldsType::getFieldType('select');
+
+    expect($fieldTypeData->getCompatibleOperators())
+        ->toBe($fieldTypeData->dataType->getCompatibleOperators());
+});
+
+class TestRepeaterFieldType extends BaseFieldType
+{
+    public function configure(): FieldSchema
+    {
+        return FieldSchema::multiChoice()
+            ->key('test-repeater')
+            ->label('Test Repeater')
+            ->icon('heroicon-o-squares-plus')
+            ->searchable(false)
+            ->sortable(false)
+            ->filterable(false)
+            ->withoutUserOptions()
+            ->visibilityOperators([
+                VisibilityOperator::IS_EMPTY,
+                VisibilityOperator::IS_NOT_EMPTY,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
Cherry-pick of #102 for 2.x branch.

- Fixes `array_key_exists(): Argument #1 ($key) must be a valid array offset type` crash when rendering infolists for models with repeater-type custom fields
- Adds `visibilityOperators()` to `FieldSchema`/`FieldTypeData` so field types can declare their own compatible visibility operators instead of inheriting from `FieldDataType`
- Routes all operator resolution through `FieldTypeData::getCompatibleOperators()` (4 call sites) to respect overrides

## Root cause
`BackendVisibilityService::normalizeValueForEvaluation()` assumed all `MULTI_CHOICE` fields store scalar option IDs. Fields with `withoutUserOptions` (like repeater) store complex nested arrays — passing those to `Collection::get()` crashes `array_key_exists()` in PHP 8.4.

## Test plan
- [x] Added test: withoutUserOptions multi-choice fields don't crash during value extraction
- [x] Added test: field types can override compatible visibility operators
- [x] Added test: field types without override use dataType defaults
- [x] All existing visibility tests pass (10/10)