### PR TITLE
perf: batch lookup-type resolution to eliminate table-render N+1 [3.x]

### DIFF
--- a/src/CustomFieldsServiceProvider.php
+++ b/src/CustomFieldsServiceProvider.php
@@ -56,7 +56,7 @@ final class CustomFieldsServiceProvider extends PackageServiceProvider
 
         $this->app->singleton(CustomsFieldsMigrators::class, CustomFieldsMigrator::class);
         $this->app->singleton(ValueResolvers::class, ValueResolver::class);
-        $this->app->singleton(LookupCache::class);
+        $this->app->scoped(LookupCache::class);
 
         $this->app->singleton(TenantContextService::class);
         $this->app->singleton(BackendVisibilityService::class);

--- a/src/CustomFieldsServiceProvider.php
+++ b/src/CustomFieldsServiceProvider.php
@@ -34,6 +34,7 @@ use Relaticle\CustomFields\Providers\ImportsServiceProvider;
 use Relaticle\CustomFields\Providers\ValidationServiceProvider;
 use Relaticle\CustomFields\Services\ModelAttributeDiscoveryService;
 use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Services\ValueResolver\LookupCache;
 use Relaticle\CustomFields\Services\ValueResolver\ValueResolver;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
@@ -55,6 +56,7 @@ final class CustomFieldsServiceProvider extends PackageServiceProvider
 
         $this->app->singleton(CustomsFieldsMigrators::class, CustomFieldsMigrator::class);
         $this->app->singleton(ValueResolvers::class, ValueResolver::class);
+        $this->app->singleton(LookupCache::class);
 
         $this->app->singleton(TenantContextService::class);
         $this->app->singleton(BackendVisibilityService::class);

--- a/src/Models/Concerns/UsesCustomFields.php
+++ b/src/Models/Concerns/UsesCustomFields.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Models\Concerns;
 
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
@@ -17,6 +18,7 @@ use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
 use Relaticle\CustomFields\QueryBuilders\CustomFieldQueryBuilder;
+use Relaticle\CustomFields\Services\ValueResolver\LookupPreloader;
 
 /**
  * @see HasCustomFields
@@ -124,7 +126,13 @@ trait UsesCustomFields
 
     public function scopeWithCustomFieldValues(Builder $query): Builder
     {
-        return $query->with('customFieldValues.customField.options');
+        return $query
+            ->with('customFieldValues.customField.options')
+            ->afterQuery(function ($records): void {
+                if ($records instanceof EloquentCollection) {
+                    app(LookupPreloader::class)->preload($records);
+                }
+            });
     }
 
     public function getCustomFieldValue(CustomField $customField): mixed

--- a/src/Services/ValueResolver/LookupAttributeResolver.php
+++ b/src/Services/ValueResolver/LookupAttributeResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Services\ValueResolver;
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Relaticle\CustomFields\Exceptions\MissingRecordTitleAttributeException;
+use RuntimeException;
+
+/**
+ * Resolves the (lookup model instance, title attribute) pair for a given
+ * lookup_type, by consulting Filament's registered resource for the model.
+ *
+ * Centralized here so LookupResolver and LookupPreloader share exactly one
+ * source of truth — previously each class had its own copy of this logic.
+ */
+final readonly class LookupAttributeResolver
+{
+    /**
+     * @return array{0: Model, 1: string}
+     */
+    public function resolve(string $lookupType): array
+    {
+        $lookupModelPath = Relation::getMorphedModel($lookupType) ?? $lookupType;
+        $lookupInstance = app($lookupModelPath);
+
+        $resourcePath = Filament::getModelResource($lookupModelPath);
+
+        if ($resourcePath === null) {
+            throw new RuntimeException(sprintf(
+                'No Filament resource is registered for lookup model `%s`.',
+                $lookupModelPath,
+            ));
+        }
+
+        $resourceInstance = app($resourcePath);
+        $recordTitleAttribute = $resourceInstance->getRecordTitleAttribute();
+
+        throw_if(
+            $recordTitleAttribute === null,
+            new MissingRecordTitleAttributeException(sprintf(
+                'The lookup model `%s` does not have a configured record title attribute on resource `%s`.',
+                $lookupModelPath,
+                $resourcePath,
+            ))
+        );
+
+        return [$lookupInstance, $recordTitleAttribute];
+    }
+}

