### PR TITLE
fix: allow $guarded usage with UsesCustomFields trait [1.x]

### DIFF
--- a/src/Models/Concerns/UsesCustomFields.php
+++ b/src/Models/Concerns/UsesCustomFields.php
@@ -23,8 +23,10 @@ trait UsesCustomFields
 {
     public function __construct($attributes = [])
     {
-        // Ensure custom fields are included in a fillable array
-        $this->fillable = array_merge(['custom_fields'], $this->fillable);
+        if (count($this->getFillable()) !== 0) {
+            $this->mergeFillable(['custom_fields']);
+        }
+
         parent::__construct($attributes);
     }
 

--- a/tests/Feature/Models/UsesCustomFieldsTest.php
+++ b/tests/Feature/Models/UsesCustomFieldsTest.php
@@ -43,6 +43,25 @@ it('returns empty value when custom field has no value', function () {
     expect($value)->toBeNull();
 });
 
+it('does not override guarded when model uses guarded instead of fillable', function () {
+    $model = new GuardedTestModel;
+
+    expect($model->getFillable())->toBe([])
+        ->and($model->getGuarded())->toBe(['id']);
+});
+
+class GuardedTestModel extends Model
+{
+    use UsesCustomFields;
+
+    protected $guarded = ['id'];
+
+    public function getMorphClass()
+    {
+        return 'guarded_test_model';
+    }
+}
+
 class TestModel extends Model
 {
     use UsesCustomFields;


### PR DESCRIPTION
## Summary

- Only merge `custom_fields` into `$fillable` when the model explicitly defines fillable properties
- This prevents the trait from overriding `$guarded` on models that rely on it instead of `$fillable`
- Backport of the fix already present in 3.x

Closes #109

## Test plan

- [ ] Apply trait to a model using `$guarded` instead of `$fillable`
- [ ] Verify mass assignment protection still works as expected
- [ ] Verify custom fields still work on models using `$fillable`