### PR TITLE
feat: currency field display consistency and constraint improvements

### DIFF
--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -87,6 +87,18 @@ return [
     | Configure database table names and migration paths.
     |
     */
+    /*
+    |--------------------------------------------------------------------------
+    | Currency Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Default currency settings for currency field types.
+    |
+    */
+    'currency' => [
+        'default_code' => env('CUSTOM_FIELDS_DEFAULT_CURRENCY', 'USD'),
+    ],
+
     'database' => [
         'migrations_path' => database_path('custom-fields'),
         'table_names' => [

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -97,6 +97,10 @@ return [
     */
     'currency' => [
         'default_code' => env('CUSTOM_FIELDS_DEFAULT_CURRENCY', 'USD'),
+
+        // Override the currency list (null = auto-detect from PHP intl/ICU).
+        // Format: ['USD' => 'US Dollar', 'EUR' => 'Euro', ...]
+        'currencies' => null,
     ],
 
     'database' => [

--- a/src/Data/CustomFieldOptionSettingsData.php
+++ b/src/Data/CustomFieldOptionSettingsData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Relaticle\CustomFields\Data;
 
 use Spatie\LaravelData\Attributes\MapName;

--- a/src/Data/Settings/CurrencyFieldSettingsData.php
+++ b/src/Data/Settings/CurrencyFieldSettingsData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Data\Settings;
 
+use Relaticle\CustomFields\Support\CurrencyProvider;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
@@ -19,10 +20,12 @@ class CurrencyFieldSettingsData extends Data
 
     public static function fromAdditional(array $additional): self
     {
+        $code = $additional['currency_code'] ?? 'USD';
+
         return new self(
-            currencyCode: $additional['currency_code'] ?? 'USD',
+            currencyCode: $code,
             displayType: $additional['display_type'] ?? 'symbol',
-            decimalPlaces: (int) ($additional['decimal_places'] ?? 2),
+            decimalPlaces: (int) ($additional['decimal_places'] ?? CurrencyProvider::getDecimalDigits($code)),
         );
     }
 }

--- a/src/Data/Settings/CurrencyFieldSettingsData.php
+++ b/src/Data/Settings/CurrencyFieldSettingsData.php
@@ -4,14 +4,25 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Data\Settings;
 
+use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
+use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 
+#[MapName(SnakeCaseMapper::class)]
 class CurrencyFieldSettingsData extends Data
 {
     public function __construct(
-        public string $currency_code = 'USD',
-        public string $display_type = 'symbol',
-        public int $decimal_places = 2,
-        public string $grouping = 'default',
+        public string $currencyCode = 'USD',
+        public string $displayType = 'symbol',
+        public int $decimalPlaces = 2,
     ) {}
+
+    public static function fromAdditional(array $additional): self
+    {
+        return new self(
+            currencyCode: $additional['currency_code'] ?? 'USD',
+            displayType: $additional['display_type'] ?? 'symbol',
+            decimalPlaces: (int) ($additional['decimal_places'] ?? 2),
+        );
+    }
 }

--- a/src/Data/Settings/CurrencyFieldSettingsData.php
+++ b/src/Data/Settings/CurrencyFieldSettingsData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Data\Settings;
+
+use Spatie\LaravelData\Data;
+
+class CurrencyFieldSettingsData extends Data
+{
+    public function __construct(
+        public string $currency_code = 'USD',
+        public string $display_type = 'symbol',
+        public int $decimal_places = 2,
+        public string $grouping = 'default',
+    ) {}
+}

--- a/src/Exceptions/CustomFieldAlreadyExistsException.php
+++ b/src/Exceptions/CustomFieldAlreadyExistsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Relaticle\CustomFields\Exceptions;
 
 use Exception;

--- a/src/Exceptions/FieldTypeNotOptionableException.php
+++ b/src/Exceptions/FieldTypeNotOptionableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Relaticle\CustomFields\Exceptions;
 
 use Exception;

--- a/src/Exceptions/MissingRecordTitleAttributeException.php
+++ b/src/Exceptions/MissingRecordTitleAttributeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Relaticle\CustomFields\Exceptions;
 
 use Exception;

--- a/src/Facades/CustomFields.php
+++ b/src/Facades/CustomFields.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Relaticle\CustomFields\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -15,6 +15,7 @@ use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
+use Relaticle\CustomFields\Support\CurrencyProvider;
 use Relaticle\CustomFields\Validation\Capabilities\MaxValueCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MinValueCapability;
 
@@ -74,7 +75,7 @@ class CurrencyFieldType extends BaseFieldType
                     Select::make('settings.additional.currency_code')
                         ->label('Currency')
                         ->searchable()
-                        ->options(fn (): array => $this->getCurrencyOptions())
+                        ->options(fn (): array => CurrencyProvider::getOptions())
                         ->afterStateHydrated(function (Select $component, mixed $state) use ($defaultCode): void {
                             if (blank($state)) {
                                 $component->state($defaultCode);
@@ -98,6 +99,7 @@ class CurrencyFieldType extends BaseFieldType
 
                     Select::make('settings.additional.decimal_places')
                         ->label('Decimal Places')
+                        ->helperText('Auto-detected from currency. Override only if needed.')
                         ->options(function (Get $get): array {
                             $code = $get('settings.additional.currency_code') ?? 'USD';
 
@@ -114,87 +116,19 @@ class CurrencyFieldType extends BaseFieldType
 
                             return $options;
                         })
-                        ->afterStateHydrated(function (Select $component, mixed $state): void {
-                            $component->state($state === null ? '2' : (string) $state);
+                        ->afterStateHydrated(function (Select $component, mixed $state, Get $get): void {
+                            if ($state !== null) {
+                                $component->state((string) $state);
+
+                                return;
+                            }
+
+                            $code = $get('settings.additional.currency_code') ?? 'USD';
+                            $component->state((string) CurrencyProvider::getDecimalDigits($code));
                         })
                         ->required(),
 
                 ]),
         ];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getCurrencyOptions(): array
-    {
-        static $options = null;
-
-        if ($options !== null) {
-            return $options;
-        }
-
-        $currencies = [
-            'USD' => 'US Dollar',
-            'EUR' => 'Euro',
-            'GBP' => 'British Pound',
-            'JPY' => 'Japanese Yen',
-            'CHF' => 'Swiss Franc',
-            'CAD' => 'Canadian Dollar',
-            'AUD' => 'Australian Dollar',
-            'NZD' => 'New Zealand Dollar',
-            'CNY' => 'Chinese Yuan',
-            'HKD' => 'Hong Kong Dollar',
-            'SGD' => 'Singapore Dollar',
-            'SEK' => 'Swedish Krona',
-            'NOK' => 'Norwegian Krone',
-            'DKK' => 'Danish Krone',
-            'KRW' => 'South Korean Won',
-            'INR' => 'Indian Rupee',
-            'BRL' => 'Brazilian Real',
-            'MXN' => 'Mexican Peso',
-            'ZAR' => 'South African Rand',
-            'TRY' => 'Turkish Lira',
-            'RUB' => 'Russian Ruble',
-            'PLN' => 'Polish Zloty',
-            'THB' => 'Thai Baht',
-            'IDR' => 'Indonesian Rupiah',
-            'MYR' => 'Malaysian Ringgit',
-            'PHP' => 'Philippine Peso',
-            'CZK' => 'Czech Koruna',
-            'HUF' => 'Hungarian Forint',
-            'ILS' => 'Israeli Shekel',
-            'CLP' => 'Chilean Peso',
-            'ARS' => 'Argentine Peso',
-            'COP' => 'Colombian Peso',
-            'PEN' => 'Peruvian Sol',
-            'AED' => 'UAE Dirham',
-            'SAR' => 'Saudi Riyal',
-            'QAR' => 'Qatari Riyal',
-            'KWD' => 'Kuwaiti Dinar',
-            'BHD' => 'Bahraini Dinar',
-            'OMR' => 'Omani Rial',
-            'EGP' => 'Egyptian Pound',
-            'NGN' => 'Nigerian Naira',
-            'KES' => 'Kenyan Shilling',
-            'GHS' => 'Ghanaian Cedi',
-            'TWD' => 'Taiwan Dollar',
-            'VND' => 'Vietnamese Dong',
-            'BGN' => 'Bulgarian Lev',
-            'RON' => 'Romanian Leu',
-            'ISK' => 'Icelandic Krona',
-            'UAH' => 'Ukrainian Hryvnia',
-            'PKR' => 'Pakistani Rupee',
-            'BDT' => 'Bangladeshi Taka',
-            'LKR' => 'Sri Lankan Rupee',
-        ];
-
-        $options = [];
-
-        foreach ($currencies as $code => $name) {
-            $options[$code] = sprintf('%s (%s)', $name, $code);
-        }
-
-        return $options;
     }
 }

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -74,7 +74,7 @@ class CurrencyFieldType extends BaseFieldType
                     Select::make('settings.additional.currency_code')
                         ->label('Currency')
                         ->searchable()
-                        ->options(fn (): array => self::getCurrencyOptions())
+                        ->options(fn (): array => $this->getCurrencyOptions())
                         ->afterStateHydrated(function (Select $component, mixed $state) use ($defaultCode): void {
                             if (blank($state)) {
                                 $component->state($defaultCode);
@@ -107,11 +107,12 @@ class CurrencyFieldType extends BaseFieldType
 
                             $formatterNoDecimals = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
                             $formatterNoDecimals->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+
                             $sampleNoDecimals = $formatterNoDecimals->formatCurrency(1200, $code) ?: '1,200';
 
                             return [
-                                '2' => "2 decimals ({$sample})",
-                                '0' => "No decimals ({$sampleNoDecimals})",
+                                '2' => sprintf('2 decimals (%s)', $sample),
+                                '0' => sprintf('No decimals (%s)', $sampleNoDecimals),
                             ];
                         })
                         ->afterStateHydrated(function (Select $component, mixed $state): void {
@@ -138,7 +139,7 @@ class CurrencyFieldType extends BaseFieldType
     /**
      * @return array<string, string>
      */
-    private static function getCurrencyOptions(): array
+    private function getCurrencyOptions(): array
     {
         static $options = null;
 
@@ -205,7 +206,7 @@ class CurrencyFieldType extends BaseFieldType
         $options = [];
 
         foreach ($currencies as $code => $name) {
-            $options[$code] = "{$name} ({$code})";
+            $options[$code] = sprintf('%s (%s)', $name, $code);
         }
 
         return $options;

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -64,6 +64,8 @@ class CurrencyFieldType extends BaseFieldType
      */
     private function settingsSchema(): array
     {
+        $defaultCode = config('custom-fields.currency.default_code', 'USD');
+
         return [
             Fieldset::make('Currency Settings')
                 ->columnSpanFull()
@@ -73,7 +75,11 @@ class CurrencyFieldType extends BaseFieldType
                         ->label('Currency')
                         ->searchable()
                         ->options(fn (): array => self::getCurrencyOptions())
-                        ->default(config('custom-fields.currency.default_code', 'USD'))
+                        ->afterStateHydrated(function (Select $component, mixed $state) use ($defaultCode): void {
+                            if (blank($state)) {
+                                $component->state($defaultCode);
+                            }
+                        })
                         ->required()
                         ->live(),
 
@@ -85,7 +91,11 @@ class CurrencyFieldType extends BaseFieldType
                             'code' => 'Code (USD 1,200.50)',
                             'name' => 'Name (1,200.50 US dollars)',
                         ])
-                        ->default('symbol')
+                        ->afterStateHydrated(function (Select $component, mixed $state): void {
+                            if (blank($state)) {
+                                $component->state('symbol');
+                            }
+                        })
                         ->required(),
 
                     Select::make('settings.additional.decimal_places')
@@ -100,11 +110,13 @@ class CurrencyFieldType extends BaseFieldType
                             $sampleNoDecimals = $formatterNoDecimals->formatCurrency(1200, $code) ?: '1,200';
 
                             return [
-                                2 => "2 decimals ({$sample})",
-                                0 => "No decimals ({$sampleNoDecimals})",
+                                '2' => "2 decimals ({$sample})",
+                                '0' => "No decimals ({$sampleNoDecimals})",
                             ];
                         })
-                        ->default(2)
+                        ->afterStateHydrated(function (Select $component, mixed $state): void {
+                            $component->state($state === null ? '2' : (string) $state);
+                        })
                         ->required(),
 
                     Select::make('settings.additional.grouping')
@@ -113,7 +125,11 @@ class CurrencyFieldType extends BaseFieldType
                             'default' => 'Default (1,200.50)',
                             'none' => 'None (1200.50)',
                         ])
-                        ->default('default')
+                        ->afterStateHydrated(function (Select $component, mixed $state): void {
+                            if (blank($state)) {
+                                $component->state('default');
+                            }
+                        })
                         ->required(),
                 ]),
         ];

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\FieldTypeSystem\Definitions;
 
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Utilities\Get;
+use NumberFormatter;
+use Relaticle\CustomFields\Data\Settings\CurrencyFieldSettingsData;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
-use Relaticle\CustomFields\Validation\Capabilities\DecimalPlacesCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MaxValueCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MinValueCapability;
 
-/**
- * ABOUTME: Field type definition for Currency fields
- * ABOUTME: Provides Currency functionality with appropriate validation rules
- */
 class CurrencyFieldType extends BaseFieldType
 {
     public function configure(): FieldSchema
@@ -32,7 +33,10 @@ class CurrencyFieldType extends BaseFieldType
             ->withValidationCapabilities(
                 MinValueCapability::class,
                 MaxValueCapability::class,
-                DecimalPlacesCapability::class,
+            )
+            ->withSettings(
+                CurrencyFieldSettingsData::class,
+                fn (): array => $this->settingsSchema(),
             )
             ->importExample('99.99')
             ->importTransformer(function (mixed $state): ?float {
@@ -53,5 +57,141 @@ class CurrencyFieldType extends BaseFieldType
 
                 return number_format((float) $value, 2, '.', '');
             });
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    private function settingsSchema(): array
+    {
+        return [
+            Fieldset::make('Currency Settings')
+                ->columnSpanFull()
+                ->columns(2)
+                ->schema([
+                    Select::make('settings.additional.currency_code')
+                        ->label('Currency')
+                        ->searchable()
+                        ->options(fn (): array => self::getCurrencyOptions())
+                        ->default(config('custom-fields.currency.default_code', 'USD'))
+                        ->required()
+                        ->live(),
+
+                    Select::make('settings.additional.display_type')
+                        ->label('Display')
+                        ->options([
+                            'symbol' => 'Symbol ($1,200.50)',
+                            'narrow_symbol' => 'Narrow Symbol ($1,200.50)',
+                            'code' => 'Code (USD 1,200.50)',
+                            'name' => 'Name (1,200.50 US dollars)',
+                        ])
+                        ->default('symbol')
+                        ->required(),
+
+                    Select::make('settings.additional.decimal_places')
+                        ->label('Decimal Places')
+                        ->options(function (Get $get): array {
+                            $code = $get('settings.additional.currency_code') ?? 'USD';
+                            $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+                            $sample = $formatter->formatCurrency(1200.50, $code) ?: '1,200.50';
+
+                            $formatterNoDecimals = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+                            $formatterNoDecimals->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+                            $sampleNoDecimals = $formatterNoDecimals->formatCurrency(1200, $code) ?: '1,200';
+
+                            return [
+                                2 => "2 decimals ({$sample})",
+                                0 => "No decimals ({$sampleNoDecimals})",
+                            ];
+                        })
+                        ->default(2)
+                        ->required(),
+
+                    Select::make('settings.additional.grouping')
+                        ->label('Grouping')
+                        ->options([
+                            'default' => 'Default (1,200.50)',
+                            'none' => 'None (1200.50)',
+                        ])
+                        ->default('default')
+                        ->required(),
+                ]),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function getCurrencyOptions(): array
+    {
+        static $options = null;
+
+        if ($options !== null) {
+            return $options;
+        }
+
+        $currencies = [
+            'USD' => 'US Dollar',
+            'EUR' => 'Euro',
+            'GBP' => 'British Pound',
+            'JPY' => 'Japanese Yen',
+            'CHF' => 'Swiss Franc',
+            'CAD' => 'Canadian Dollar',
+            'AUD' => 'Australian Dollar',
+            'NZD' => 'New Zealand Dollar',
+            'CNY' => 'Chinese Yuan',
+            'HKD' => 'Hong Kong Dollar',
+            'SGD' => 'Singapore Dollar',
+            'SEK' => 'Swedish Krona',
+            'NOK' => 'Norwegian Krone',
+            'DKK' => 'Danish Krone',
+            'KRW' => 'South Korean Won',
+            'INR' => 'Indian Rupee',
+            'BRL' => 'Brazilian Real',
+            'MXN' => 'Mexican Peso',
+            'ZAR' => 'South African Rand',
+            'TRY' => 'Turkish Lira',
+            'RUB' => 'Russian Ruble',
+            'PLN' => 'Polish Zloty',
+            'THB' => 'Thai Baht',
+            'IDR' => 'Indonesian Rupiah',
+            'MYR' => 'Malaysian Ringgit',
+            'PHP' => 'Philippine Peso',
+            'CZK' => 'Czech Koruna',
+            'HUF' => 'Hungarian Forint',
+            'ILS' => 'Israeli Shekel',
+            'CLP' => 'Chilean Peso',
+            'ARS' => 'Argentine Peso',
+            'COP' => 'Colombian Peso',
+            'PEN' => 'Peruvian Sol',
+            'AED' => 'UAE Dirham',
+            'SAR' => 'Saudi Riyal',
+            'QAR' => 'Qatari Riyal',
+            'KWD' => 'Kuwaiti Dinar',
+            'BHD' => 'Bahraini Dinar',
+            'OMR' => 'Omani Rial',
+            'EGP' => 'Egyptian Pound',
+            'NGN' => 'Nigerian Naira',
+            'KES' => 'Kenyan Shilling',
+            'GHS' => 'Ghanaian Cedi',
+            'TWD' => 'Taiwan Dollar',
+            'VND' => 'Vietnamese Dong',
+            'BGN' => 'Bulgarian Lev',
+            'RON' => 'Romanian Leu',
+            'HRK' => 'Croatian Kuna',
+            'ISK' => 'Icelandic Krona',
+            'UAH' => 'Ukrainian Hryvnia',
+            'PKR' => 'Pakistani Rupee',
+            'BDT' => 'Bangladeshi Taka',
+            'LKR' => 'Sri Lankan Rupee',
+        ];
+
+        $options = [];
+
+        foreach ($currencies as $code => $name) {
+            $options[$code] = "{$name} ({$code})";
+        }
+
+        return $options;
     }
 }

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -7,8 +7,8 @@ namespace Relaticle\CustomFields\FieldTypeSystem\Definitions;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
-use Relaticle\CustomFields\Filament\Integration\Components\Infolists\TextEntry;
-use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\TextColumn;
+use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
+use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
 use Relaticle\CustomFields\Validation\Capabilities\DecimalPlacesCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MaxValueCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MinValueCapability;
@@ -26,8 +26,8 @@ class CurrencyFieldType extends BaseFieldType
             ->label('Currency')
             ->icon('mdi-currency-usd')
             ->formComponent(CurrencyComponent::class)
-            ->tableColumn(TextColumn::class)
-            ->infolistEntry(TextEntry::class)
+            ->tableColumn(CurrencyColumn::class)
+            ->infolistEntry(CurrencyEntry::class)
             ->priority(25)
             ->withValidationCapabilities(
                 MinValueCapability::class,
@@ -40,12 +40,18 @@ class CurrencyFieldType extends BaseFieldType
                     return null;
                 }
 
-                // Remove currency symbols and formatting chars
                 if (is_string($state)) {
                     $state = preg_replace('/[^0-9.-]/', '', $state);
                 }
 
                 return round(floatval($state), 2);
+            })
+            ->exportTransformer(function (mixed $value): ?string {
+                if ($value === null) {
+                    return null;
+                }
+
+                return number_format((float) $value, 2, '.', '');
             });
     }
 }

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -108,8 +108,8 @@ class CurrencyFieldType extends BaseFieldType
                                 $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
                                 $sample = $formatter->formatCurrency(1200.50, $code) ?: number_format(1200.50, $digits);
 
