### PR TITLE
perf: batch query in UniqueCustomFieldValue to avoid N+1 [3.x]

### DIFF
--- a/src/Rules/UniqueCustomFieldValue.php
+++ b/src/Rules/UniqueCustomFieldValue.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
@@ -30,22 +31,32 @@ final class UniqueCustomFieldValue implements ValidationRule
         $values = is_array($value) ? $value : [$value];
         $fieldType = app(FieldManager::class)->getFieldTypeInstance($this->customField->type);
 
+        $normalizedByOriginal = [];
+
         foreach ($values as $singleValue) {
-            if (blank($singleValue)) {
+            if (blank($singleValue) || ! is_scalar($singleValue)) {
                 continue;
             }
 
-            if (! is_scalar($singleValue)) {
-                continue;
-            }
-
-            $normalizedValue = $fieldType
+            $normalizedByOriginal[(string) $singleValue] = $fieldType
                 ? $fieldType->setValue((string) $singleValue)
                 : (string) $singleValue;
+        }
 
-            if ($this->existsOnAnotherEntity($normalizedValue)) {
+        if ($normalizedByOriginal === []) {
+            return;
+        }
+
+        $takenValues = $this->findTakenValues(array_values($normalizedByOriginal));
+
+        if ($takenValues === []) {
+            return;
+        }
+
+        foreach ($normalizedByOriginal as $originalValue => $normalizedValue) {
+            if (in_array($normalizedValue, $takenValues, true)) {
                 $fail(__('custom-fields::custom-fields.validation.unique_value', [
-                    'value' => $singleValue,
+                    'value' => $originalValue,
                 ]));
 
                 return;
@@ -53,10 +64,53 @@ final class UniqueCustomFieldValue implements ValidationRule
         }
     }
 
-    private function existsOnAnotherEntity(string $normalizedValue): bool
+    /**
+     * Return the subset of normalized values that already exist on another entity.
+     *
+     * Executes a single query regardless of how many values are submitted,
+     * avoiding the N+1 pattern of checking each value individually.
+     *
+     * @param  array<int, string>  $normalizedValues
+     * @return array<int, string>
+     */
+    private function findTakenValues(array $normalizedValues): array
+    {
+        $valueColumn = $this->customField->getValueColumn();
+        $query = $this->baseQuery();
+
+        if ($valueColumn === 'json_value') {
+            $query->where(function (Builder $q) use ($normalizedValues): void {
+                foreach ($normalizedValues as $value) {
+                    $q->orWhereJsonContains('json_value', $value);
+                }
+            });
+
+            $stored = [];
+
+            foreach ($query->pluck('json_value')->all() as $storedArray) {
+                if ($storedArray instanceof \Traversable) {
+                    $storedArray = iterator_to_array($storedArray, false);
+                }
+
+                if (is_array($storedArray)) {
+                    $stored = array_merge($stored, $storedArray);
+                }
+            }
+
+            return array_values(array_intersect($normalizedValues, $stored));
+        }
+
+        return $query->whereIn($valueColumn, $normalizedValues)
+            ->pluck($valueColumn)
+            ->map(static fn (mixed $v): string => (string) $v)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function baseQuery(): Builder
     {
         $valueModel = CustomFields::newValueModel();
-        $valueColumn = $this->customField->getValueColumn();
 
         $entityType = $this->customField->entity_type;
         $entityClass = Relation::getMorphedModel($entityType) ?? $entityType;
@@ -65,12 +119,6 @@ final class UniqueCustomFieldValue implements ValidationRule
         $query = $valueModel->newQuery()
             ->where('custom_field_id', $this->customField->getKey())
             ->where('entity_type', $morphAlias);
-
-        if ($valueColumn === 'json_value') {
-            $query->whereJsonContains('json_value', $normalizedValue);
-        } else {
-            $query->where($valueColumn, $normalizedValue);
-        }
 
         if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
             $tenantFk = config('custom-fields.database.column_names.tenant_foreign_key');
@@ -81,6 +129,6 @@ final class UniqueCustomFieldValue implements ValidationRule
             $query->where('entity_id', '!=', $this->ignoreEntityId);
         }
 
-        return $query->exists();
+        return $query;
     }
 }

--- a/src/Rules/UniqueCustomFieldValue.php
+++ b/src/Rules/UniqueCustomFieldValue.php
@@ -85,9 +85,9 @@ final class UniqueCustomFieldValue implements ValidationRule
         }
 
         return $query->whereIn($valueColumn, $normalizedValues)
+            ->distinct()
             ->pluck($valueColumn)
             ->map(static fn (mixed $v): string => (string) $v)
-            ->unique()
             ->values()
             ->all();
     }

