### PR TITLE
fix(phpstan): use covariant Model in Scope apply signatures for laravel 13 [3.x]

### DIFF
--- a/src/Models/Scopes/ActivableScope.php
+++ b/src/Models/Scopes/ActivableScope.php
@@ -20,7 +20,7 @@ class ActivableScope implements Scope
     /**
      * Apply the scope to a given Eloquent query builder.
      *
-     * @param  Builder<Model>  $builder
+     * @param  Builder<covariant Model>  $builder
      */
     public function apply(Builder $builder, Model $model): void
     {

--- a/src/Models/Scopes/CustomFieldsActivableScope.php
+++ b/src/Models/Scopes/CustomFieldsActivableScope.php
@@ -17,6 +17,8 @@ class CustomFieldsActivableScope extends ActivableScope
 {
     /**
      * Apply the scope to a given Eloquent query builder.
+     *
+     * @param  Builder<covariant Model>  $builder
      */
     #[Override]
     public function apply(Builder $builder, Model $model): void

--- a/src/Models/Scopes/SortOrderScope.php
+++ b/src/Models/Scopes/SortOrderScope.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Scope;
 class SortOrderScope implements Scope
 {
     /**
-     * @param  Builder<Model>  $builder
+     * @param  Builder<covariant Model>  $builder
      */
     public function apply(Builder $builder, Model $model): void
     {

--- a/src/Models/Scopes/TenantScope.php
+++ b/src/Models/Scopes/TenantScope.php
@@ -14,7 +14,7 @@ use Relaticle\CustomFields\Services\TenantContextService;
 class TenantScope implements Scope
 {
     /**
-     * @param  Builder<Model>  $builder
+     * @param  Builder<covariant Model>  $builder
      */
     public function apply(Builder $builder, Model $model): void
     {


### PR DESCRIPTION
## Summary

- Update `@param Builder<Model>` to `@param Builder<covariant Model>` on `apply()` methods of all 4 scope classes
- Add the matching `@param` docblock to `CustomFieldsActivableScope::apply()` (PHPStan flagged it directly despite `#[Override]`)

## Why

Laravel 13's `Illuminate\Database\Eloquent\Scope::apply()` declares `Builder<covariant Model>`. PHPStan failed in the `L13.* - prefer-stable` matrix because the invariant `Builder<Model>` in the implementing classes was incompatible with the covariant parent signature.

## Test plan

- [x] `vendor/bin/phpstan analyse --memory-limit=2G` → No errors (lockfile on `laravel/framework v13.6.0`)
- [x] `vendor/bin/pint --test` → pass
- [x] `vendor/bin/rector --dry-run` → OK
- [ ] CI green on `L12.* - prefer-stable` and `L13.* - prefer-stable` matrices