-                                $label = $digits === 0 ? 'No decimals' : "{$digits} decimals";
-                                $options[(string) $digits] = "{$label} ({$sample})";
+                                $label = $digits === 0 ? 'No decimals' : $digits . ' decimals';
+                                $options[(string) $digits] = sprintf('%s (%s)', $label, $sample);
                             }
 
                             return $options;

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -48,14 +48,14 @@ class CurrencyFieldType extends BaseFieldType
                     $state = preg_replace('/[^0-9.-]/', '', $state);
                 }
 
-                return round(floatval($state), 2);
+                return (float) $state;
             })
             ->exportTransformer(function (mixed $value): ?string {
                 if ($value === null) {
                     return null;
                 }
 
-                return number_format((float) $value, 2, '.', '');
+                return rtrim(rtrim(number_format((float) $value, 10, '.', ''), '0'), '.');
             });
     }
 
@@ -87,9 +87,7 @@ class CurrencyFieldType extends BaseFieldType
                         ->label('Display')
                         ->options([
                             'symbol' => 'Symbol ($1,200.50)',
-                            'narrow_symbol' => 'Narrow Symbol ($1,200.50)',
                             'code' => 'Code (USD 1,200.50)',
-                            'name' => 'Name (1,200.50 US dollars)',
                         ])
                         ->afterStateHydrated(function (Select $component, mixed $state): void {
                             if (blank($state)) {
@@ -102,36 +100,25 @@ class CurrencyFieldType extends BaseFieldType
                         ->label('Decimal Places')
                         ->options(function (Get $get): array {
                             $code = $get('settings.additional.currency_code') ?? 'USD';
-                            $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
-                            $sample = $formatter->formatCurrency(1200.50, $code) ?: '1,200.50';
 
-                            $formatterNoDecimals = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
-                            $formatterNoDecimals->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+                            $options = [];
 
-                            $sampleNoDecimals = $formatterNoDecimals->formatCurrency(1200, $code) ?: '1,200';
+                            foreach ([0, 2, 3] as $digits) {
+                                $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+                                $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
+                                $sample = $formatter->formatCurrency(1200.50, $code) ?: number_format(1200.50, $digits);
 
-                            return [
-                                '2' => sprintf('2 decimals (%s)', $sample),
-                                '0' => sprintf('No decimals (%s)', $sampleNoDecimals),
-                            ];
+                                $label = $digits === 0 ? 'No decimals' : "{$digits} decimals";
+                                $options[(string) $digits] = "{$label} ({$sample})";
+                            }
+
+                            return $options;
                         })
                         ->afterStateHydrated(function (Select $component, mixed $state): void {
                             $component->state($state === null ? '2' : (string) $state);
                         })
                         ->required(),
 
-                    Select::make('settings.additional.grouping')
-                        ->label('Grouping')
-                        ->options([
-                            'default' => 'Default (1,200.50)',
-                            'none' => 'None (1200.50)',
-                        ])
-                        ->afterStateHydrated(function (Select $component, mixed $state): void {
-                            if (blank($state)) {
-                                $component->state('default');
-                            }
-                        })
-                        ->required(),
                 ]),
         ];
     }
