### PR TITLE
fix: support $guarded models and MariaDB driver [3.x]

### DIFF
--- a/src/Models/Concerns/UsesCustomFields.php
+++ b/src/Models/Concerns/UsesCustomFields.php
@@ -31,8 +31,31 @@ trait UsesCustomFields
 
         parent::__construct($attributes);
 
-        // Handle custom_fields immediately if present in attributes
         $this->handleCustomFields();
+    }
+
+    public function isFillable($key): bool
+    {
+        if ($key === 'custom_fields') {
+            return true;
+        }
+
+        return parent::isFillable($key);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    protected function fillableFromArray(array $attributes): array
+    {
+        $fillable = parent::fillableFromArray($attributes);
+
+        if (array_key_exists('custom_fields', $attributes) && ! array_key_exists('custom_fields', $fillable)) {
+            $fillable['custom_fields'] = $attributes['custom_fields'];
+        }
+
+        return $fillable;
     }
 
     /**

--- a/src/Support/DatabaseFieldConstraints.php
+++ b/src/Support/DatabaseFieldConstraints.php
@@ -38,6 +38,7 @@ final class DatabaseFieldConstraints
         'text_value' => [
             'max' => [
                 'mysql' => 65535,
+                'mariadb' => 65535,
                 'pgsql' => 1073741823,
                 'sqlite' => 1000000000,
             ],

--- a/tests/Feature/Models/UsesCustomFieldsTraitTest.php
+++ b/tests/Feature/Models/UsesCustomFieldsTraitTest.php
@@ -127,7 +127,7 @@ describe('Guarded Model Support', function (): void {
         expect($model->title)->toBe('Test Title');
     });
 
-    it('stores custom_fields in temp storage when filling a guarded model', function (): void {
+    it('allows custom_fields to be filled on a guarded model', function (): void {
         $model = new GuardedTestModel;
         $model->fill(['custom_fields' => ['test_field' => 'test_value']]);
 

--- a/tests/Feature/Models/UsesCustomFieldsTraitTest.php
+++ b/tests/Feature/Models/UsesCustomFieldsTraitTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Models\Concerns\UsesCustomFields;
+use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
@@ -91,3 +94,61 @@ describe('Custom Field Value Cleanup on Delete', function (): void {
         expect(CustomFieldValue::withoutGlobalScopes()->where('entity_id', $post->getKey())->count())->toBe(0);
     });
 });
+
+describe('Fillable Model Support', function (): void {
+    it('includes custom_fields in getFillable for models with $fillable', function (): void {
+        $model = new FillableTestModel;
+
+        expect($model->getFillable())->toContain('custom_fields');
+    });
+
+    it('recognizes custom_fields as fillable via isFillable on fillable models', function (): void {
+        $model = new FillableTestModel;
+
+        expect($model->isFillable('custom_fields'))->toBeTrue();
+    });
+});
+
+describe('Guarded Model Support', function (): void {
+    it('recognizes custom_fields as fillable via isFillable override', function (): void {
+        $model = new GuardedTestModel;
+
+        expect($model->isFillable('custom_fields'))->toBeTrue()
+            ->and($model->getGuarded())->toBe(['id']);
+    });
+
+    it('allows mass assignment of custom_fields on guarded models', function (): void {
+        $model = new GuardedTestModel;
+        $model->fill([
+            'title' => 'Test Title',
+            'custom_fields' => ['field_one' => 'value_one'],
+        ]);
+
+        expect($model->title)->toBe('Test Title');
+    });
+
+    it('stores custom_fields in temp storage when filling a guarded model', function (): void {
+        $model = new GuardedTestModel;
+        $model->fill(['custom_fields' => ['test_field' => 'test_value']]);
+
+        expect($model->custom_fields)->toBe(['test_field' => 'test_value']);
+    });
+});
+
+class FillableTestModel extends Model implements HasCustomFields
+{
+    use UsesCustomFields;
+
+    protected $table = 'posts';
+
+    protected $fillable = ['title'];
+}
+
+class GuardedTestModel extends Model implements HasCustomFields
+{
+    use UsesCustomFields;
+
+    protected $table = 'posts';
+
+    protected $guarded = ['id'];
+}

--- a/tests/Feature/Support/DatabaseFieldConstraintsTest.php
+++ b/tests/Feature/Support/DatabaseFieldConstraintsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Support\DatabaseFieldConstraints;
+
+it('includes mariadb in text_value driver-specific constraints', function (): void {
+    $constraints = DatabaseFieldConstraints::getConstraintsForColumn('text_value');
+
+    expect($constraints['max'])->toHaveKey('mariadb');
+});
+
+it('has the same max value for mariadb as mysql', function (): void {
+    $constraints = DatabaseFieldConstraints::getConstraintsForColumn('text_value');
+
+    expect($constraints['max']['mariadb'])->toBe($constraints['max']['mysql']);
+});


### PR DESCRIPTION
## Summary
- Models using `$guarded` instead of `$fillable` couldn't save custom fields. Replace `mergeFillable` with `isFillable()` and `fillableFromArray()` overrides.
- Add MariaDB to `text_value` driver-specific constraints (matches MySQL at 65535).

Closes #121
Closes #120

## Test plan
- [x] Guarded model recognizes `custom_fields` as fillable via `isFillable()` override
- [x] Guarded model can mass-assign `custom_fields`
- [x] Guarded model stores `custom_fields` in temp storage when filling
- [x] MariaDB included in text_value constraints
- [x] MariaDB constraint matches MySQL value
- [x] Full test suite passes (no regressions)