### PR TITLE
fix: handle pre-existing releases and protected branch pushes in CI [2.x]

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update:
@@ -34,9 +35,12 @@ jobs:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
         with:
-          branch: ${{ steps.branch.outputs.name }}
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+          branch: chore/changelog-${{ github.event.release.tag_name }}
+          base: ${{ steps.branch.outputs.name }}
+          title: "chore: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          commit-message: "chore: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          body: "Auto-generated CHANGELOG update for release ${{ github.event.release.tag_name }}."
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,19 @@ jobs:
             echo "flag=" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check if release exists
+        id: check
+        run: |
+          if gh release view "${{ github.ref_name }}" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
         run: gh release create "${{ github.ref_name }}" --generate-notes ${{ steps.prerelease.outputs.flag }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- **release.yml**: Skip `gh release create` if the release already exists (prevents HTTP 422 when release is created manually before CI runs)
- **changelog.yml**: Use `peter-evans/create-pull-request` instead of `git-auto-commit-action` to work with protected branches that require PRs

## Context

Both failures happened during the 2.3.6 release:
1. Release workflow failed because the GitHub release was already created manually
2. Changelog workflow failed because 2.x is a protected branch that rejects direct pushes