### PR TITLE
fix: remove blade-capture-directive from test providers [2.x]

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,6 @@ use Relaticle\CustomFields\Tests\database\factories\UserFactory;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 use Relaticle\CustomFields\Tests\Fixtures\Providers\AdminPanelProvider;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Spatie\LaravelData\LaravelDataServiceProvider;
 
 class TestCase extends BaseTestCase
@@ -64,7 +63,6 @@ class TestCase extends BaseTestCase
     {
         $providers = [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             BladeMdiServiceProvider::class,


### PR DESCRIPTION
## Summary

Remove `BladeCaptureDirectiveServiceProvider` from `tests/TestCase.php`.

## Root Cause

Filament dropped `ryangjchandler/blade-capture-directive` as a dependency. The CI workflow runs `composer update --prefer-stable` which resolves to a Filament version without this package. Since `TestCase.php` explicitly registers the provider, all tests fail with `Class not found`.