### PR TITLE
fix(i18n): restore validation messages masked by duplicate top-level lang key [3.x]

### DIFF
--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -353,6 +353,17 @@ return [
         'parameter_missing' => 'This validation rule requires exactly :count parameter(s). Please add all required parameters.',
         'invalid_rule_for_field_type' => 'The selected rule is not valid for this field type.',
         'unique_value' => 'The value ":value" is already assigned to another record.',
+        'min_length' => 'Minimum Length',
+        'max_length' => 'Maximum Length',
+        'min_value' => 'Minimum Value',
+        'max_value' => 'Maximum Value',
+        'min_selections' => 'Minimum Selections',
+        'max_selections' => 'Maximum Selections',
+        'max_file_size_kb' => 'Maximum File Size (KB)',
+        'accepted_file_types' => 'Accepted File Types',
+        'accepted_file_types_placeholder' => 'e.g. image/png, application/pdf',
+        'decimal_places' => 'Decimal Places',
+        'decimal_places_placeholder' => 'Enter a value between 0 and 4',
     ],
 
     'empty_states' => [
@@ -539,20 +550,6 @@ return [
         'markdown_editor' => 'Markdown Editor',
         'select' => 'Select',
         'tags_input' => 'Tags Input',
-    ],
-
-    'validation' => [
-        'min_length' => 'Minimum Length',
-        'max_length' => 'Maximum Length',
-        'min_value' => 'Minimum Value',
-        'max_value' => 'Maximum Value',
-        'min_selections' => 'Minimum Selections',
-        'max_selections' => 'Maximum Selections',
-        'max_file_size_kb' => 'Maximum File Size (KB)',
-        'accepted_file_types' => 'Accepted File Types',
-        'accepted_file_types_placeholder' => 'e.g. image/png, application/pdf',
-        'decimal_places' => 'Decimal Places',
-        'decimal_places_placeholder' => 'Enter a value between 0 and 4',
     ],
 
     'currency' => [

--- a/tests/Feature/Translations/LanguageKeysTest.php
+++ b/tests/Feature/Translations/LanguageKeysTest.php
@@ -98,3 +98,16 @@ it('preserves backwards-compatible description_position keys', function (string 
     'field.form.description_position_options.below',
     'field.form.description_position_options.above',
 ]);
+
+it('has no duplicate top-level keys in any language file (PHP silently drops earlier definitions)', function (string $path): void {
+    $contents = file_get_contents($path);
+    preg_match_all("/^    '([^']+)' =>/m", $contents, $matches);
+
+    $duplicates = array_filter(array_count_values($matches[1]), fn (int $count): bool => $count > 1);
+
+    expect($duplicates)->toBe([], sprintf(
+        'Duplicate top-level key(s) in %s: %s. PHP keeps only the last definition, masking earlier values.',
+        basename(dirname($path)).'/'.basename($path),
+        implode(', ', array_keys($duplicates)),
+    ));
+})->with(fn () => glob(__DIR__.'/../../../resources/lang/*/*.php'));


### PR DESCRIPTION
## Summary

`resources/lang/en/custom-fields.php` had two top-level `'validation' => [...]` blocks at lines 131 and 544. PHP silently keeps only the **last** occurrence of duplicate array keys, so the 11-key block at the bottom wiped out the 200+ key block above it — including `'unique_value'` (line 355).

User-visible symptom on `Edit Order` (and any model using `unique` custom-field validation):

```
custom-fields::custom-fields.validation.unique_value
```

…was rendered verbatim instead of the translated message, because `__()` couldn't resolve the key.

## Changes

- **`resources/lang/en/custom-fields.php`** — merged the 11 capability labels (`min_length`, `max_length`, `min_value`, `max_value`, `min_selections`, `max_selections`, `max_file_size_kb`, `accepted_file_types`, `accepted_file_types_placeholder`, `decimal_places`, `decimal_places_placeholder`) into the canonical `validation` block at line 131, then removed the duplicate block. No keys lost.
- **`tests/Feature/Translations/LanguageKeysTest.php`** — added a structural test that scans every `resources/lang/<locale>/*.php` for duplicate top-level keys and asserts none exist. Existing key-existence tests didn't catch this because none of the listed keys happened to live in the masked block.

## Test plan

- [x] `vendor/bin/pest tests/Feature/Translations/` — 131 passed
- [x] Manually injected a single-quoted duplicate `'validation'` block; new test fails with: `Duplicate top-level key(s) in en/custom-fields.php: validation. PHP keeps only the last definition, masking earlier values.`
- [x] Removed the injection; test passes.
- [x] In-browser verification at `/shop/orders/3/edit` (filament-demo): entering a duplicate email in an `Email Unique` custom field now displays `The value "armen@gmail.com" is already assigned to another record.` instead of the raw key.
- [x] `vendor/bin/pint --dirty` — pass