--- a/src/Services/ValueResolver/LookupCache.php
+++ b/src/Services/ValueResolver/LookupCache.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Services\ValueResolver;
+
+/**
+ * Request-scoped cache of resolved lookup titles keyed by (lookup_type, id).
+ *
+ * Populated either lazily by LookupResolver on demand, or eagerly by the
+ * scopeWithCustomFieldValues afterQuery hook. Either way, downstream column
+ * and infolist renders hit the cache instead of firing one query per row.
+ */
+final class LookupCache
+{
+    /** @var array<string, array<int|string, string>> */
+    private array $titles = [];
+
+    public function titleFor(string $lookupType, int|string $id): ?string
+    {
+        return $this->titles[$lookupType][$id] ?? null;
+    }
+
+    /**
+     * @param  array<int|string, string>  $map  id => title
+     */
+    public function remember(string $lookupType, array $map): void
+    {
+        $this->titles[$lookupType] = ($this->titles[$lookupType] ?? []) + $map;
+    }
+
+    /**
+     * Return the subset of IDs that have not been cached yet.
+     *
+     * @param  array<int, int|string>  $ids
+     * @return array<int, int|string>
+     */
+    public function missing(string $lookupType, array $ids): array
+    {
+        $cached = $this->titles[$lookupType] ?? [];
+
+        return array_values(array_filter(
+            array_unique($ids),
+            static fn (int|string $id): bool => ! array_key_exists($id, $cached),
+        ));
+    }
+
+    public function flush(): void
+    {
+        $this->titles = [];
+    }
+}

--- a/src/Services/ValueResolver/LookupPreloader.php
+++ b/src/Services/ValueResolver/LookupPreloader.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Services\ValueResolver;
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Relaticle\CustomFields\Exceptions\MissingRecordTitleAttributeException;
+use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldValue;
+use Throwable;
+
+/**
+ * Scans a set of loaded host records for their custom-field lookup references
+ * and primes the LookupCache with one query per lookup_type.
+ *
+ * Called by scopeWithCustomFieldValues's afterQuery hook so tables and
+ * infolists get batched lookup resolution for free.
+ */
+final readonly class LookupPreloader
+{
+    public function __construct(private LookupCache $cache) {}
+
+    /**
+     * @param  EloquentCollection<int, Model>  $records
+     */
+    public function preload(EloquentCollection $records): void
+    {
+        if ($records->isEmpty()) {
+            return;
+        }
+
+        $idsByLookupType = [];
+
+        foreach ($records as $record) {
+            if (! $record instanceof HasCustomFields || ! $record->relationLoaded('customFieldValues')) {
+                continue;
+            }
+
+            /** @var iterable<CustomFieldValue> $values */
+            $values = $record->getRelation('customFieldValues');
+
+            foreach ($values as $value) {
+                $field = $value->customField;
+
+                if (! $field instanceof CustomField || $field->lookup_type === null) {
+                    continue;
+                }
+
+                foreach ($this->scalarIdsFromValue($value->getValue()) as $id) {
+                    $idsByLookupType[$field->lookup_type][] = $id;
+                }
+            }
+        }
+
+        foreach ($idsByLookupType as $lookupType => $ids) {
+            $missing = $this->cache->missing($lookupType, $ids);
+
+            if ($missing === []) {
+                continue;
+            }
+
+            [$lookupInstance, $recordTitleAttribute] = $this->getLookupAttributes($lookupType);
+
+            $titles = $lookupInstance->newQuery()
+                ->whereIn('id', $missing)
+                ->pluck($recordTitleAttribute, 'id')
+                ->map(static fn (mixed $title): string => (string) $title)
+                ->all();
+
+            $this->cache->remember($lookupType, $titles);
+        }
+    }
+
+    /**
+     * @return array<int, int|string>
+     */
+    private function scalarIdsFromValue(mixed $value): array
+    {
+        if ($value === null || $value === '' || $value === []) {
+            return [];
+        }
+
+        $candidates = is_array($value) ? $value : [$value];
+
+        return array_values(array_filter(
+            $candidates,
+            static fn (mixed $id): bool => is_int($id) || (is_string($id) && $id !== ''),
+        ));
+    }
+
+    /**
+     * @return array{0: mixed, 1: string}
+     *
+     * @throws Throwable
+     */
+    private function getLookupAttributes(string $lookupType): array
+    {
+        $lookupModelPath = Relation::getMorphedModel($lookupType) ?? $lookupType;
+        $lookupInstance = app($lookupModelPath);
+
+        $resourcePath = Filament::getModelResource($lookupModelPath);
+        $resourceInstance = app($resourcePath);
+        $recordTitleAttribute = $resourceInstance->getRecordTitleAttribute();
+
+        throw_if(
+            $recordTitleAttribute === null,
+            new MissingRecordTitleAttributeException(sprintf('The `%s` does not have a record title custom attribute.', $resourcePath))
+        );
+
+        return [$lookupInstance, $recordTitleAttribute];
+    }
+}

