### PR TITLE
fix: integrate exportTransformer in ExporterBuilder

### DIFF
--- a/src/Filament/Integration/Builders/ExporterBuilder.php
+++ b/src/Filament/Integration/Builders/ExporterBuilder.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\CircularDependencyException;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Contracts\ValueResolvers;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Filament\Integration\Factories\ExportColumnFactory;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
@@ -41,14 +42,19 @@ final class ExporterBuilder extends BaseBuilder
                         return null; // Don't export values for hidden fields
                     }
 
-                    // Get the value resolver and resolve the value
                     $valueResolver = app(ValueResolvers::class);
 
-                    return $valueResolver->resolve(
+                    $value = $valueResolver->resolve(
                         record: $record,
                         customField: $field,
                         exportable: true
                     );
+
+                    $transformer = CustomFieldsType::getFieldTypeInstance($field->typeData->key)
+                        ?->configure()
+                        ->getExportTransformer();
+
+                    return $transformer ? $transformer($value) : $value;
                 });
             })
             ->values();


### PR DESCRIPTION
## Summary

- Wire up `exportTransformer` in `ExporterBuilder`, matching how `importTransformer` is already integrated in `ImportColumnConfigurator`
- Field types that define an `exportTransformer` (e.g. repeater fields that need to JSON-encode nested arrays) now have their transformer applied during export
- Previously, `exportTransformer` / `getExportTransformer()` existed on `FieldSchema` but was never called — dead code

## Changes

`ExporterBuilder::columns()` now resolves the field type's `exportTransformer` and applies it to the resolved value before returning it to the export column.

## Test plan

- Export a model with a repeater custom field — values should appear as JSON-encoded strings in CSV
- Export a model with standard custom fields — behavior unchanged (transformer is null, raw value returned)