### PR TITLE
feat: configurable description position for custom fields [3.x]

### DIFF
--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -41,6 +41,11 @@ return [
             'code' => 'Code',
             'code_helper_text' => 'Unique code to identify this field throughout the resource.',
             'description' => 'Description',
+            'description_position' => 'Description Position',
+            'description_position_options' => [
+                'below' => 'Below field',
+                'above' => 'Above field',
+            ],
             'settings' => 'Settings',
             'encrypted' => 'Encrypted',
             'encrypted_help' => 'When enabled, this field\'s values will be stored securely using encryption.',

--- a/src/Data/CustomFieldSettingsData.php
+++ b/src/Data/CustomFieldSettingsData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Data;
 
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\DescriptionPosition;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
@@ -24,6 +25,7 @@ class CustomFieldSettingsData extends Data
         public int $max_values = 1,
         public bool $unique_per_entity_type = false,
         public ?string $description = null,
+        public ?DescriptionPosition $descriptionPosition = null,
         public VisibilityData $visibility = new VisibilityData,
         public array $additional = [],
     ) {

--- a/src/Enums/CustomFieldsFeature.php
+++ b/src/Enums/CustomFieldsFeature.php
@@ -19,6 +19,7 @@ enum CustomFieldsFeature: string
     case FIELD_UNIQUE_VALUE = 'field_unique_value';
     case FIELD_VALIDATION_RULES = 'field_validation_rules';
     case FIELD_DESCRIPTION = 'field_description';
+    case FIELD_DESCRIPTION_POSITION = 'field_description_position';
 
     // Visibility features
     case MODEL_ATTRIBUTE_CONDITIONS = 'model_attribute_conditions';

--- a/src/Enums/DescriptionPosition.php
+++ b/src/Enums/DescriptionPosition.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Enums;
 
-enum DescriptionPosition: string
+use Filament\Support\Contracts\HasLabel;
+
+enum DescriptionPosition: string implements HasLabel
 {
     case BELOW = 'below';
     case ABOVE = 'above';

--- a/src/Enums/DescriptionPosition.php
+++ b/src/Enums/DescriptionPosition.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Enums;
+
+enum DescriptionPosition: string
+{
+    case BELOW = 'below';
+    case ABOVE = 'above';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::BELOW => __('custom-fields::custom-fields.field.form.description_position_options.below'),
+            self::ABOVE => __('custom-fields::custom-fields.field.form.description_position_options.above'),
+        };
+    }
+}

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Filament\Integration\Base;
 
 use Filament\Forms\Components\Field;
+use Filament\Schemas\Components\Text;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Contracts\FormComponentInterface;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\DescriptionPosition;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Services\ValidationService;
@@ -55,10 +57,20 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         $field
             ->name($customField->getFieldName())
             ->label($customField->name)
-            ->helperText(
-                FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION)
-                    ? ($customField->settings->description ?? null)
-                    : null
+            ->when(
+                FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION) &&
+                filled($customField->settings->description),
+                function (Field $field) use ($customField): Field {
+                    $description = $customField->settings->description;
+                    $position = $customField->settings->descriptionPosition;
+
+                    if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION) &&
+                        $position === DescriptionPosition::ABOVE) {
+                        return $field->aboveContent(fn (): Text => Text::make($description));
+                    }
+
+                    return $field->helperText($description);
+                }
             )
             ->afterStateHydrated(
                 fn (mixed $component, mixed $state, mixed $record): mixed => $component->state(

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -274,18 +274,12 @@ class FieldForm implements FormInterface
                 ->label(__('custom-fields::custom-fields.field.form.description'))
                 ->maxLength(255)
                 ->rows(2)
-                ->live()
+                ->live(onBlur: true)
                 ->columnSpanFull()
                 ->visible(fn (): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION)),
             Select::make('settings.description_position')
                 ->label(__('custom-fields::custom-fields.field.form.description_position'))
-                ->options(
-                    collect(DescriptionPosition::cases())
-                        ->mapWithKeys(fn (DescriptionPosition $position): array => [
-                            $position->value => $position->getLabel(),
-                        ])
-                        ->all()
-                )
+                ->options(DescriptionPosition::class)
                 ->placeholder(__('custom-fields::custom-fields.field.form.description_position_options.below'))
                 ->visible(fn (Get $get): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION) &&
                     FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION) &&

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -27,6 +27,7 @@ use Illuminate\Validation\Rules\Unique;
 use Relaticle\CustomFields\Contracts\ValidationCapability;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\DescriptionPosition;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Facades\Entities;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -273,8 +274,23 @@ class FieldForm implements FormInterface
                 ->label(__('custom-fields::custom-fields.field.form.description'))
                 ->maxLength(255)
                 ->rows(2)