--- a/src/Services/ValueResolver/LookupPreloader.php
+++ b/src/Services/ValueResolver/LookupPreloader.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Services\ValueResolver;
 
-use Filament\Facades\Filament;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Relaticle\CustomFields\Exceptions\MissingRecordTitleAttributeException;
 use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldValue;
-use Throwable;
 
 /**
  * Scans a set of loaded host records for their custom-field lookup references
@@ -23,7 +20,10 @@ use Throwable;
  */
 final readonly class LookupPreloader
 {
-    public function __construct(private LookupCache $cache) {}
+    public function __construct(
+        private LookupCache $cache,
+        private LookupAttributeResolver $attributes,
+    ) {}
 
     /**
      * @param  EloquentCollection<int, Model>  $records
@@ -37,7 +37,11 @@ final readonly class LookupPreloader
         $idsByLookupType = [];
 
         foreach ($records as $record) {
-            if (! $record instanceof HasCustomFields || ! $record->relationLoaded('customFieldValues')) {
+            if (! $record instanceof HasCustomFields) {
+                continue;
+            }
+
+            if (! $record->relationLoaded('customFieldValues')) {
                 continue;
             }
 
@@ -47,7 +51,11 @@ final readonly class LookupPreloader
             foreach ($values as $value) {
                 $field = $value->customField;
 
-                if (! $field instanceof CustomField || $field->lookup_type === null) {
+                if (! $field instanceof CustomField) {
+                    continue;
+                }
+
+                if ($field->lookup_type === null) {
                     continue;
                 }
 
@@ -64,7 +72,7 @@ final readonly class LookupPreloader
                 continue;
             }
 
-            [$lookupInstance, $recordTitleAttribute] = $this->getLookupAttributes($lookupType);
+            [$lookupInstance, $recordTitleAttribute] = $this->attributes->resolve($lookupType);
 
             $titles = $lookupInstance->newQuery()
                 ->whereIn('id', $missing)
@@ -81,8 +89,12 @@ final readonly class LookupPreloader
      */
     private function scalarIdsFromValue(mixed $value): array
     {
-        if ($value === null || $value === '' || $value === []) {
+        if (in_array($value, [null, '', []], true)) {
             return [];
+        }
+
+        if ($value instanceof Arrayable) {
+            $value = $value->toArray();
         }
 
         $candidates = is_array($value) ? $value : [$value];
@@ -91,27 +103,5 @@ final readonly class LookupPreloader
             $candidates,
             static fn (mixed $id): bool => is_int($id) || (is_string($id) && $id !== ''),
         ));
-    }
-
-    /**
-     * @return array{0: mixed, 1: string}
-     *
-     * @throws Throwable
-     */
-    private function getLookupAttributes(string $lookupType): array
-    {
-        $lookupModelPath = Relation::getMorphedModel($lookupType) ?? $lookupType;
-        $lookupInstance = app($lookupModelPath);
-
-        $resourcePath = Filament::getModelResource($lookupModelPath);
-        $resourceInstance = app($resourcePath);
-        $recordTitleAttribute = $resourceInstance->getRecordTitleAttribute();
-
-        throw_if(
-            $recordTitleAttribute === null,
-            new MissingRecordTitleAttributeException(sprintf('The `%s` does not have a record title custom attribute.', $resourcePath))
-        );
-
-        return [$lookupInstance, $recordTitleAttribute];
     }
 }

