### PR TITLE
fix: preserve getFillable() backward compat for $fillable models [1.x]

### DIFF
--- a/src/Models/Concerns/UsesCustomFields.php
+++ b/src/Models/Concerns/UsesCustomFields.php
@@ -23,6 +23,10 @@ trait UsesCustomFields
 {
     public function __construct($attributes = [])
     {
+        if (count($this->getFillable()) !== 0) {
+            $this->mergeFillable(['custom_fields']);
+        }
+
         parent::__construct($attributes);
 
         $this->handleCustomFields();

--- a/tests/Feature/Models/UsesCustomFieldsTest.php
+++ b/tests/Feature/Models/UsesCustomFieldsTest.php
@@ -19,8 +19,13 @@ function createTestModelTable()
 it('handles custom fields from fillable array', function () {
     $testModel = new TestModel;
 
-    // Test that custom_fields is recognized as fillable via isFillable override
     expect($testModel->isFillable('custom_fields'))->toBeTrue();
+});
+
+it('includes custom_fields in getFillable for models with $fillable', function () {
+    $testModel = new TestModel;
+
+    expect($testModel->getFillable())->toContain('custom_fields');
 });
 
 it('returns empty value when custom field has no value', function () {


### PR DESCRIPTION
## Summary
The guarded models fix (#110) removed `mergeFillable` from the constructor, which means `getFillable()` no longer includes `custom_fields` for models using `$fillable`. This restores backward compatibility by keeping `mergeFillable` for `$fillable` models while the `isFillable()` + `fillableFromArray()` overrides handle `$guarded` models.

## Test plan
- [x] `getFillable()` includes `custom_fields` for models with `$fillable`
- [x] `isFillable('custom_fields')` returns true for fillable models
- [x] Guarded model tests still pass
- [x] All existing tests pass