@@ -195,7 +182,6 @@ class CurrencyFieldType extends BaseFieldType
             'VND' => 'Vietnamese Dong',
             'BGN' => 'Bulgarian Lev',
             'RON' => 'Romanian Leu',
-            'HRK' => 'Croatian Kuna',
             'ISK' => 'Icelandic Krona',
             'UAH' => 'Ukrainian Hryvnia',
             'PKR' => 'Pakistani Rupee',

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -108,7 +108,7 @@ class CurrencyFieldType extends BaseFieldType
                                 $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
                                 $sample = $formatter->formatCurrency(1200.50, $code) ?: number_format(1200.50, $digits);
 
-                                $label = $digits === 0 ? 'No decimals' : $digits . ' decimals';
+                                $label = $digits === 0 ? 'No decimals' : $digits.' decimals';
                                 $options[(string) $digits] = sprintf('%s (%s)', $label, $sample);
                             }
 

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -105,10 +105,19 @@ class CurrencyFieldType extends BaseFieldType
 
                             $options = [];
 
-                            foreach ([0, 2, 3] as $digits) {
-                                $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
-                                $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
-                                $sample = $formatter->formatCurrency(1200.50, $code) ?: number_format(1200.50, $digits);
+                            foreach ([0, 2, 3, 4] as $digits) {
+                                $sample = number_format(1200.50, $digits);
+
+                                if (class_exists(NumberFormatter::class)) {
+                                    $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+                                    $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, $digits);
+
+                                    $formatted = $formatter->formatCurrency(1200.50, $code);
+
+                                    if ($formatted !== false) {
+                                        $sample = $formatted;
+                                    }
+                                }
 
                                 $label = $digits === 0 ? 'No decimals' : $digits.' decimals';
                                 $options[(string) $digits] = sprintf('%s (%s)', $label, $sample);

--- a/src/Filament/Integration/Builders/TableBuilder.php
+++ b/src/Filament/Integration/Builders/TableBuilder.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Filament\Integration\Builders;
 
+use Closure;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -38,10 +39,17 @@ final class TableBuilder extends BaseBuilder
                     return $column;
                 }
 