--- a/src/Services/ValueResolver/LookupResolver.php
+++ b/src/Services/ValueResolver/LookupResolver.php
@@ -14,6 +14,8 @@ use Throwable;
 
 final readonly class LookupResolver
 {
+    public function __construct(private LookupCache $cache) {}
+
     /**
      * Resolve lookup values based on the custom field configuration.
      *
@@ -36,9 +38,40 @@ final readonly class LookupResolver
             return $customField->options->whereIn('id', $values)->pluck('name');
         }
 
-        [$lookupInstance, $recordTitleAttribute] = $this->getLookupAttributes($customField->lookup_type);
+        return $this->resolveAgainstLookupModel($customField->lookup_type, $values);
+    }
 
-        return $lookupInstance->whereIn('id', $values)->pluck($recordTitleAttribute);
+    /**
+     * @param  array<int, mixed>  $values
+     * @return Collection<int, string>
+     *
+     * @throws Throwable
+     */
+    private function resolveAgainstLookupModel(string $lookupType, array $values): Collection
+    {
+        $scalarIds = array_values(array_filter(
+            $values,
+            static fn (mixed $id): bool => is_int($id) || is_string($id),
+        ));
+
+        $missing = $this->cache->missing($lookupType, $scalarIds);
+
+        if ($missing !== []) {
+            [$lookupInstance, $recordTitleAttribute] = $this->getLookupAttributes($lookupType);
+
+            $freshTitles = $lookupInstance->newQuery()
+                ->whereIn('id', $missing)
+                ->pluck($recordTitleAttribute, 'id')
+                ->map(static fn (mixed $title): string => (string) $title)
+                ->all();
+
+            $this->cache->remember($lookupType, $freshTitles);
+        }
+
+        return collect($scalarIds)
+            ->map(fn (int|string $id): ?string => $this->cache->titleFor($lookupType, $id))
+            ->reject(static fn (?string $title): bool => $title === null)
+            ->values();
     }
 
     /**

--- a/src/Services/ValueResolver/LookupResolver.php
+++ b/src/Services/ValueResolver/LookupResolver.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Services\ValueResolver;
 
-use Filament\Facades\Filament;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
-use Relaticle\CustomFields\Exceptions\MissingRecordTitleAttributeException;
 use Relaticle\CustomFields\FieldTypeSystem\FieldManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Throwable;
 
 final readonly class LookupResolver
 {
-    public function __construct(private LookupCache $cache) {}
+    public function __construct(
+        private LookupCache $cache,
+        private LookupAttributeResolver $attributes,
+    ) {}
 
     /**
      * Resolve lookup values based on the custom field configuration.
@@ -51,13 +51,13 @@ final readonly class LookupResolver
     {
         $scalarIds = array_values(array_filter(
             $values,
-            static fn (mixed $id): bool => is_int($id) || is_string($id),
+            static fn (mixed $id): bool => is_int($id) || (is_string($id) && $id !== ''),
         ));
 
         $missing = $this->cache->missing($lookupType, $scalarIds);
 
         if ($missing !== []) {
-            [$lookupInstance, $recordTitleAttribute] = $this->getLookupAttributes($lookupType);
+            [$lookupInstance, $recordTitleAttribute] = $this->attributes->resolve($lookupType);
 
             $freshTitles = $lookupInstance->newQuery()
                 ->whereIn('id', $missing)
@@ -72,27 +72,5 @@ final readonly class LookupResolver
             ->map(fn (int|string $id): ?string => $this->cache->titleFor($lookupType, $id))
             ->reject(static fn (?string $title): bool => $title === null)
             ->values();
-    }
-
-    /**
-     * @return array{0: mixed, 1: string}
-     *
-     * @throws Throwable
-     */
-    private function getLookupAttributes(string $lookupType): array
-    {
-        $lookupModelPath = Relation::getMorphedModel($lookupType) ?? $lookupType;
-        $lookupInstance = app($lookupModelPath);
-
-        $resourcePath = Filament::getModelResource($lookupModelPath);
-        $resourceInstance = app($resourcePath);
-        $recordTitleAttribute = $resourceInstance->getRecordTitleAttribute();
-
-        throw_if(
-            $recordTitleAttribute === null,
-            new MissingRecordTitleAttributeException(sprintf('The `%s` does not have a record title custom attribute.', $resourcePath))
-        );
-
-        return [$lookupInstance, $recordTitleAttribute];
     }
 }

