### PR TITLE
fix: prevent self-clear of field_code in visibility condition repeater

### DIFF
--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -124,7 +124,7 @@ final class VisibilityComponent extends Component
             ->options(fn (Get $get): array => $this->getAvailableFields($get))
             ->required()
             ->live()
-            ->afterStateUpdated(fn (Get $get, Set $set) => $this->resetConditionValues($get, $set))
+            ->afterStateUpdated(fn (Get $get, Set $set) => $this->resetValuesAndOperator($get, $set))
             ->columnSpan($fieldCodeSpan);
 
         $schema[] = Select::make('operator')
@@ -465,6 +465,12 @@ final class VisibilityComponent extends Component
         if ($get instanceof Get) {
             $set('operator', array_key_first($this->getCompatibleOperators($get)));
         }
+    }
+
+    private function resetValuesAndOperator(Get $get, Set $set): void
+    {
+        $this->clearAllValueFields($set);
+        $set('operator', array_key_first($this->getCompatibleOperators($get)));
     }
 
     private function clearAllValueFields(Set $set): void


### PR DESCRIPTION
## Summary

Fixes a bug in the visibility conditions UI for custom fields where selecting a value in the **Field** (`field_code`) Select inside the conditions Repeater immediately clears the selection.

## Reproduction

1. Open Custom Fields management page.
2. Edit any field (or section).
3. Set Visibility mode to anything that requires conditions (e.g. *Visible when*).
4. Inside the conditions Repeater, pick a value in the **Field** select.
5. The select clears itself instantly. The user cannot save a working condition.

The bug also affects the `ConditionSource::ModelAttribute` source where the dropdown of model attributes appears, gets selected, and disappears.

## Root cause

`src/Filament/Management/Forms/Components/VisibilityComponent.php` line 127:

```php
$schema[] = Select::make('field_code')
    ...
    ->afterStateUpdated(fn (Get $get, Set $set) => $this->resetConditionValues($get, $set))
```

`resetConditionValues()` is shared with the `source` Select and contains:

```php
private function resetConditionValues(?Get $get, Set $set): void
{
    $this->clearAllValueFields($set);
    $set('field_code', null); // wipes the user's freshly selected value
    ...
}
```

So when the user picks `field_code`, Filament fires `afterStateUpdated`, which sets `field_code` back to `null`.

## Fix

Split the reset path:

- `resetConditionValues()` keeps its current behavior and remains the callback for the `source` Select (it should clear `field_code` when the source switches).
- New `resetValuesAndOperator()` is used by the `field_code` Select. It only clears the value fields and resets the operator to the first compatible option. It does not touch `field_code`.

## Verification

- Existing test suite passes (654 passed).
- Manual reproduction confirmed before / after.