-                // Wrap the existing state with visibility check
-                $column->formatStateUsing(function (mixed $state, mixed $record) use ($field, $backendVisibilityService, $allFields): mixed {
+                $existingFormatter = (fn (): ?Closure => $this->formatStateUsing)->call($column); // @phpstan-ignore property.notFound
+
+                $column->formatStateUsing(function (mixed $state, mixed $record) use ($field, $backendVisibilityService, $allFields, $existingFormatter, $column): mixed {
                     if (! $backendVisibilityService->isFieldVisible($record, $field, $allFields)) {
-                        return null; // Return null or empty value when field should be hidden
+                        return null;
+                    }
+
+                    if ($existingFormatter) {
+                        return $column->evaluate($existingFormatter, [
+                            'state' => $state,
+                        ]);
                     }
 
                     return $state;

--- a/src/Filament/Integration/Builders/TableBuilder.php
+++ b/src/Filament/Integration/Builders/TableBuilder.php
@@ -49,6 +49,8 @@ final class TableBuilder extends BaseBuilder
                     if ($existingFormatter) {
                         return $column->evaluate($existingFormatter, [
                             'state' => $state,
+                            'record' => $record,
+                            'column' => $column,
                         ]);
                     }
 

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Filament\Integration\Components\Forms;
 
 use Filament\Forms\Components\TextInput;
 use Illuminate\Support\Str;
+use NumberFormatter;
 use Relaticle\CustomFields\Filament\Integration\Base\AbstractFormComponent;
 use Relaticle\CustomFields\Models\CustomField;
 
@@ -13,10 +14,12 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 {
     public function create(CustomField $customField): TextInput
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+        $decimalPlaces = $customField->getDecimalPlaces();
+        $currencyCode = $customField->getCurrencyCode();
+        $prefix = self::getCurrencySymbol($currencyCode, $customField->getCurrencyDisplayType());
 
         return TextInput::make($customField->getFieldName())
-            ->prefix('$')
+            ->prefix($prefix)
             ->numeric()
             ->inputMode('decimal')
             ->step($decimalPlaces > 0 ? 1 / (10 ** $decimalPlaces) : 1)
@@ -32,7 +35,27 @@ final readonly class CurrencyComponent extends AbstractFormComponent
                     return null;
                 }
 
-                return Str::of($state)->replace(['$', ','], '')->toFloat();
+                return Str::of($state)->replace(',', '')->toFloat();
             });
+    }
+
+    private static function getCurrencySymbol(string $currencyCode, string $displayType): string
+    {
+        $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+        $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+
+        $formatted = $formatter->formatCurrency(0, $currencyCode);
+
+        if ($formatted === false) {
+            return $currencyCode;
+        }
+
+        $symbol = str_replace(['0', ' ', "\xC2\xA0"], '', $formatted);
+
+        if ($symbol === '' || $displayType === 'code') {
+            return $currencyCode;
+        }
+
+        return $symbol;
     }
 }

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -41,6 +41,14 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 
     private function getCurrencySymbol(string $currencyCode, string $displayType): string
     {
+        if ($displayType === 'code') {
+            return $currencyCode;
+        }
+
+        if (! class_exists(NumberFormatter::class)) {
+            return $currencyCode;
+        }
+
         $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
         $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
 
@@ -52,7 +60,7 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 
         $symbol = str_replace(['0', ' ', "\xC2\xA0"], '', $formatted);
 
-        if ($symbol === '' || $displayType === 'code') {
+        if ($symbol === '') {
             return $currencyCode;
         }
 

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -16,7 +16,7 @@ final readonly class CurrencyComponent extends AbstractFormComponent
     {
         $decimalPlaces = $customField->getDecimalPlaces();
         $currencyCode = $customField->getCurrencyCode();
-        $prefix = self::getCurrencySymbol($currencyCode, $customField->getCurrencyDisplayType());
+        $prefix = $this->getCurrencySymbol($currencyCode, $customField->getCurrencyDisplayType());
 
         return TextInput::make($customField->getFieldName())
             ->prefix($prefix)
@@ -39,7 +39,7 @@ final readonly class CurrencyComponent extends AbstractFormComponent
             });
     }
 
