### PR TITLE
fix: use deploy key for changelog direct push [3.x]

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update:
@@ -28,6 +27,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.branch.outputs.name }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -35,12 +35,9 @@ jobs:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: chore/changelog-${{ github.event.release.tag_name }}
-          base: ${{ steps.branch.outputs.name }}
-          title: "chore: update CHANGELOG for ${{ github.event.release.tag_name }}"
-          commit-message: "chore: update CHANGELOG for ${{ github.event.release.tag_name }}"
-          body: "Auto-generated CHANGELOG update for release ${{ github.event.release.tag_name }}."
-          delete-branch: true
+          branch: ${{ steps.branch.outputs.name }}
+          commit_message: "chore: update CHANGELOG for ${{ github.event.release.tag_name }}"
+          file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Summary

- Switches changelog workflow from `peter-evans/create-pull-request` to direct push using deploy key
- The deploy key is added to the repo's ruleset bypass list, allowing CI to push directly to protected branches
- No more orphaned changelog PRs that need manual merge

## How it works

1. `actions/checkout` uses `ssh-key: ${{ secrets.DEPLOY_KEY }}`
2. `git-auto-commit-action` pushes the CHANGELOG update directly to the release branch
3. The deploy key bypasses the ruleset's PR requirement