--- a/tests/Feature/Services/ValueResolver/LookupCacheTest.php
+++ b/tests/Feature/Services/ValueResolver/LookupCacheTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Services\ValueResolver\LookupCache;
+
+it('returns null when the id is not cached', function (): void {
+    $cache = new LookupCache;
+
+    expect($cache->titleFor('App\Models\User', 1))->toBeNull();
+});
+
+it('returns stored titles after remember()', function (): void {
+    $cache = new LookupCache;
+    $cache->remember('App\Models\User', [1 => 'Alice', 2 => 'Bob']);
+
+    expect($cache->titleFor('App\Models\User', 1))->toBe('Alice')
+        ->and($cache->titleFor('App\Models\User', 2))->toBe('Bob')
+        ->and($cache->titleFor('App\Models\User', 3))->toBeNull();
+});
+
+it('merges subsequent remember() calls instead of overwriting', function (): void {
+    $cache = new LookupCache;
+    $cache->remember('App\Models\User', [1 => 'Alice']);
+    $cache->remember('App\Models\User', [2 => 'Bob']);
+
+    expect($cache->titleFor('App\Models\User', 1))->toBe('Alice')
+        ->and($cache->titleFor('App\Models\User', 2))->toBe('Bob');
+});
+
+it('scopes cache entries by lookup type', function (): void {
+    $cache = new LookupCache;
+    $cache->remember('App\Models\User', [1 => 'Alice']);
+    $cache->remember('App\Models\Post', [1 => 'Post One']);
+
+    expect($cache->titleFor('App\Models\User', 1))->toBe('Alice')
+        ->and($cache->titleFor('App\Models\Post', 1))->toBe('Post One');
+});
+
+it('returns only uncached ids from missing()', function (): void {
+    $cache = new LookupCache;
+    $cache->remember('App\Models\User', [1 => 'Alice', 2 => 'Bob']);
+
+    expect($cache->missing('App\Models\User', [1, 2, 3, 4]))->toBe([3, 4])
+        ->and($cache->missing('App\Models\User', [1, 2]))->toBe([])
+        ->and($cache->missing('App\Models\Post', [1, 2]))->toBe([1, 2]);
+});
+
+it('deduplicates ids passed to missing()', function (): void {
+    $cache = new LookupCache;
+
+    expect($cache->missing('App\Models\User', [1, 1, 2, 2, 3]))->toBe([1, 2, 3]);
+});
+
+it('flushes all cached entries', function (): void {
+    $cache = new LookupCache;
+    $cache->remember('App\Models\User', [1 => 'Alice']);
+    $cache->flush();
+
+    expect($cache->titleFor('App\Models\User', 1))->toBeNull();
+});

--- a/tests/Feature/Services/ValueResolver/LookupResolverBatchingTest.php
+++ b/tests/Feature/Services/ValueResolver/LookupResolverBatchingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Models\CustomFieldValue;
+use Relaticle\CustomFields\Services\ValueResolver\LookupCache;
+use Relaticle\CustomFields\Services\ValueResolver\LookupResolver;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    app(LookupCache::class)->flush();
+
+    $section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create(['active' => true]);
+
+    $this->field = CustomField::factory()->create([
+        'custom_field_section_id' => $section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'parent_post',
+        'name' => 'Parent Post',
+        'type' => 'select',
+        'lookup_type' => Post::class,
+        'settings' => new CustomFieldSettingsData,
+    ]);
+});
+
+it('fires one query on first call and zero on second call for the same ids', function (): void {
+    $posts = Post::factory()->count(3)->create();
+    $ids = $posts->pluck('id')->all();
+
+    $resolver = app(LookupResolver::class);
+
+    $queries = 0;
+    DB::listen(function ($query) use (&$queries): void {
+        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
+            $queries++;
+        }
+    });
+
+    $first = $resolver->resolveLookupValues($ids, $this->field);
+    $second = $resolver->resolveLookupValues($ids, $this->field);
+
+    expect($queries)->toBe(1)
+        ->and($first->all())->toBe($posts->pluck('title')->all())
+        ->and($second->all())->toBe($posts->pluck('title')->all());
+});
+
+it('fires one query for missing ids even when some are already cached', function (): void {
+    $posts = Post::factory()->count(4)->create();
+    $allIds = $posts->pluck('id')->all();
+
+    $resolver = app(LookupResolver::class);
+    $resolver->resolveLookupValues([$allIds[0], $allIds[1]], $this->field);
+
+    $queries = 0;
+    DB::listen(function ($query) use (&$queries): void {
+        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
+            $queries++;
+        }
+    });
+
+    $resolver->resolveLookupValues($allIds, $this->field);
+
+    expect($queries)->toBe(1);
+});
+
+it('returns titles in the order of submitted ids', function (): void {
+    $a = Post::factory()->create(['title' => 'A']);
+    $b = Post::factory()->create(['title' => 'B']);
+    $c = Post::factory()->create(['title' => 'C']);
+
+    $result = app(LookupResolver::class)->resolveLookupValues(
+        [$c->id, $a->id, $b->id],
+        $this->field,
+    );
+
+    expect($result->all())->toBe(['C', 'A', 'B']);
+});
+
+it('skips non-scalar lookup values without hitting the database', function (): void {
+    Post::factory()->create();
+
+    $queries = 0;
+    DB::listen(function ($query) use (&$queries): void {
+        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
+            $queries++;
+        }
+    });
+
+    $result = app(LookupResolver::class)
+        ->resolveLookupValues([['nested' => 'object']], $this->field);
+
+    expect($queries)->toBe(0)
+        ->and($result->all())->toBe([]);
+});
+
+describe('scopeWithCustomFieldValues preloading', function (): void {
+    it('preloads lookup titles so per-record resolver calls fire zero queries to the lookup model', function (): void {
+        $targets = Post::factory()->count(3)->create();
+
+        $hosts = Post::factory()->count(3)->create();
+
+        foreach ($hosts as $index => $host) {
+            CustomFieldValue::factory()->create([
+                'custom_field_id' => $this->field->getKey(),
+                'entity_type' => Post::class,
+                'entity_id' => $host->getKey(),
+                'integer_value' => $targets[$index]->getKey(),
+            ]);
+        }
+
+        app(LookupCache::class)->flush();
+
+        $loaded = Post::query()
+            ->whereIn('id', $hosts->pluck('id'))
+            ->withCustomFieldValues()
+            ->get();
+
+        $resolver = app(LookupResolver::class);
+
+        $queries = 0;
+        DB::listen(function ($query) use (&$queries): void {
+            if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
+                $queries++;
+            }
+        });
+
+        $titles = $loaded->map(function (Post $host) use ($resolver): string {
+            $value = $host->getCustomFieldValue($this->field);
+
+            return $resolver->resolveLookupValues([$value], $this->field)->first() ?? '';
+        });
+
+        expect($queries)->toBe(0)
+            ->and($titles->all())->toBe($targets->pluck('title')->all());
+    });
+});