-    private static function getCurrencySymbol(string $currencyCode, string $displayType): string
+    private function getCurrencySymbol(string $currencyCode, string $displayType): string
     {
         $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
         $formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -13,7 +13,7 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 {
     public function create(CustomField $customField): TextInput
     {
-        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
 
         return TextInput::make($customField->getFieldName())
             ->prefix('$')

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -13,7 +13,7 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 {
     public function create(CustomField $customField): TextInput
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
 
         return TextInput::make($customField->getFieldName())
             ->prefix('$')

--- a/src/Filament/Integration/Components/Forms/CurrencyComponent.php
+++ b/src/Filament/Integration/Components/Forms/CurrencyComponent.php
@@ -13,15 +13,26 @@ final readonly class CurrencyComponent extends AbstractFormComponent
 {
     public function create(CustomField $customField): TextInput
     {
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+
         return TextInput::make($customField->getFieldName())
             ->prefix('$')
             ->numeric()
             ->inputMode('decimal')
-            ->step(0.01)
-            ->minValue(0)
-            ->default(0)
-            ->rules(['numeric', 'min:0'])
-            ->formatStateUsing(fn (mixed $state): string => number_format((float) $state, 2))
-            ->dehydrateStateUsing(fn (mixed $state): float => Str::of($state)->replace(['$', ','], '')->toFloat());
+            ->step($decimalPlaces > 0 ? 1 / (10 ** $decimalPlaces) : 1)
+            ->formatStateUsing(function (mixed $state) use ($decimalPlaces): ?string {
+                if ($state === null || $state === '') {
+                    return null;
+                }
+
+                return number_format((float) $state, $decimalPlaces);
+            })
+            ->dehydrateStateUsing(function (mixed $state): ?float {
+                if ($state === null || $state === '') {
+                    return null;
+                }
+
+                return Str::of($state)->replace(['$', ','], '')->toFloat();
+            });
     }
 }

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -12,12 +12,12 @@ final class CurrencyEntry extends AbstractInfolistEntry
 {
     public function make(CustomField $customField): BaseTextEntry
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
-
         return BaseTextEntry::make($customField->getFieldName())
             ->label($customField->name)
-            ->numeric(decimalPlaces: $decimalPlaces)
-            ->prefix('$')
+            ->money(
+                $customField->getCurrencyCode(),
+                decimalPlaces: $customField->getDecimalPlaces(),
+            )
             ->state(fn (mixed $record) => $record->getCustomFieldValue($customField));
     }
 }

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Filament\Integration\Components\Infolists;
+
+use Filament\Infolists\Components\TextEntry as BaseTextEntry;
+use Relaticle\CustomFields\Filament\Integration\Base\AbstractInfolistEntry;
+use Relaticle\CustomFields\Models\CustomField;
+
+final class CurrencyEntry extends AbstractInfolistEntry
+{
+    public function make(CustomField $customField): BaseTextEntry
+    {
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+
+        return BaseTextEntry::make($customField->getFieldName())
+            ->label($customField->name)
+            ->numeric(decimalPlaces: $decimalPlaces)
+            ->prefix('$')
+            ->state(fn (mixed $record) => $record->getCustomFieldValue($customField));
+    }
+}

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -12,7 +12,7 @@ final class CurrencyEntry extends AbstractInfolistEntry
 {
     public function make(CustomField $customField): BaseTextEntry
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
 
         return BaseTextEntry::make($customField->getFieldName())
             ->label($customField->name)

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -6,26 +6,20 @@ namespace Relaticle\CustomFields\Filament\Integration\Components\Infolists;
 
 use Filament\Infolists\Components\TextEntry as BaseTextEntry;
 use Relaticle\CustomFields\Filament\Integration\Base\AbstractInfolistEntry;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Shared\ConfiguresCurrencyFormatting;
 use Relaticle\CustomFields\Models\CustomField;
 
 final class CurrencyEntry extends AbstractInfolistEntry
 {
+    use ConfiguresCurrencyFormatting;
+
     public function make(CustomField $customField): BaseTextEntry
     {
         $entry = BaseTextEntry::make($customField->getFieldName())
             ->label($customField->name)
             ->state(fn (mixed $record) => $record->getCustomFieldValue($customField));
 
-        if ($customField->getCurrencyDisplayType() === 'code') {
-            $entry
-                ->numeric(decimalPlaces: $customField->getDecimalPlaces())
-                ->prefix($customField->getCurrencyCode().' ');
-        } else {
-            $entry->money(
-                $customField->getCurrencyCode(),
-                decimalPlaces: $customField->getDecimalPlaces(),
-            );
-        }
+        $this->applyCurrencyFormatting($entry, $customField);
 
         return $entry;
     }

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -12,12 +12,21 @@ final class CurrencyEntry extends AbstractInfolistEntry
 {
     public function make(CustomField $customField): BaseTextEntry
     {
-        return BaseTextEntry::make($customField->getFieldName())
+        $entry = BaseTextEntry::make($customField->getFieldName())
             ->label($customField->name)
-            ->money(
+            ->state(fn (mixed $record) => $record->getCustomFieldValue($customField));
+
+        if ($customField->getCurrencyDisplayType() === 'code') {
+            $entry
+                ->numeric(decimalPlaces: $customField->getDecimalPlaces())
+                ->prefix($customField->getCurrencyCode().' ');
+        } else {
+            $entry->money(
                 $customField->getCurrencyCode(),
                 decimalPlaces: $customField->getDecimalPlaces(),
-            )
-            ->state(fn (mixed $record) => $record->getCustomFieldValue($customField));
+            );
+        }
+
+        return $entry;
     }
 }

--- a/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
+++ b/src/Filament/Integration/Components/Infolists/CurrencyEntry.php
@@ -12,7 +12,7 @@ final class CurrencyEntry extends AbstractInfolistEntry
 {
     public function make(CustomField $customField): BaseTextEntry
     {
-        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
 
         return BaseTextEntry::make($customField->getFieldName())
             ->label($customField->name)

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -21,7 +21,7 @@ final class CurrencyColumn extends AbstractTableColumn
 
     public function make(CustomField $customField): BaseTextColumn
     {
-        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
 
         $column = BaseTextColumn::make($customField->getFieldName())
             ->numeric(decimalPlaces: $decimalPlaces)

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -21,11 +21,11 @@ final class CurrencyColumn extends AbstractTableColumn
 
     public function make(CustomField $customField): BaseTextColumn
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
-
         $column = BaseTextColumn::make($customField->getFieldName())
-            ->numeric(decimalPlaces: $decimalPlaces)
-            ->prefix('$');
+            ->money(
+                $customField->getCurrencyCode(),
+                decimalPlaces: $customField->getDecimalPlaces(),
+            );
 
         $this->configureLabel($column, $customField);
         $this->configureSortable($column, $customField);

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -21,11 +21,18 @@ final class CurrencyColumn extends AbstractTableColumn
 
     public function make(CustomField $customField): BaseTextColumn
     {
-        $column = BaseTextColumn::make($customField->getFieldName())
-            ->money(
+        $column = BaseTextColumn::make($customField->getFieldName());
+
+        if ($customField->getCurrencyDisplayType() === 'code') {
+            $column
+                ->numeric(decimalPlaces: $customField->getDecimalPlaces())
+                ->prefix($customField->getCurrencyCode().' ');
+        } else {
+            $column->money(
                 $customField->getCurrencyCode(),
                 decimalPlaces: $customField->getDecimalPlaces(),
             );
+        }
 
         $this->configureLabel($column, $customField);
         $this->configureSortable($column, $customField);

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns;
 
 use Filament\Tables\Columns\TextColumn as BaseTextColumn;
 use Relaticle\CustomFields\Filament\Integration\Base\AbstractTableColumn;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Shared\ConfiguresCurrencyFormatting;
 use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresColumnLabel;
 use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresColumnState;
 use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresSearchable;
@@ -16,6 +17,7 @@ final class CurrencyColumn extends AbstractTableColumn
 {
     use ConfiguresColumnLabel;
     use ConfiguresColumnState;
+    use ConfiguresCurrencyFormatting;
     use ConfiguresSearchable;
     use ConfiguresSortable;
 
@@ -23,17 +25,7 @@ final class CurrencyColumn extends AbstractTableColumn
     {
         $column = BaseTextColumn::make($customField->getFieldName());
 
-        if ($customField->getCurrencyDisplayType() === 'code') {
-            $column
-                ->numeric(decimalPlaces: $customField->getDecimalPlaces())
-                ->prefix($customField->getCurrencyCode().' ');
-        } else {
-            $column->money(
-                $customField->getCurrencyCode(),
-                decimalPlaces: $customField->getDecimalPlaces(),
-            );
-        }
-
+        $this->applyCurrencyFormatting($column, $customField);
         $this->configureLabel($column, $customField);
         $this->configureSortable($column, $customField);
         $this->configureSearchable($column, $customField);

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns;
+
+use Filament\Tables\Columns\TextColumn as BaseTextColumn;
+use Relaticle\CustomFields\Filament\Integration\Base\AbstractTableColumn;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresColumnLabel;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresColumnState;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresSearchable;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Tables\ConfiguresSortable;
+use Relaticle\CustomFields\Models\CustomField;
+
+final class CurrencyColumn extends AbstractTableColumn
+{
+    use ConfiguresColumnLabel;
+    use ConfiguresColumnState;
+    use ConfiguresSearchable;
+    use ConfiguresSortable;
+
+    public function make(CustomField $customField): BaseTextColumn
+    {
+        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+
+        $column = BaseTextColumn::make($customField->getFieldName())
+            ->numeric(decimalPlaces: $decimalPlaces)
+            ->prefix('$');
+
+        $this->configureLabel($column, $customField);
+        $this->configureSortable($column, $customField);
+        $this->configureSearchable($column, $customField);
+        $this->configureState($column, $customField);
+
+        return $column;
+    }
+}

--- a/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/CurrencyColumn.php
@@ -21,7 +21,7 @@ final class CurrencyColumn extends AbstractTableColumn
 
     public function make(CustomField $customField): BaseTextColumn
     {
-        $decimalPlaces = (int) ($customField->validation_rules?->get('decimal_places') ?? 2);
+        $decimalPlaces = (int) ($customField->validation_rules->get('decimal_places') ?? 2);
 
         $column = BaseTextColumn::make($customField->getFieldName())
             ->numeric(decimalPlaces: $decimalPlaces)

--- a/src/Filament/Integration/Concerns/Shared/ConfiguresCurrencyFormatting.php
+++ b/src/Filament/Integration/Concerns/Shared/ConfiguresCurrencyFormatting.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Filament\Integration\Concerns\Shared;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Tables\Columns\TextColumn;
+use Relaticle\CustomFields\Models\CustomField;
+
+trait ConfiguresCurrencyFormatting
+{
+    protected function applyCurrencyFormatting(TextColumn|TextEntry $component, CustomField $customField): void
+    {
+        if ($customField->getCurrencyDisplayType() === 'code') {
+            $component
+                ->numeric(decimalPlaces: $customField->getDecimalPlaces())
+                ->prefix($customField->getCurrencyCode().' ');
+        } else {
+            $component->money(
+                $customField->getCurrencyCode(),
+                decimalPlaces: $customField->getDecimalPlaces(),
+            );
+        }
+    }
+}

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -227,7 +227,7 @@ class CustomField extends Model
 
     public function getDecimalPlaces(int $default = 2): int
     {
-        return $this->getCurrencySettings()->decimalPlaces;
+        return $this->getCurrencySettings()->decimalPlaces ?? $default;
     }
 
     public function getCurrencyCode(): string

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -70,7 +70,7 @@ class CustomField extends Model
     /**
      * @var array<string>
      */
-    protected $guarded = [];
+    protected $guarded = ['id'];
 
     protected $attributes = [
         'width' => CustomFieldWidth::_100,

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -17,6 +17,7 @@ use Override;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 use Relaticle\CustomFields\Data\FieldTypeData;
+use Relaticle\CustomFields\Data\Settings\CurrencyFieldSettingsData;
 use Relaticle\CustomFields\Database\Factories\CustomFieldFactory;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\CustomFieldWidth;
@@ -207,21 +208,35 @@ class CustomField extends Model
         return 'custom_fields.'.$this->code;
     }
 
+    public function getCurrencySettings(): CurrencyFieldSettingsData
+    {
+        $additional = $this->settings->additional ?? [];
+
+        // Legacy fallback: decimal_places may live in validation_rules
+        if (! isset($additional['decimal_places']) && $this->validation_rules?->has('decimal_places')) { // @phpstan-ignore nullsafe.neverNull
+            $additional['decimal_places'] = $this->validation_rules->get('decimal_places');
+        }
+
+        // Apply config default for currency_code
+        if (! isset($additional['currency_code'])) {
+            $additional['currency_code'] = config('custom-fields.currency.default_code', 'USD');
+        }
+
+        return CurrencyFieldSettingsData::fromAdditional($additional);
+    }
+
     public function getDecimalPlaces(int $default = 2): int
     {
-        return (int) ($this->settings->additional['decimal_places']
-            ?? $this->validation_rules?->get('decimal_places') // @phpstan-ignore nullsafe.neverNull
-            ?? $default);
+        return $this->getCurrencySettings()->decimalPlaces;
     }
 
     public function getCurrencyCode(): string
     {
-        return $this->settings->additional['currency_code']
-            ?? config('custom-fields.currency.default_code', 'USD');
+        return $this->getCurrencySettings()->currencyCode;
     }
 
     public function getCurrencyDisplayType(): string
     {
-        return $this->settings->additional['display_type'] ?? 'symbol';
+        return $this->getCurrencySettings()->displayType;
     }
 }

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -206,4 +206,22 @@ class CustomField extends Model
     {
         return 'custom_fields.'.$this->code;
     }
+
+    public function getDecimalPlaces(int $default = 2): int
+    {
+        return (int) ($this->settings->additional['decimal_places']
+            ?? $this->validation_rules?->get('decimal_places') // @phpstan-ignore nullsafe.neverNull
+            ?? $default);
+    }
+
+    public function getCurrencyCode(): string
+    {
+        return $this->settings->additional['currency_code']
+            ?? config('custom-fields.currency.default_code', 'USD');
+    }
+
+    public function getCurrencyDisplayType(): string
+    {
+        return $this->settings->additional['display_type'] ?? 'symbol';
+    }
 }

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -206,7 +206,7 @@ final class ValidationService
         // Currency fields: enforce decimal places from settings
         if ($customField->type === 'currency') {
             $decimalPlaces = $customField->getDecimalPlaces();
-            $rules[] = $decimalPlaces === 0 ? 'integer' : "decimal:0,{$decimalPlaces}";
+            $rules[] = $decimalPlaces === 0 ? 'integer' : 'decimal:0,'.$decimalPlaces;
         }
 
         return $rules;

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -203,6 +203,12 @@ final class ValidationService
             $rules[] = new UniqueCustomFieldValue($customField, $ignoreEntityId);
         }
 
+        // Currency fields: enforce decimal places from settings
+        if ($customField->type === 'currency') {
+            $decimalPlaces = $customField->getDecimalPlaces();
+            $rules[] = $decimalPlaces === 0 ? 'integer' : "decimal:0,{$decimalPlaces}";
+        }
+
         return $rules;
     }
 

--- a/src/Support/CurrencyProvider.php
+++ b/src/Support/CurrencyProvider.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Support;
+
+use NumberFormatter;
+use ResourceBundle;
+
+final class CurrencyProvider
+{
+    /** @var array<string, string>|null */
+    private static ?array $cachedOptions = null;
+
+    private static ?string $cachedLocale = null;
+
+    /** @var array<string, int>|null */
+    private static ?array $cachedDigits = null;
+
+    /**
+     * Known-obsolete currency codes that ICU doesn't consistently mark as historical.
+     * These were replaced by other currencies (mostly EUR) but lack date annotations in ICU data.
+     *
+     * @var array<int, string>
+     */
+    private const OBSOLETE_CODES = [
+        // Replaced by EUR
+        'ADP', 'ATS', 'BEF', 'CYP', 'DEM', 'EEK', 'ESP', 'FIM', 'FRF', 'GRD',
+        'HRK', 'IEP', 'ITL', 'LTL', 'LUF', 'LVL', 'MCF', 'MTL', 'NLG', 'PTE',
+        'SIT', 'SKK', 'SML', 'VAL',
+        // Other obsolete
+        'MGF', 'MRO', 'STD', 'VEB', 'VEF', 'TMM', 'ZWD', 'ZWL', 'ZWR',
+    ];
+
+    /**
+     * X-prefixed codes that are real currencies (CFA franc zones, East Caribbean).
+     *
+     * @var array<int, string>
+     */
+    private const REAL_X_CODES = ['XOF', 'XAF', 'XPF', 'XCD'];
+
+    /**
+     * @return array<string, string> Currency code => "Name (CODE)" for select options
+     */
+    public static function getOptions(): array
+    {
+        $locale = app()->getLocale();
+
+        if (self::$cachedOptions !== null && self::$cachedLocale === $locale) {
+            return self::$cachedOptions;
+        }
+
+        self::$cachedLocale = $locale;
+
+        $configCurrencies = config('custom-fields.currency.currencies');
+
+        if (is_array($configCurrencies) && $configCurrencies !== []) {
+            return self::$cachedOptions = self::buildOptionsFromConfig($configCurrencies);
+        }
+
+        return self::$cachedOptions = self::buildOptionsFromIcu($locale);
+    }
+
+    /**
+     * Get the standard number of decimal places for a currency code.
+     */
+    public static function getDecimalDigits(string $code): int
+    {
+        if (self::$cachedDigits === null) {
+            self::$cachedDigits = [];
+        }
+
+        if (isset(self::$cachedDigits[$code])) {
+            return self::$cachedDigits[$code];
+        }
+
+        $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+        $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $code);
+
+        return self::$cachedDigits[$code] = $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function buildOptionsFromIcu(string $locale): array
+    {
+        $bundle = new ResourceBundle($locale, 'ICUDATA-curr');
+        $currencies = $bundle->get('Currencies');
+        $options = [];
+
+        foreach ($currencies as $code => $data) {
+            if (strlen($code) !== 3) {
+                continue;
+            }
+
+            $name = $data[1];
+
+            if (preg_match('/\(\d{4}/', $name)) {
+                continue;
+            }
+
+            if ($code[0] === 'X' && ! in_array($code, self::REAL_X_CODES, true)) {
+                continue;
+            }
+
+            if (in_array($code, self::OBSOLETE_CODES, true)) {
+                continue;
+            }
+
+            $options[$code] = sprintf('%s (%s)', $name, $code);
+        }
+
+        ksort($options);
+
+        return $options;
+    }
+
+    /**
+     * @param  array<string, string>  $currencies  Code => Name pairs from config
+     * @return array<string, string>
+     */
+    private static function buildOptionsFromConfig(array $currencies): array
+    {
+        $options = [];
+
+        foreach ($currencies as $code => $name) {
+            $options[$code] = sprintf('%s (%s)', $name, $code);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Flush cached data (useful for testing).
+     */
+    public static function flush(): void
+    {
+        self::$cachedOptions = null;
+        self::$cachedLocale = null;
+        self::$cachedDigits = null;
+    }
+}

--- a/src/Support/CurrencyProvider.php
+++ b/src/Support/CurrencyProvider.php
@@ -4,19 +4,12 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Support;
 
+use Illuminate\Support\Str;
 use NumberFormatter;
 use ResourceBundle;
 
 final class CurrencyProvider
 {
-    /** @var array<string, string>|null */
-    private static ?array $cachedOptions = null;
-
-    private static ?string $cachedLocale = null;
-
-    /** @var array<string, int>|null */
-    private static ?array $cachedDigits = null;
-
     /**
      * Known-obsolete currency codes that ICU doesn't consistently mark as historical.
      * These were replaced by other currencies (mostly EUR) but lack date annotations in ICU data.
@@ -46,19 +39,15 @@ final class CurrencyProvider
     {
         $locale = app()->getLocale();
 
-        if (self::$cachedOptions !== null && self::$cachedLocale === $locale) {
-            return self::$cachedOptions;
-        }
+        return once(function () use ($locale): array {
+            $configCurrencies = config('custom-fields.currency.currencies');
 
-        self::$cachedLocale = $locale;
+            if (is_array($configCurrencies) && $configCurrencies !== []) {
+                return self::buildOptionsFromConfig($configCurrencies);
+            }
 
-        $configCurrencies = config('custom-fields.currency.currencies');
-
-        if (is_array($configCurrencies) && $configCurrencies !== []) {
-            return self::$cachedOptions = self::buildOptionsFromConfig($configCurrencies);
-        }
-
-        return self::$cachedOptions = self::buildOptionsFromIcu($locale);
+            return self::buildOptionsFromIcu($locale);
+        });
     }
 
     /**
@@ -66,18 +55,12 @@ final class CurrencyProvider
      */
     public static function getDecimalDigits(string $code): int
     {
-        if (self::$cachedDigits === null) {
-            self::$cachedDigits = [];
-        }
+        return once(function () use ($code): int {
+            $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+            $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $code);
 
-        if (isset(self::$cachedDigits[$code])) {
-            return self::$cachedDigits[$code];
-        }
-
-        $formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
-        $formatter->setTextAttribute(NumberFormatter::CURRENCY_CODE, $code);
-
-        return self::$cachedDigits[$code] = $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS);
+            return $formatter->getAttribute(NumberFormatter::FRACTION_DIGITS);
+        });
     }
 
     /**
@@ -90,7 +73,7 @@ final class CurrencyProvider
         $options = [];
 
         foreach ($currencies as $code => $data) {
-            if (strlen($code) !== 3) {
+            if (Str::length($code) !== 3) {
                 continue;
             }
 
@@ -129,15 +112,5 @@ final class CurrencyProvider
         }
 
         return $options;
-    }
-
-    /**
-     * Flush cached data (useful for testing).
-     */
-    public static function flush(): void
-    {
-        self::$cachedOptions = null;
-        self::$cachedLocale = null;
-        self::$cachedDigits = null;
     }
 }

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -150,13 +150,14 @@ describe('CurrencyComponent', function (): void {
 });
 
 describe('CurrencyFieldType Export Transformer', function (): void {
-    it('formats values with 2 decimal places for CSV export', function (): void {
+    it('exports values preserving meaningful precision', function (): void {
         $transformer = (new CurrencyFieldType)->configure()->getExportTransformer();
 
-        expect($transformer(1234.5))->toBe('1234.50')
-            ->and($transformer(0))->toBe('0.00')
-            ->and($transformer(99.999))->toBe('100.00')
-            ->and($transformer(42))->toBe('42.00');
+        expect($transformer(1234.5))->toBe('1234.5')
+            ->and($transformer(0))->toBe('0')
+            ->and($transformer(99.999))->toBe('99.999')
+            ->and($transformer(42))->toBe('42')
+            ->and($transformer(1234.50))->toBe('1234.5');
     });
 
     it('returns null for null values in export', function (): void {

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -34,7 +34,7 @@ describe('CurrencyEntry', function (): void {
     it('creates a text entry with currency prefix', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
-        $entry = (new CurrencyEntry())->make($field);
+        $entry = (new CurrencyEntry)->make($field);
 
         expect($entry)
             ->toBeInstanceOf(BaseTextEntry::class)
@@ -46,7 +46,7 @@ describe('CurrencyEntry', function (): void {
             'validation_rules' => ['decimal_places' => 0],
         ]);
 
-        $entry = (new CurrencyEntry())->make($field);
+        $entry = (new CurrencyEntry)->make($field);
 
         expect($entry)->toBeInstanceOf(BaseTextEntry::class);
     });

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Tables\Columns\TextColumn as BaseTextColumn;
+use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
+use Relaticle\CustomFields\Models\CustomField;
+
+describe('CurrencyColumn', function (): void {
+    it('creates a text column with currency prefix', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        $column = (new CurrencyColumn())->make($field);
+
+        expect($column)
+            ->toBeInstanceOf(BaseTextColumn::class)
+            ->and($column->getPrefix())->toBe('$');
+    });
+
+    it('creates a column for fields with custom decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 4],
+        ]);
+
+        $column = (new CurrencyColumn())->make($field);
+
+        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+    });
+});

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -10,7 +10,7 @@ describe('CurrencyColumn', function (): void {
     it('creates a text column with currency prefix', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
-        $column = (new CurrencyColumn())->make($field);
+        $column = (new CurrencyColumn)->make($field);
 
         expect($column)
             ->toBeInstanceOf(BaseTextColumn::class)
@@ -22,7 +22,7 @@ describe('CurrencyColumn', function (): void {
             'validation_rules' => ['decimal_places' => 4],
         ]);
 
-        $column = (new CurrencyColumn())->make($field);
+        $column = (new CurrencyColumn)->make($field);
 
         expect($column)->toBeInstanceOf(BaseTextColumn::class);
     });

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry as BaseTextEntry;
 use Filament\Tables\Columns\TextColumn as BaseTextColumn;
+use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
 use Relaticle\CustomFields\Models\CustomField;
@@ -49,5 +51,53 @@ describe('CurrencyEntry', function (): void {
         $entry = (new CurrencyEntry)->make($field);
 
         expect($entry)->toBeInstanceOf(BaseTextEntry::class);
+    });
+});
+
+describe('CurrencyComponent', function (): void {
+    it('creates a text input with currency prefix', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect($component)
+            ->toBeInstanceOf(TextInput::class)
+            ->and($component->getPrefixLabel())->toBe('$');
+    });
+
+    it('has no hardcoded default value', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect($component->getDefaultState())->toBeNull();
+    });
+
+    it('uses step matching default 2 decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect((float) $component->getStep())->toBe(0.01);
+    });
+
+    it('uses step matching configured decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 4],
+        ]);
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect((float) $component->getStep())->toBe(0.0001);
+    });
+
+    it('uses step of 1 for zero decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 0],
+        ]);
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect((int) $component->getStep())->toBe(1);
     });
 });

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry as BaseTextEntry;
 use Filament\Tables\Columns\TextColumn as BaseTextColumn;
+use Relaticle\CustomFields\FieldTypeSystem\Definitions\CurrencyFieldType;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
@@ -99,5 +100,22 @@ describe('CurrencyComponent', function (): void {
         $component = app(CurrencyComponent::class)->create($field);
 
         expect((int) $component->getStep())->toBe(1);
+    });
+});
+
+describe('CurrencyFieldType Export Transformer', function (): void {
+    it('formats values with 2 decimal places for CSV export', function (): void {
+        $transformer = (new CurrencyFieldType)->configure()->getExportTransformer();
+
+        expect($transformer(1234.5))->toBe('1234.50')
+            ->and($transformer(0))->toBe('0.00')
+            ->and($transformer(99.999))->toBe('100.00')
+            ->and($transformer(42))->toBe('42.00');
+    });
+
+    it('returns null for null values in export', function (): void {
+        $transformer = (new CurrencyFieldType)->configure()->getExportTransformer();
+
+        expect($transformer(null))->toBeNull();
     });
 });

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Filament\Infolists\Components\TextEntry as BaseTextEntry;
 use Filament\Tables\Columns\TextColumn as BaseTextColumn;
