### PR TITLE
fix: render tags-input infolist entries as badges

### DIFF
--- a/src/Filament/Integration/Components/Infolists/MultiChoiceEntry.php
+++ b/src/Filament/Integration/Components/Infolists/MultiChoiceEntry.php
@@ -4,17 +4,31 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Filament\Integration\Components\Infolists;
 
+use Filament\Infolists\Components\Entry;
+use Filament\Infolists\Components\TextEntry as BaseTextEntry;
 use Filament\Infolists\Components\ViewEntry;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Integration\Base\AbstractInfolistEntry;
+use Relaticle\CustomFields\Filament\Integration\Concerns\Shared\ConfiguresBadgeColors;
 use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
 use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Services\ValueResolver\LookupMultiValueResolver;
 
 final class MultiChoiceEntry extends AbstractInfolistEntry
 {
-    public function make(CustomField $customField): ViewEntry
+    use ConfiguresBadgeColors;
+
+    public function __construct(
+        private readonly LookupMultiValueResolver $valueResolver,
+    ) {}
+
+    public function make(CustomField $customField): Entry
     {
+        if ($customField->typeData->acceptsArbitraryValues) {
+            return $this->makeTagsEntry($customField);
+        }
+
         $options = $customField->options->pluck('name', 'id')->all();
         $optionColors = $this->resolveOptionColors($customField);
 
@@ -26,6 +40,16 @@ final class MultiChoiceEntry extends AbstractInfolistEntry
                 'selected' => $record->getCustomFieldValue($customField) ?? [],
                 'optionColors' => $optionColors,
             ]);
+    }
+
+    private function makeTagsEntry(CustomField $customField): BaseTextEntry
+    {
+        $entry = BaseTextEntry::make($customField->getFieldName())
+            ->label($customField->name)
+            ->placeholder('—')
+            ->state(fn (HasCustomFields $record): array => $this->valueResolver->resolve($record, $customField));
+
+        return $this->applyBadgeColorsIfEnabled($entry, $customField);
     }
 
     /** @return array<int, string> */

--- a/tests/Feature/Filament/Components/MultiChoiceEntryTest.php
+++ b/tests/Feature/Filament/Components/MultiChoiceEntryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Infolists\Components\TextEntry as BaseTextEntry;
+use Filament\Infolists\Components\ViewEntry;
+use Relaticle\CustomFields\Filament\Integration\Components\Infolists\MultiChoiceEntry;
+use Relaticle\CustomFields\Models\CustomField;
+
+describe('MultiChoiceEntry', function (): void {
+    it('renders a checkbox-list view entry for option-backed fields (checkbox-list)', function (): void {
+        $field = CustomField::factory()->ofType('checkbox-list')->create();
+
+        $entry = app(MultiChoiceEntry::class)->make($field);
+
+        expect($entry)
+            ->toBeInstanceOf(ViewEntry::class)
+            ->getView()->toBe('custom-fields::infolists.checkbox-list-entry');
+    });
+
+    it('renders a badge text entry for arbitrary-value fields (tags-input)', function (): void {
+        $field = CustomField::factory()->ofType('tags-input')->create();
+
+        $entry = app(MultiChoiceEntry::class)->make($field);
+
+        expect($entry)
+            ->toBeInstanceOf(BaseTextEntry::class)
+            ->isBadge()->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary

`MultiChoiceEntry` is used by both `checkbox-list` and `tags-input`. It renders the field's predefined options as a checkbox list and marks options whose ID appears in the stored selection. `tags-input` calls `->withArbitraryValues()`, so its stored values are raw user-typed strings, not option IDs — the `in_array($optionId, $selected, false)` check never matches and the user's actual tags don't render. The result is what the linked issue shows: tags-input fields appear as an unchecked checkbox list of suggestions instead of the tags the user entered.

The table column path (`MultiChoiceColumn` → `LookupMultiValueResolver` → `LookupResolver`) already special-cases `acceptsArbitraryValues` and renders the stored strings as badges, which is why the list view works. This PR brings the infolist entry in line with that behavior.

## Change

`MultiChoiceEntry::make()` now branches on `\$customField->typeData->acceptsArbitraryValues`:

- **Arbitrary-value fields (tags-input)** → return a `TextEntry` with the stored strings resolved via `LookupMultiValueResolver` and rendered as badges via the existing `ConfiguresBadgeColors` trait (which already handles the tags-vs-options color logic).
- **Option-backed fields (checkbox-list)** → unchanged checkbox-list view rendering.

No new dependencies, no API changes, no new view files — the fix reuses pieces that already exist in the codebase.

## Test plan

- [x] New `tests/Feature/Filament/Components/MultiChoiceEntryTest.php` covers both branches (asserts `ViewEntry` for `checkbox-list`, `TextEntry` + `isBadge()` for `tags-input`). Verified the test fails on `3.x` without this fix.
- [x] `vendor/bin/pest --parallel` — 656 passed, 3 todos, 0 failed.
- [x] `vendor/bin/pint --test` — passed.
- [x] `vendor/bin/rector --dry-run` — clean.
- [x] `vendor/bin/phpstan analyse` — no errors.
- [x] `vendor/bin/pest --type-coverage --min=100.0` — 100% maintained.
- [x] Manual: created a tags-input field on an app's Company model, saved tag values, called `MultiChoiceEntry::make()` and confirmed the returned entry is `TextEntry` with `isBadge() === true`; checkbox-list still returns the `ViewEntry` with `custom-fields::infolists.checkbox-list-entry`.

## Closes

Fixes relaticle/relaticle#281