+                ->live()
                 ->columnSpanFull()
                 ->visible(fn (): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION)),
+            Select::make('settings.description_position')
+                ->label(__('custom-fields::custom-fields.field.form.description_position'))
+                ->options(
+                    collect(DescriptionPosition::cases())
+                        ->mapWithKeys(fn (DescriptionPosition $position): array => [
+                            $position->value => $position->getLabel(),
+                        ])
+                        ->all()
+                )
+                ->placeholder(__('custom-fields::custom-fields.field.form.description_position_options.below'))
+                ->visible(fn (Get $get): bool => FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION) &&
+                    FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION) &&
+                    filled($get('settings.description'))
+                ),
             Fieldset::make(
                 __(
                     'custom-fields::custom-fields.field.form.settings'

--- a/src/Models/CustomField.php
+++ b/src/Models/CustomField.php
@@ -225,9 +225,9 @@ class CustomField extends Model
         return CurrencyFieldSettingsData::fromAdditional($additional);
     }
 
-    public function getDecimalPlaces(int $default = 2): int
+    public function getDecimalPlaces(): int
     {
-        return $this->getCurrencySettings()->decimalPlaces ?? $default;
+        return $this->getCurrencySettings()->decimalPlaces;
     }
 
     public function getCurrencyCode(): string

--- a/src/Services/Visibility/CoreVisibilityLogicService.php
+++ b/src/Services/Visibility/CoreVisibilityLogicService.php
@@ -31,11 +31,9 @@ final readonly class CoreVisibilityLogicService
      * Extract visibility data from a custom field.
      * This is the authoritative method for getting visibility configuration.
      */
-    public function getVisibilityData(CustomField $field): ?VisibilityData
+    public function getVisibilityData(CustomField $field): VisibilityData
     {
-        $settings = $field->settings;
-
-        return $settings->visibility ?? null;
+        return $field->settings->visibility;
     }
 
     /**
@@ -43,9 +41,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function getVisibilityDataFromSection(CustomFieldSection $section): ?VisibilityData
     {
-        $settings = $section->settings;
-
-        return $settings->visibility ?? null;
+        return $section->settings->visibility;
     }
 
     /**
@@ -54,9 +50,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function hasVisibilityConditions(CustomField $field): bool
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility?->requiresConditions() ?? false;
+        return $this->getVisibilityData($field)->requiresConditions();
     }
 
     /**
@@ -77,9 +71,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function getDependentFields(CustomField $field): array
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility?->getDependentFields() ?? [];
+        return $this->getVisibilityData($field)->getDependentFields();
     }
 
     /**
@@ -90,9 +82,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function evaluateVisibility(CustomField $field, array $fieldValues, ?Model $record = null): bool
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility?->evaluate($fieldValues, $record) ?? true;
+        return $this->getVisibilityData($field)->evaluate($fieldValues, $record);
     }
 
     /**
@@ -185,9 +175,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function getVisibilityMode(CustomField $field): VisibilityMode
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility->mode ?? VisibilityMode::ALWAYS_VISIBLE;
+        return $this->getVisibilityData($field)->mode;
     }
 
     /**
@@ -196,9 +184,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function getVisibilityLogic(CustomField $field): VisibilityLogic
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility->logic ?? VisibilityLogic::ALL;
+        return $this->getVisibilityData($field)->logic;
     }
 
     /**
@@ -211,7 +197,7 @@ final readonly class CoreVisibilityLogicService
     {
         $visibility = $this->getVisibilityData($field);
 
-        if (! $visibility instanceof VisibilityData || ! $visibility->conditions instanceof DataCollection) {
+        if (! $visibility->conditions instanceof DataCollection) {
             return [];
         }
 
@@ -223,9 +209,7 @@ final readonly class CoreVisibilityLogicService
      */
     public function shouldAlwaysSave(CustomField $field): bool
     {
-        $visibility = $this->getVisibilityData($field);
-
-        return $visibility->alwaysSave ?? false;
+        return $this->getVisibilityData($field)->alwaysSave;
     }
 
     /**

--- a/tests/Feature/DescriptionPositionTest.php
+++ b/tests/Feature/DescriptionPositionTest.php
@@ -2,7 +2,16 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\DescriptionPosition;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
 
 it('has the correct backing values', function (): void {
     expect(DescriptionPosition::BELOW->value)->toBe('below');
@@ -13,10 +22,6 @@ it('returns translatable labels', function (): void {
     expect(DescriptionPosition::BELOW->getLabel())->toBeString()->not->toBeEmpty();
     expect(DescriptionPosition::ABOVE->getLabel())->toBeString()->not->toBeEmpty();
 });
-
-use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
-use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 
 it('has FIELD_DESCRIPTION_POSITION feature flag disabled by default', function (): void {
     expect(FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION))->toBeFalse();
@@ -30,8 +35,6 @@ it('can enable FIELD_DESCRIPTION_POSITION feature flag', function (): void {
 
     expect(FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION))->toBeTrue();
 });
-
-use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 
 it('includes descriptionPosition as null by default in settings', function (): void {
     $settings = new CustomFieldSettingsData;
@@ -57,12 +60,6 @@ it('serializes and deserializes descriptionPosition through settings', function 
 
     expect($restored->descriptionPosition)->toBe(DescriptionPosition::ABOVE);
 });
-
-use Relaticle\CustomFields\Models\CustomField;
-use Relaticle\CustomFields\Models\CustomFieldSection;
-use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
-use Relaticle\CustomFields\Tests\Fixtures\Models\User;
-use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
 
 it('renders description below field by default', function (): void {
     $this->actingAs(User::factory()->create());
@@ -90,7 +87,8 @@ it('renders description below field by default', function (): void {
     ]);
 
     livewire(CreatePost::class)
-        ->assertSuccessful();
+        ->assertSuccessful()
+        ->assertSeeHtml('Help text below');
 });
 
 it('renders description above field when position is ABOVE and feature enabled', function (): void {
@@ -121,7 +119,8 @@ it('renders description above field when position is ABOVE and feature enabled',
     ]);
 
     livewire(CreatePost::class)
-        ->assertSuccessful();
+        ->assertSuccessful()
+        ->assertSeeHtml('Help text above');
 });
 
 it('ignores description position when FIELD_DESCRIPTION_POSITION feature is disabled', function (): void {
@@ -152,5 +151,6 @@ it('ignores description position when FIELD_DESCRIPTION_POSITION feature is disa
     ]);
 
     livewire(CreatePost::class)
-        ->assertSuccessful();
+        ->assertSuccessful()
+        ->assertSeeHtml('Should render below despite ABOVE setting');
 });

--- a/tests/Feature/DescriptionPositionTest.php
+++ b/tests/Feature/DescriptionPositionTest.php
@@ -57,3 +57,100 @@ it('serializes and deserializes descriptionPosition through settings', function 
 
     expect($restored->descriptionPosition)->toBe(DescriptionPosition::ABOVE);
 });
+
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
+
+it('renders description below field by default', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $config = FeatureConfigurator::configure()
+        ->enable(
+            CustomFieldsFeature::FIELD_DESCRIPTION,
+            CustomFieldsFeature::SYSTEM_SECTIONS,
+        );
+    config(['custom-fields.features' => $config]);
+
+    $section = CustomFieldSection::factory()->create([
+        'entity_type' => Post::class,
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Test Field',
+        'code' => 'test_field',
+        'type' => 'text',
+        'entity_type' => Post::class,
+        'settings' => new CustomFieldSettingsData(
+            description: 'Help text below',
+        ),
+    ]);
+
+    livewire(CreatePost::class)
+        ->assertSuccessful();
+});
+
+it('renders description above field when position is ABOVE and feature enabled', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $config = FeatureConfigurator::configure()
+        ->enable(
+            CustomFieldsFeature::FIELD_DESCRIPTION,
+            CustomFieldsFeature::FIELD_DESCRIPTION_POSITION,
+            CustomFieldsFeature::SYSTEM_SECTIONS,
+        );
+    config(['custom-fields.features' => $config]);
+
+    $section = CustomFieldSection::factory()->create([
+        'entity_type' => Post::class,
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Test Field Above',
+        'code' => 'test_field_above',
+        'type' => 'text',
+        'entity_type' => Post::class,
+        'settings' => new CustomFieldSettingsData(
+            description: 'Help text above',
+            descriptionPosition: DescriptionPosition::ABOVE,
+        ),
+    ]);
+
+    livewire(CreatePost::class)
+        ->assertSuccessful();
+});
+
+it('ignores description position when FIELD_DESCRIPTION_POSITION feature is disabled', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $config = FeatureConfigurator::configure()
+        ->enable(
+            CustomFieldsFeature::FIELD_DESCRIPTION,
+            CustomFieldsFeature::SYSTEM_SECTIONS,
+        )
+        ->disable(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION);
+    config(['custom-fields.features' => $config]);
+
+    $section = CustomFieldSection::factory()->create([
+        'entity_type' => Post::class,
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Test Field Fallback',
+        'code' => 'test_field_fallback',
+        'type' => 'text',
+        'entity_type' => Post::class,
+        'settings' => new CustomFieldSettingsData(
+            description: 'Should render below despite ABOVE setting',
+            descriptionPosition: DescriptionPosition::ABOVE,
+        ),
+    ]);
+
+    livewire(CreatePost::class)
+        ->assertSuccessful();
+});

--- a/tests/Feature/DescriptionPositionTest.php
+++ b/tests/Feature/DescriptionPositionTest.php
@@ -30,3 +30,30 @@ it('can enable FIELD_DESCRIPTION_POSITION feature flag', function (): void {
 
     expect(FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION))->toBeTrue();
 });
+
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+
+it('includes descriptionPosition as null by default in settings', function (): void {
+    $settings = new CustomFieldSettingsData;
+
+    expect($settings->descriptionPosition)->toBeNull();
+});
+
+it('stores descriptionPosition enum in settings', function (): void {
+    $settings = new CustomFieldSettingsData(
+        descriptionPosition: DescriptionPosition::ABOVE,
+    );
+
+    expect($settings->descriptionPosition)->toBe(DescriptionPosition::ABOVE);
+});
+
+it('serializes and deserializes descriptionPosition through settings', function (): void {
+    $settings = new CustomFieldSettingsData(
+        descriptionPosition: DescriptionPosition::ABOVE,
+    );
+
+    $array = $settings->toArray();
+    $restored = CustomFieldSettingsData::from($array);
+
+    expect($restored->descriptionPosition)->toBe(DescriptionPosition::ABOVE);
+});

--- a/tests/Feature/DescriptionPositionTest.php
+++ b/tests/Feature/DescriptionPositionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\DescriptionPosition;
+
+it('has the correct backing values', function (): void {
+    expect(DescriptionPosition::BELOW->value)->toBe('below');
+    expect(DescriptionPosition::ABOVE->value)->toBe('above');
+});
+
+it('returns translatable labels', function (): void {
+    expect(DescriptionPosition::BELOW->getLabel())->toBeString()->not->toBeEmpty();
+    expect(DescriptionPosition::ABOVE->getLabel())->toBeString()->not->toBeEmpty();
+});

--- a/tests/Feature/DescriptionPositionTest.php
+++ b/tests/Feature/DescriptionPositionTest.php
@@ -13,3 +13,20 @@ it('returns translatable labels', function (): void {
     expect(DescriptionPosition::BELOW->getLabel())->toBeString()->not->toBeEmpty();
     expect(DescriptionPosition::ABOVE->getLabel())->toBeString()->not->toBeEmpty();
 });
+
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+
+it('has FIELD_DESCRIPTION_POSITION feature flag disabled by default', function (): void {
+    expect(FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION))->toBeFalse();
+});
+
+it('can enable FIELD_DESCRIPTION_POSITION feature flag', function (): void {
+    $config = FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION);
+
+    config(['custom-fields.features' => $config]);
+
+    expect(FeatureManager::isEnabled(CustomFieldsFeature::FIELD_DESCRIPTION_POSITION))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Adds per-field configuration for where the description text appears: **below the input** (default, current behavior) or **above the input** (between label and input)
- New `DescriptionPosition` enum with `BELOW`/`ABOVE` cases mapping to Filament's `belowContent()` and `aboveContent()` schema slots
- New `FIELD_DESCRIPTION_POSITION` feature flag (disabled by default) — both `FIELD_DESCRIPTION` and `FIELD_DESCRIPTION_POSITION` must be enabled for the position selector to appear
- Position Select in the field management form, visible only when both flags are enabled and the description field has a value
- No database migration required — stored as a nullable property in the existing JSON `settings` column via `CustomFieldSettingsData`

## Changes

| File | Change |
|---|---|
| `src/Enums/DescriptionPosition.php` | New enum with BELOW/ABOVE cases and translatable labels |
| `src/Enums/CustomFieldsFeature.php` | Added `FIELD_DESCRIPTION_POSITION` case |
| `src/Data/CustomFieldSettingsData.php` | Added nullable `descriptionPosition` property |
| `src/Filament/Integration/Base/AbstractFormComponent.php` | Position-aware rendering via `when()` block |
| `src/Filament/Management/Schemas/FieldForm.php` | Position Select + `live()` on description Textarea |
| `resources/lang/en/custom-fields.php` | Translation keys for position labels |

## Test plan

- 10 new tests in `tests/Feature/DescriptionPositionTest.php` covering:
  - Enum backing values and translatable labels
  - Feature flag disabled by default and can be enabled
  - DTO null default, enum storage, serialization round-trip
  - Rendering below by default, above when enabled, fallback when flag disabled