+use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
 use Relaticle\CustomFields\Models\CustomField;
 
@@ -25,5 +27,27 @@ describe('CurrencyColumn', function (): void {
         $column = (new CurrencyColumn)->make($field);
 
         expect($column)->toBeInstanceOf(BaseTextColumn::class);
+    });
+});
+
+describe('CurrencyEntry', function (): void {
+    it('creates a text entry with currency prefix', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        $entry = (new CurrencyEntry())->make($field);
+
+        expect($entry)
+            ->toBeInstanceOf(BaseTextEntry::class)
+            ->and($entry->getPrefix())->toBe('$');
+    });
+
+    it('creates an entry for fields with custom decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 0],
+        ]);
+
+        $entry = (new CurrencyEntry())->make($field);
+
+        expect($entry)->toBeInstanceOf(BaseTextEntry::class);
     });
 });

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -12,12 +12,27 @@ use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\Curren
 use Relaticle\CustomFields\Models\CustomField;
 
 describe('CurrencyColumn', function (): void {
-    it('creates a text column with money formatting', function (): void {
+    it('creates a money-formatted column with symbol display type by default', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
         $column = (new CurrencyColumn)->make($field);
 
-        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+        expect($column)
+            ->toBeInstanceOf(BaseTextColumn::class)
+            ->isMoney()->toBeTrue();
+    });
+
+    it('uses numeric formatting with code prefix for code display type', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'EUR', 'display_type' => 'code']],
+        ]);
+
+        $column = (new CurrencyColumn)->make($field);
+
+        expect($column)
+            ->toBeInstanceOf(BaseTextColumn::class)
+            ->isNumeric()->toBeTrue()
+            ->getPrefix()->toBe('EUR ');
     });
 
     it('uses configured currency code from settings', function (): void {
@@ -27,7 +42,9 @@ describe('CurrencyColumn', function (): void {
 
         $column = (new CurrencyColumn)->make($field);
 
-        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+        expect($column)
+            ->toBeInstanceOf(BaseTextColumn::class)
+            ->isMoney()->toBeTrue();
     });
 
     it('creates a column for fields with zero decimal places', function (): void {
@@ -37,7 +54,9 @@ describe('CurrencyColumn', function (): void {
 
         $column = (new CurrencyColumn)->make($field);
 
-        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+        expect($column)
+            ->toBeInstanceOf(BaseTextColumn::class)
+            ->isMoney()->toBeTrue();
     });
 
     it('falls back to validation_rules for legacy decimal places', function (): void {
@@ -52,12 +71,27 @@ describe('CurrencyColumn', function (): void {
 });
 
 describe('CurrencyEntry', function (): void {
-    it('creates a text entry with money formatting', function (): void {
+    it('creates a money-formatted entry with symbol display type by default', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
         $entry = (new CurrencyEntry)->make($field);
 
-        expect($entry)->toBeInstanceOf(BaseTextEntry::class);
+        expect($entry)
+            ->toBeInstanceOf(BaseTextEntry::class)
+            ->isMoney()->toBeTrue();
+    });
+
+    it('uses numeric formatting with code prefix for code display type', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'GBP', 'display_type' => 'code']],
+        ]);
+
+        $entry = (new CurrencyEntry)->make($field);
+
+        expect($entry)
+            ->toBeInstanceOf(BaseTextEntry::class)
+            ->isNumeric()->toBeTrue()
+            ->getPrefix()->toBe('GBP ');
     });
 
     it('creates an entry for fields with zero decimal places', function (): void {
@@ -67,7 +101,9 @@ describe('CurrencyEntry', function (): void {
 
         $entry = (new CurrencyEntry)->make($field);
 
-        expect($entry)->toBeInstanceOf(BaseTextEntry::class);
+        expect($entry)
+            ->toBeInstanceOf(BaseTextEntry::class)
+            ->isMoney()->toBeTrue();
     });
 });
 

--- a/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
+++ b/tests/Feature/Filament/Components/CurrencyFieldComponentsTest.php
@@ -12,17 +12,35 @@ use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\Curren
 use Relaticle\CustomFields\Models\CustomField;
 
 describe('CurrencyColumn', function (): void {
-    it('creates a text column with currency prefix', function (): void {
+    it('creates a text column with money formatting', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
         $column = (new CurrencyColumn)->make($field);
 
-        expect($column)
-            ->toBeInstanceOf(BaseTextColumn::class)
-            ->and($column->getPrefix())->toBe('$');
+        expect($column)->toBeInstanceOf(BaseTextColumn::class);
     });
 
-    it('creates a column for fields with custom decimal places', function (): void {
+    it('uses configured currency code from settings', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'EUR', 'decimal_places' => 2]],
+        ]);
+
+        $column = (new CurrencyColumn)->make($field);
+
+        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+    });
+
+    it('creates a column for fields with zero decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['decimal_places' => 0]],
+        ]);
+
+        $column = (new CurrencyColumn)->make($field);
+
+        expect($column)->toBeInstanceOf(BaseTextColumn::class);
+    });
+
+    it('falls back to validation_rules for legacy decimal places', function (): void {
         $field = CustomField::factory()->ofType('currency')->create([
             'validation_rules' => ['decimal_places' => 4],
         ]);
@@ -34,19 +52,17 @@ describe('CurrencyColumn', function (): void {
 });
 
 describe('CurrencyEntry', function (): void {
-    it('creates a text entry with currency prefix', function (): void {
+    it('creates a text entry with money formatting', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
         $entry = (new CurrencyEntry)->make($field);
 
-        expect($entry)
-            ->toBeInstanceOf(BaseTextEntry::class)
-            ->and($entry->getPrefix())->toBe('$');
+        expect($entry)->toBeInstanceOf(BaseTextEntry::class);
     });
 
-    it('creates an entry for fields with custom decimal places', function (): void {
+    it('creates an entry for fields with zero decimal places', function (): void {
         $field = CustomField::factory()->ofType('currency')->create([
-            'validation_rules' => ['decimal_places' => 0],
+            'settings' => ['additional' => ['decimal_places' => 0]],
         ]);
 
         $entry = (new CurrencyEntry)->make($field);
@@ -66,6 +82,26 @@ describe('CurrencyComponent', function (): void {
             ->and($component->getPrefixLabel())->toBe('$');
     });
 
+    it('uses EUR symbol for EUR currency', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'EUR']],
+        ]);
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect($component->getPrefixLabel())->toContain('€');
+    });
+
+    it('uses currency code as prefix for code display type', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'USD', 'display_type' => 'code']],
+        ]);
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect($component->getPrefixLabel())->toBe('USD');
+    });
+
     it('has no hardcoded default value', function (): void {
         $field = CustomField::factory()->ofType('currency')->create();
 
@@ -82,9 +118,9 @@ describe('CurrencyComponent', function (): void {
         expect((float) $component->getStep())->toBe(0.01);
     });
 
-    it('uses step matching configured decimal places', function (): void {
+    it('uses step matching configured decimal places from settings', function (): void {
         $field = CustomField::factory()->ofType('currency')->create([
-            'validation_rules' => ['decimal_places' => 4],
+            'settings' => ['additional' => ['decimal_places' => 4]],
         ]);
 
         $component = app(CurrencyComponent::class)->create($field);
@@ -94,12 +130,22 @@ describe('CurrencyComponent', function (): void {
 
     it('uses step of 1 for zero decimal places', function (): void {
         $field = CustomField::factory()->ofType('currency')->create([
-            'validation_rules' => ['decimal_places' => 0],
+            'settings' => ['additional' => ['decimal_places' => 0]],
         ]);
 
         $component = app(CurrencyComponent::class)->create($field);
 
         expect((int) $component->getStep())->toBe(1);
+    });
+
+    it('falls back to validation_rules for legacy decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 4],
+        ]);
+
+        $component = app(CurrencyComponent::class)->create($field);
+
+        expect((float) $component->getStep())->toBe(0.0001);
     });
 });
 
@@ -117,5 +163,57 @@ describe('CurrencyFieldType Export Transformer', function (): void {
         $transformer = (new CurrencyFieldType)->configure()->getExportTransformer();
 
         expect($transformer(null))->toBeNull();
+    });
+});
+
+describe('CustomField currency helpers', function (): void {
+    it('returns decimal places from settings', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['decimal_places' => 0]],
+        ]);
+
+        expect($field->getDecimalPlaces())->toBe(0);
+    });
+
+    it('falls back to validation_rules for decimal places', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'validation_rules' => ['decimal_places' => 3],
+        ]);
+
+        expect($field->getDecimalPlaces())->toBe(3);
+    });
+
+    it('returns default decimal places when nothing configured', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        expect($field->getDecimalPlaces())->toBe(2);
+    });
+
+    it('returns currency code from settings', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['currency_code' => 'EUR']],
+        ]);
+
+        expect($field->getCurrencyCode())->toBe('EUR');
+    });
+
+    it('returns default currency code when nothing configured', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        expect($field->getCurrencyCode())->toBe('USD');
+    });
+
+    it('returns display type from settings', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create([
+            'settings' => ['additional' => ['display_type' => 'code']],
+        ]);
+
+        expect($field->getCurrencyDisplayType())->toBe('code');
+    });
+
+    it('returns default display type when nothing configured', function (): void {
+        $field = CustomField::factory()->ofType('currency')->create();
+
+        expect($field->getCurrencyDisplayType())->toBe('symbol');
     });
 });

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Livewire\Component;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;


