### PR TITLE
fix: guard against non-scalar values in UniqueCustomFieldValue rule [3.x]

### DIFF
--- a/src/Rules/UniqueCustomFieldValue.php
+++ b/src/Rules/UniqueCustomFieldValue.php
@@ -35,6 +35,10 @@ final class UniqueCustomFieldValue implements ValidationRule
                 continue;
             }
 
+            if (! is_scalar($singleValue)) {
+                continue;
+            }
+
             $normalizedValue = $fieldType
                 ? $fieldType->setValue((string) $singleValue)
                 : (string) $singleValue;

--- a/tests/Feature/Rules/UniqueCustomFieldValueTest.php
+++ b/tests/Feature/Rules/UniqueCustomFieldValueTest.php
@@ -330,6 +330,56 @@ describe('Edit record — text field uniqueness via Livewire', function (): void
     });
 });
 
+describe('Non-scalar value handling', function (): void {
+    it('does not crash when link field receives array-of-objects instead of array-of-strings', function (): void {
+        $rule = new UniqueCustomFieldValue($this->linkField);
+        $errors = [];
+
+        $rule->validate(
+            'custom_fields.domains',
+            [['url' => 'https://example.com']],
+            function (string $message) use (&$errors): void {
+                $errors[] = $message;
+            }
+        );
+
+        expect($errors)->toBeEmpty();
+    });
+
+    it('does not crash when text field receives an array instead of a string', function (): void {
+        $rule = new UniqueCustomFieldValue($this->textField);
+        $errors = [];
+
+        $rule->validate(
+            'custom_fields.slug',
+            ['nested', 'array'],
+            function (string $message) use (&$errors): void {
+                $errors[] = $message;
+            }
+        );
+
+        expect($errors)->toBeEmpty();
+    });
+
+    it('still validates scalar values after skipping non-scalar ones', function (): void {
+        $existing = Post::factory()->create();
+        storeLinkValueForPost($existing, $this->linkField, ['taken.com']);
+
+        $rule = new UniqueCustomFieldValue($this->linkField);
+        $errors = [];
+
+        $rule->validate(
+            'custom_fields.domains',
+            [['url' => 'https://skip.me'], 'taken.com'],
+            function (string $message) use (&$errors): void {
+                $errors[] = $message;
+            }
+        );
+
+        expect($errors)->not->toBeEmpty();
+    });
+});
+
 describe('Morph alias resolution', function (): void {
     beforeEach(function (): void {
         Relation::morphMap([


### PR DESCRIPTION
## Summary

- Skip non-scalar values (arrays, objects) in `UniqueCustomFieldValue` validation loop
- Prevents `ErrorException: Array to string conversion` when multi-value fields (link, email, phone) receive malformed input (e.g., array-of-objects instead of array-of-strings)
- Non-scalar values are caught by other validation rules (`string`, `regex`, `max`) — no behavior change for valid input

## Context

When the API receives `{"domains": [{"url": "https://example.com"}]}` instead of the correct `{"domains": ["https://example.com"]}`, the `(string)` cast in the uniqueness check crashes with a 500. This should be a 422 validation error.

## Test plan

- [ ] Verify malformed link/email/phone input returns 422 instead of 500
- [ ] Verify correct scalar input still triggers uniqueness checks
- [ ] Verify Filament forms still work (they always submit scalars via `dehydrateStateUsing`)