--- a/src/Rules/UniqueCustomFieldValue.php
+++ b/src/Rules/UniqueCustomFieldValue.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -28,39 +29,32 @@ final class UniqueCustomFieldValue implements ValidationRule
             return;
         }
 
-        $values = is_array($value) ? $value : [$value];
         $fieldType = app(FieldManager::class)->getFieldTypeInstance($this->customField->type);
 
-        $normalizedByOriginal = [];
+        $normalizedByOriginal = collect(Arr::wrap($value))
+            ->reject(fn (mixed $v): bool => blank($v) || ! is_scalar($v))
+            ->mapWithKeys(fn (mixed $v): array => [
+                (string) $v => $fieldType?->setValue((string) $v) ?? (string) $v,
+            ]);
 
-        foreach ($values as $singleValue) {
-            if (blank($singleValue) || ! is_scalar($singleValue)) {
-                continue;
-            }
-
-            $normalizedByOriginal[(string) $singleValue] = $fieldType
-                ? $fieldType->setValue((string) $singleValue)
-                : (string) $singleValue;
-        }
-
-        if ($normalizedByOriginal === []) {
+        if ($normalizedByOriginal->isEmpty()) {
             return;
         }
 
-        $takenValues = $this->findTakenValues(array_values($normalizedByOriginal));
+        $takenValues = $this->findTakenValues($normalizedByOriginal->values()->all());
 
         if ($takenValues === []) {
             return;
         }
 
-        foreach ($normalizedByOriginal as $originalValue => $normalizedValue) {
-            if (in_array($normalizedValue, $takenValues, true)) {
-                $fail(__('custom-fields::custom-fields.validation.unique_value', [
-                    'value' => $originalValue,
-                ]));
+        $collision = $normalizedByOriginal->search(
+            fn (string $normalized): bool => in_array($normalized, $takenValues, true)
+        );
 
-                return;
-            }
+        if ($collision !== false) {
+            $fail(__('custom-fields::custom-fields.validation.unique_value', [
+                'value' => $collision,
+            ]));
         }
     }
 
@@ -85,17 +79,7 @@ final class UniqueCustomFieldValue implements ValidationRule
                 }
             });
 
-            $stored = [];
-
-            foreach ($query->pluck('json_value')->all() as $storedArray) {
-                if ($storedArray instanceof \Traversable) {
-                    $storedArray = iterator_to_array($storedArray, false);
-                }
-
-                if (is_array($storedArray)) {
-                    $stored = array_merge($stored, $storedArray);
-                }
-            }
+            $stored = $query->pluck('json_value')->flatten(1)->all();
 
             return array_values(array_intersect($normalizedValues, $stored));
         }

--- a/tests/Feature/Rules/UniqueCustomFieldValueTest.php
+++ b/tests/Feature/Rules/UniqueCustomFieldValueTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\DB;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -376,6 +377,57 @@ describe('Non-scalar value handling', function (): void {
             }
         );
 
+        expect($errors)->not->toBeEmpty();
+    });
+});
+
+describe('Query efficiency', function (): void {
+    it('issues a single query when validating a multi-value link field with many values', function (): void {
+        $queries = 0;
+        DB::listen(function ($query) use (&$queries): void {
+            if (str_contains($query->sql, 'custom_field_values')) {
+                $queries++;
+            }
+        });
+
+        $rule = new UniqueCustomFieldValue($this->linkField);
+        $errors = [];
+
+        $rule->validate(
+            'custom_fields.domains',
+            ['a.com', 'b.com', 'c.com', 'd.com', 'e.com'],
+            function (string $message) use (&$errors): void {
+                $errors[] = $message;
+            }
+        );
+
+        expect($queries)->toBe(1);
+        expect($errors)->toBeEmpty();
+    });
+
+    it('issues a single query when validating a multi-value field where one value already exists', function (): void {
+        $existing = Post::factory()->create();
+        storeLinkValueForPost($existing, $this->linkField, ['taken.com']);
+
+        $queries = 0;
+        DB::listen(function ($query) use (&$queries): void {
+            if (str_contains($query->sql, 'custom_field_values')) {
+                $queries++;
+            }
+        });
+
+        $rule = new UniqueCustomFieldValue($this->linkField);
+        $errors = [];
+
+        $rule->validate(
+            'custom_fields.domains',
+            ['fresh.com', 'another.com', 'taken.com', 'more.com', 'last.com'],
+            function (string $message) use (&$errors): void {
+                $errors[] = $message;
+            }
+        );
+
+        expect($queries)->toBe(1);
         expect($errors)->not->toBeEmpty();
     });
 });