### PR DESCRIPTION
## Summary

- **CurrencyColumn**: Dedicated table column with money formatting and configurable display type (symbol `$1,200.50` or code `USD 1,200.50`)
- **CurrencyEntry**: Dedicated infolist entry with money formatting and configurable display type
- **CurrencyComponent**: Removed hardcoded `minValue(0)`, `default(0)`, and `rules(['numeric', 'min:0'])` — lets the capability system (MinValueCapability) handle these. `formatStateUsing` and `dehydrateStateUsing` now handle null and respect configured decimal places. `NumberFormatter` guarded with `class_exists()` for environments without ext-intl.
- **Currency settings**: Configurable currency code, display type (symbol/code), and decimal places (0, 2, 3, 4) with ICU-powered currency list
- **Export transformer**: CSV-safe export preserving meaningful precision (trims trailing zeros)

### Behavior changes

| Surface | Before | After |
|---------|--------|-------|
| Table (symbol) | Raw float `1234.56` | `$1,234.56` |
| Table (code) | Raw float `1234.56` | `USD 1,234.56` |
| Infolist (symbol) | Raw float `1234.56` | `$1,234.56` |
| Infolist (code) | Raw float `1234.56` | `USD 1,234.56` |
| Form (new record) | Pre-filled `$0.00` | Empty (null) |
| Form (negative values) | Blocked by hardcoded `min:0` | Allowed unless MinValueCapability configured |
| Form (custom decimals) | Always `100.00` | Respects config e.g. `100.000` |
| Export CSV | Raw float `1234.56789` | `1234.56789` (preserves precision) |

## Test plan

- [x] 27 tests covering CurrencyColumn, CurrencyEntry, CurrencyComponent, export transformer, and CustomField currency helpers
- [x] Tests verify actual formatting behavior (isMoney/isNumeric/getPrefix assertions)
- [x] Full suite: 474 tests passing (7 pre-existing failures unrelated to this PR)
- [x] PHPStan: 0 errors
- [x] Pint: clean