### PR TITLE
fix: prevent duplicate resource table() invocation in InteractsWithCustomFields [3.x]

### DIFF
--- a/src/Concerns/InteractsWithCustomFields.php
+++ b/src/Concerns/InteractsWithCustomFields.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Concerns;
 
-use Exception;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Container\BindingResolutionException;
@@ -20,20 +19,14 @@ trait InteractsWithCustomFields
     {
         $model = $this instanceof RelationManager ? $this->getRelationship()->getModel()::class : $this->getModel();
 
-        try {
-            $table = static::getResource()::table($table);
-        } catch (Exception) {
-            $table = parent::table($table);
-        }
-
-        // Use the new builder API
         $modelInstance = new $model;
         $columns = CustomFields::table()->forModel($modelInstance)->columns()->toArray();
         $filters = CustomFields::table()->forModel($modelInstance)->filters()->toArray();
 
-        return $table->modifyQueryUsing(function (Builder $query): void {
-            $query->with('customFieldValues.customField');
-        })
+        return $table
+            ->modifyQueryUsing(function (Builder $query): void {
+                $query->with('customFieldValues.customField');
+            })
             ->deferFilters(false)
             ->pushColumns($columns)
             ->pushFilters($filters);

--- a/tests/Feature/Integration/Resources/Pages/ListRecordsTest.php
+++ b/tests/Feature/Integration/Resources/Pages/ListRecordsTest.php
@@ -32,6 +32,14 @@ describe('Page Rendering and Authorization', function (): void {
             ->assertSuccessful();
     });
 
+    it('invokes resource table() only once when InteractsWithCustomFields is used', function (): void {
+        PostResource::$tableCallCount = 0;
+
+        livewire(ListPosts::class)->assertSuccessful();
+
+        expect(PostResource::$tableCallCount)->toBe(1);
+    });
+
     it('is forbidden for users without permission', function (): void {
         // Arrange
         $unauthorizedUser = User::factory()->create();

--- a/tests/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/Fixtures/Resources/Posts/PostResource.php
@@ -34,6 +34,8 @@ class PostResource extends Resource
 
     protected static int $globalSearchResultsLimit = 3;
 
+    public static int $tableCallCount = 0;
+
     public static function form(Schema $schema): Schema
     {
         return $schema
@@ -54,6 +56,8 @@ class PostResource extends Resource
 
     public static function table(Table $table): Table
     {
+        static::$tableCallCount++;
+
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('title')


### PR DESCRIPTION
## Summary

`InteractsWithCustomFields::table()` invoked the resource's `table()` method a second time after Filament's `ListRecords::makeTable()` had already applied it via `configureTable()`. Because Filament does not deduplicate `queryScopes`, every `modifyQueryUsing` closure registered in the resource ran twice — duplicating `withExists`, `withSum`, `whereNull`, and similar clauses in the generated SQL and roughly doubling list-page query cost. Filters, columns, and actions were also registered twice (though idempotent by name, so no visible UI duplication).

## Root cause

- `Filament/Resources/Pages/ListRecords.php` — `makeTable()` calls `static::getResource()::configureTable($table)`.
- `Filament/Resources/Resource.php` — `configureTable()` invokes `static::table($table)` on the resource.
- `Filament/Tables/Concerns/InteractsWithTable.php` — Livewire then calls `$this->table($this->makeTable())`, which resolves to the trait.
- The trait previously called `static::getResource()::table($table)` a second time, re-running every resource-defined scope.
- `Filament/Tables/Table/Concerns/HasQuery.php` — `modifyQueryUsing` appends to `queryScopes` without deduplication.

For `RelationManager`, the old `try/catch` fell through to `parent::table($table)` (a no-op), so relation managers are unaffected by the change.

## Change

Remove the redundant `static::getResource()::table($table)` call. The `$table` argument already carries the resource's configuration when the trait receives it, so the trait now layers the custom-field columns, filters, and `customFieldValues` eager load on top of the already-configured table.

## Test plan

- [x] Added regression test `it invokes resource table() only once when InteractsWithCustomFields is used` — asserts the resource's `table()` method is called exactly once.
- [x] Regression test fails on `3.x` before this change (count is 2) and passes after.
- [x] Pint clean, PHPStan clean.
- [x] Full `ListRecordsTest` Pest run introduces no new failures (2 pre-existing `$logo` view failures unrelated to this fix remain unchanged).

## Credit

Reported by Kenneth Sese with precise diagnosis and reproducer.