--- a/tests/Feature/Rules/UniqueCustomFieldValueTest.php
+++ b/tests/Feature/Rules/UniqueCustomFieldValueTest.php
@@ -383,52 +383,64 @@ describe('Non-scalar value handling', function (): void {
 
 describe('Query efficiency', function (): void {
     it('issues a single query when validating a multi-value link field with many values', function (): void {
-        $queries = 0;
-        DB::listen(function ($query) use (&$queries): void {
-            if (str_contains($query->sql, 'custom_field_values')) {
-                $queries++;
-            }
-        });
+        DB::flushQueryLog();
+        DB::enableQueryLog();
 
-        $rule = new UniqueCustomFieldValue($this->linkField);
-        $errors = [];
+        try {
+            $rule = new UniqueCustomFieldValue($this->linkField);
+            $errors = [];
 
-        $rule->validate(
-            'custom_fields.domains',
-            ['a.com', 'b.com', 'c.com', 'd.com', 'e.com'],
-            function (string $message) use (&$errors): void {
-                $errors[] = $message;
-            }
-        );
+            $rule->validate(
+                'custom_fields.domains',
+                ['a.com', 'b.com', 'c.com', 'd.com', 'e.com'],
+                function (string $message) use (&$errors): void {
+                    $errors[] = $message;
+                }
+            );
 
-        expect($queries)->toBe(1);
-        expect($errors)->toBeEmpty();
+            $queries = count(array_filter(
+                DB::getQueryLog(),
+                static fn (array $entry): bool => str_contains($entry['query'], 'custom_field_values'),
+            ));
+
+            expect($queries)->toBe(1);
+            expect($errors)->toBeEmpty();
+        } finally {
+            DB::disableQueryLog();
+            DB::flushQueryLog();
+        }
     });
 
     it('issues a single query when validating a multi-value field where one value already exists', function (): void {
         $existing = Post::factory()->create();
         storeLinkValueForPost($existing, $this->linkField, ['taken.com']);
 
-        $queries = 0;
-        DB::listen(function ($query) use (&$queries): void {
-            if (str_contains($query->sql, 'custom_field_values')) {
-                $queries++;
-            }
-        });
+        DB::flushQueryLog();
+        DB::enableQueryLog();
 
-        $rule = new UniqueCustomFieldValue($this->linkField);
-        $errors = [];
+        try {
+            $rule = new UniqueCustomFieldValue($this->linkField);
+            $errors = [];
 
-        $rule->validate(
-            'custom_fields.domains',
-            ['fresh.com', 'another.com', 'taken.com', 'more.com', 'last.com'],
-            function (string $message) use (&$errors): void {
-                $errors[] = $message;
-            }
-        );
+            $rule->validate(
+                'custom_fields.domains',
+                ['fresh.com', 'another.com', 'taken.com', 'more.com', 'last.com'],
+                function (string $message) use (&$errors): void {
+                    $errors[] = $message;
+                }
+            );
 
-        expect($queries)->toBe(1);
-        expect($errors)->not->toBeEmpty();
+            $queries = count(array_filter(
+                DB::getQueryLog(),
+                static fn (array $entry): bool => str_contains($entry['query'], 'custom_field_values'),
+            ));
+
+            expect($queries)->toBe(1);
+            expect($errors)->not->toBeEmpty();
+        } finally {
+            DB::disableQueryLog();
+            DB::flushQueryLog();
+        }
     });
 });
 


### PR DESCRIPTION
## Summary

`UniqueCustomFieldValue` previously looped over submitted values and ran one `exists()` query per value. A multi-value link field with 20 entries fired 20 queries on every form save — a direct N+1.

This rewrites the rule to do a single batch query:
- **scalar columns** (`text_value`, etc.) — `whereIn($valueColumn, $values)`
- **`json_value`** — chained `orWhereJsonContains()` with a PHP-side intersection against the stored arrays

Regardless of how many values are submitted, the rule now fires exactly one query against `custom_field_values`. Error semantics are preserved: we still fail with the first colliding value and use the original (pre-normalization) value in the message.

Inspired by [Daryl Legion's post on validating array inputs in Laravel without N+1](https://daryllegion.com/validating-array-inputs-in-laravel-without-the-n-plus-1).

## Test plan

- [x] New regression tests using `DB::listen` assert exactly 1 query against `custom_field_values` when validating a 5-value link field — both the all-unique case and the one-taken case
- [x] All 24 existing tests in `tests/Feature/Rules/UniqueCustomFieldValueTest.php` still pass (link + text field via Livewire, edit-vs-create, morph alias resolution, non-scalar values, protocol normalization)
- [x] `vendor/bin/pint` clean
- [x] `vendor/bin/phpstan` clean on the changed files
- [x] Full suite run: 7 failing tests pre-exist on `3.x` (unrelated `Integration/Resources/Pages` tests) — verified by stashing the change and re-running

## Impact

No behavior change from a user perspective. This is purely a query-count reduction: `O(n)` → `O(1)` queries per validated field, where `n` is the number of submitted values.