### PR TITLE
fix: remove blade-capture-directive from test providers [3.x]

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,7 +33,6 @@ use Relaticle\CustomFields\Tests\database\factories\UserFactory;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 use Relaticle\CustomFields\Tests\Fixtures\Providers\AdminPanelProvider;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Spatie\LaravelData\LaravelDataServiceProvider;
 
 class TestCase extends BaseTestCase
@@ -65,7 +64,6 @@ class TestCase extends BaseTestCase
     {
         $providers = [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             BladeMdiServiceProvider::class,


### PR DESCRIPTION
## Summary

Remove `BladeCaptureDirectiveServiceProvider` from `tests/TestCase.php`.

## Root Cause

Filament v5.4.0 dropped `ryangjchandler/blade-capture-directive` as a dependency. The CI workflow runs `composer update --prefer-stable` which resolved Filament to v5.4.0, causing the package to be removed. Since `TestCase.php` explicitly registers the provider, all 459 tests fail with `Class not found`.

## Result

- Before: 459 tests failed (0 assertions)
- After: 449 passed, 7 failed (unrelated Filament v5.4.0 `$logo` Blade variable issue)