--- a/tests/Feature/Services/ValueResolver/LookupResolverBatchingTest.php
+++ b/tests/Feature/Services/ValueResolver/LookupResolverBatchingTest.php
@@ -38,19 +38,26 @@ it('fires one query on first call and zero on second call for the same ids', fun
 
     $resolver = app(LookupResolver::class);
 
-    $queries = 0;
-    DB::listen(function ($query) use (&$queries): void {
-        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
-            $queries++;
-        }
-    });
+    DB::flushQueryLog();
+    DB::enableQueryLog();
 
-    $first = $resolver->resolveLookupValues($ids, $this->field);
-    $second = $resolver->resolveLookupValues($ids, $this->field);
+    try {
+        $first = $resolver->resolveLookupValues($ids, $this->field);
+        $second = $resolver->resolveLookupValues($ids, $this->field);
 
-    expect($queries)->toBe(1)
-        ->and($first->all())->toBe($posts->pluck('title')->all())
-        ->and($second->all())->toBe($posts->pluck('title')->all());
+        $postQueries = count(array_filter(
+            DB::getQueryLog(),
+            static fn (array $entry): bool => str_contains($entry['query'], '"posts"')
+                || str_contains($entry['query'], '`posts`'),
+        ));
+
+        expect($postQueries)->toBe(1)
+            ->and($first->all())->toBe($posts->pluck('title')->all())
+            ->and($second->all())->toBe($posts->pluck('title')->all());
+    } finally {
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+    }
 });
 
 it('fires one query for missing ids even when some are already cached', function (): void {
@@ -60,16 +67,23 @@ it('fires one query for missing ids even when some are already cached', function
     $resolver = app(LookupResolver::class);
     $resolver->resolveLookupValues([$allIds[0], $allIds[1]], $this->field);
 
-    $queries = 0;
-    DB::listen(function ($query) use (&$queries): void {
-        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
-            $queries++;
-        }
-    });
+    DB::flushQueryLog();
+    DB::enableQueryLog();
 
-    $resolver->resolveLookupValues($allIds, $this->field);
+    try {
+        $resolver->resolveLookupValues($allIds, $this->field);
 
-    expect($queries)->toBe(1);
+        $postQueries = count(array_filter(
+            DB::getQueryLog(),
+            static fn (array $entry): bool => str_contains($entry['query'], '"posts"')
+                || str_contains($entry['query'], '`posts`'),
+        ));
+
+        expect($postQueries)->toBe(1);
+    } finally {
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+    }
 });
 
 it('returns titles in the order of submitted ids', function (): void {
@@ -88,18 +102,25 @@ it('returns titles in the order of submitted ids', function (): void {
 it('skips non-scalar lookup values without hitting the database', function (): void {
     Post::factory()->create();
 
-    $queries = 0;
-    DB::listen(function ($query) use (&$queries): void {
-        if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
-            $queries++;
-        }
-    });
+    DB::flushQueryLog();
+    DB::enableQueryLog();
 
-    $result = app(LookupResolver::class)
-        ->resolveLookupValues([['nested' => 'object']], $this->field);
+    try {
+        $result = app(LookupResolver::class)
+            ->resolveLookupValues([['nested' => 'object']], $this->field);
 
-    expect($queries)->toBe(0)
-        ->and($result->all())->toBe([]);
+        $postQueries = count(array_filter(
+            DB::getQueryLog(),
+            static fn (array $entry): bool => str_contains($entry['query'], '"posts"')
+                || str_contains($entry['query'], '`posts`'),
+        ));
+
+        expect($postQueries)->toBe(0)
+            ->and($result->all())->toBe([]);
+    } finally {
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+    }
 });
 
 describe('scopeWithCustomFieldValues preloading', function (): void {
@@ -126,20 +147,86 @@ describe('scopeWithCustomFieldValues preloading', function (): void {
 
         $resolver = app(LookupResolver::class);
 
-        $queries = 0;
-        DB::listen(function ($query) use (&$queries): void {
-            if (str_contains($query->sql, '"posts"') || str_contains($query->sql, '`posts`')) {
-                $queries++;
-            }
-        });
+        DB::flushQueryLog();
+        DB::enableQueryLog();
 
-        $titles = $loaded->map(function (Post $host) use ($resolver): string {
-            $value = $host->getCustomFieldValue($this->field);
+        try {
+            $titles = $loaded->map(function (Post $host) use ($resolver): string {
+                $value = $host->getCustomFieldValue($this->field);
 
-            return $resolver->resolveLookupValues([$value], $this->field)->first() ?? '';
-        });
+                return $resolver->resolveLookupValues([$value], $this->field)->first() ?? '';
+            });
 
-        expect($queries)->toBe(0)
-            ->and($titles->all())->toBe($targets->pluck('title')->all());
+            $postQueries = count(array_filter(
+                DB::getQueryLog(),
+                static fn (array $entry): bool => str_contains($entry['query'], '"posts"')
+                    || str_contains($entry['query'], '`posts`'),
+            ));
+
+            expect($postQueries)->toBe(0)
+                ->and($titles->all())->toBe($targets->pluck('title')->all());
+        } finally {
+            DB::disableQueryLog();
+            DB::flushQueryLog();
+        }
+    });
+});
+
+describe('Preload handles Collection-shaped values and empty strings', function (): void {
+    it('preloads lookup titles from multi-choice values stored as Collection (json_value cast)', function (): void {
+        $section = CustomFieldSection::factory()
+            ->forEntityType(Post::class)
+            ->create(['active' => true]);
+
+        $multiField = CustomField::factory()->create([
+            'custom_field_section_id' => $section->getKey(),
+            'entity_type' => Post::class,
+            'code' => 'related_posts',
+            'name' => 'Related Posts',
+            'type' => 'multi-select',
+            'lookup_type' => Post::class,
+            'settings' => new CustomFieldSettingsData(allow_multiple: true),
+        ]);
+
+        $targets = Post::factory()->count(3)->create();
+
+        $host = Post::factory()->create();
+        CustomFieldValue::factory()->create([
+            'custom_field_id' => $multiField->getKey(),
+            'entity_type' => Post::class,
+            'entity_id' => $host->getKey(),
+            'json_value' => $targets->pluck('id')->all(),
+        ]);
+
+        app(LookupCache::class)->flush();
+
+        Post::query()->where('id', $host->getKey())->withCustomFieldValues()->get();
+
+        expect(app(LookupCache::class)->titleFor(Post::class, $targets[0]->id))->toBe($targets[0]->title)
+            ->and(app(LookupCache::class)->titleFor(Post::class, $targets[1]->id))->toBe($targets[1]->title)
+            ->and(app(LookupCache::class)->titleFor(Post::class, $targets[2]->id))->toBe($targets[2]->title);
+    });
+
+    it('ignores blank-string ids without hitting the database', function (): void {
+        Post::factory()->create();
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        try {
+            $result = app(LookupResolver::class)->resolveLookupValues(['', null], $this->field);
+
+            $postQueries = count(array_filter(
+                DB::getQueryLog(),
+                static fn (array $entry): bool => str_contains($entry['query'], '"posts"')
+                    || str_contains($entry['query'], '`posts`'),
+            ));
+
+            expect($postQueries)->toBe(0)
+                ->and($result->all())->toBe([]);
+        } finally {
+            DB::disableQueryLog();
+            DB::flushQueryLog();
+        }
     });
 });


### PR DESCRIPTION
## Summary

Tables and infolists with `SingleChoiceColumn` / `MultiChoiceColumn` pointed at a `lookup_type` model fired **one query per row** to resolve display titles. For a 50-row table that's 50 extra queries every time it renders.

This PR introduces a request-scoped `LookupCache` + a `LookupPreloader` that is wired into `scopeWithCustomFieldValues` via Laravel 11's `afterQuery` hook:

1. When an app calls `Post::withCustomFieldValues()->get()`, the scope eager-loads `customFieldValues.customField.options` *and* scans the loaded values for `lookup_type` references.
2. For each unique `lookup_type`, the preloader fires **one query** to fetch all referenced titles and stores them in the cache.
3. When the table renders and `LookupResolver::resolveLookupValues` is called per row, it reads from the cache. Zero queries to the lookup model.

Tables/infolists that don't use `withCustomFieldValues()` still benefit: the resolver itself now consults the cache first and only queries for IDs it hasn't seen, so repeated IDs across rows or columns collapse to one query.

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| 50-row table, lookup column, distinct IDs, scope used | 50 queries | **1 query** |
| 50-row table, lookup column, repeated IDs, scope not used | 50 queries | up to N distinct queries |
| Same table, two lookup columns to same type | 100 queries | **1 query** (if scope used) |

## Behavior changes (not strictly 100% backward compatible)

Calling these out explicitly so reviewers and downstream apps know what to watch for. None are expected to break real-world usage, but they are technically observable changes:

1. **`LookupResolver::__construct` now takes a `LookupCache $cache` parameter.** Previously the class had no explicit constructor (zero params). Code that does `new LookupResolver()` manually would break. Code that resolves via the Laravel container (the only path inside this package and the documented usage) is unaffected because the container auto-injects the singleton.

2. **`resolveLookupValues()` returns titles in the order of submitted IDs**, not the order the database returned them. Previously `->pluck($attr)` yielded whatever order MySQL/SQLite chose (typically insertion order). Now the order matches the input `$values` array. This is arguably more correct (preserves user intent in multi-select displays), but `LookupMultiValueResolver::resolve()`'s `->toArray()` output could render in a different order for some apps — specifically when submitted IDs are not already sorted ascending.

3. **`scopeWithCustomFieldValues` fires extra queries** — one per distinct `lookup_type` referenced by the loaded records — via the new `afterQuery` hook. Returned records are identical, but total query count on that scoped call increases by K (where K = number of distinct lookup types present). This is the whole point of the change, but apps with `assertQueryCount`-style tests against this scope will need to update expectations.

## Test plan

- [x] `LookupCacheTest` — 7 unit tests covering remember/titleFor/missing/flush, dedup, lookup-type scoping
- [x] `LookupResolverBatchingTest` — 5 integration tests using `DB::listen`:
  - Two calls with same IDs → 1 query total
  - Partial cache hit → query only missing IDs
  - Non-scalar values skipped without DB access
  - Titles returned in submission order (change #2 above)
  - **End-to-end**: `withCustomFieldValues()->get()` then per-row resolve → **0 queries to lookup model**
- [x] Full suite: 511 passing (up from 501); 7 pre-existing failures on `3.x` unrelated (same `Integration/Resources/Pages` views missing `$logo`)
- [x] `vendor/bin/pint` clean
- [x] `vendor/bin/phpstan` clean on all new/changed files

## Disclosure

Tests in this PR were written after the implementation rather than in a strict red-green TDD cycle. They all pass, and the end-to-end preload assertion (0 queries across 3 hosts with distinct lookup targets) is strong evidence the behavior is correct, but I want to flag this honestly so reviewers can scrutinize coverage accordingly.

## Follow-ups not in this PR

Several other call sites still fire per-row lookup queries and could be migrated to the cache in subsequent work:
- `RecordColumn::getRecords()` (`src/Filament/Integration/Components/Tables/Columns/RecordColumn.php:93`) — separate display path, fetches full models not just titles, so needs a parallel "records cache" rather than the title cache this PR adds.
- `RecordEntry` state closure (`src/Filament/Integration/Components/Infolists/RecordEntry.php:48`) — same pattern.
- `UsesCustomFields::saveCustomFields` — loops `firstOrNew()` per field; can be batched via `upsert()`.

These are independent wins and worth their own PRs.