### PR TITLE
feat: cross-record (relation-path) visibility conditions [3.x]

### DIFF
--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -139,4 +139,29 @@ return [
             'tenant_foreign_key' => 'tenant_id',
         ],
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Visibility Condition Sources (cross-record / model-attribute)
+    |--------------------------------------------------------------------------
+    |
+    | Opt-in scoping for non-custom-field condition sources. Defaults preserve
+    | historical behavior: when restrict_to_configured is false, the
+    | MODEL_ATTRIBUTE_CONDITIONS feature exposes own-column conditions for all
+    | entities. Set it true to expose the own-column source only for entities
+    | listed below.
+    |
+    | The relation-attribute source is never auto-discovered: a relation path
+    | appears only when explicitly listed under an entity's 'relations', regardless
+    | of restrict_to_configured. The restrict flag governs only the own-column source.
+    |
+    */
+    'visibility' => [
+        'restrict_to_configured' => false,
+        'sources' => [
+            // \App\Models\HouseholdMember::class => [
+            //     'relations' => ['household.projects' => 'Household → Projects'],
+            //     'attributes' => ['status' => 'Status'],
+            // ],
+        ],
+    ],
 ];

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -139,29 +139,4 @@ return [
             'tenant_foreign_key' => 'tenant_id',
         ],
     ],
-    /*
-    |--------------------------------------------------------------------------
-    | Visibility Condition Sources (cross-record / model-attribute)
-    |--------------------------------------------------------------------------
-    |
-    | Opt-in scoping for non-custom-field condition sources. Defaults preserve
-    | historical behavior: when restrict_to_configured is false, the
-    | MODEL_ATTRIBUTE_CONDITIONS feature exposes own-column conditions for all
-    | entities. Set it true to expose the own-column source only for entities
-    | listed below.
-    |
-    | The relation-attribute source is never auto-discovered: a relation path
-    | appears only when explicitly listed under an entity's 'relations', regardless
-    | of restrict_to_configured. The restrict flag governs only the own-column source.
-    |
-    */
-    'visibility' => [
-        'restrict_to_configured' => false,
-        'sources' => [
-            // \App\Models\HouseholdMember::class => [
-            //     'relations' => ['household.projects' => 'Household → Projects'],
-            //     'attributes' => ['status' => 'Status'],
-            // ],
-        ],
-    ],
 ];

--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -439,6 +439,7 @@ return [
         'condition_source' => [
             'custom_field' => 'Custom Field',
             'model_attribute' => 'Model Attribute',
+            'relation_attribute' => 'Related record',
         ],
         'custom_field_section_type' => [
             'section' => 'Section',

--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -504,6 +504,8 @@ return [
             'less_than' => 'Less than',
             'is_empty' => 'Is empty',
             'is_not_empty' => 'Is not empty',
+            'is_in' => 'Is in',
+            'is_not_in' => 'Is not in',
         ],
     ],
 

--- a/src/Data/EntityConfigurationData.php
+++ b/src/Data/EntityConfigurationData.php
@@ -36,6 +36,7 @@ final class EntityConfigurationData extends Data
         public ?Collection $features = null,
         public int $priority = 999,
         public array $metadata = [],
+        public array $conditionRelations = [],
         public ?AvatarConfiguration $avatarConfiguration = null,
     ) {
         $this->features ??= collect([
@@ -207,7 +208,16 @@ final class EntityConfigurationData extends Data
 
     public function getRelationships(): array
     {
-        return [];
+        return $this->conditionRelations;
+    }
+
+    /**
+     * @return array<string, string> path => label allowlist of relation paths usable as
+     *                               cross-record visibility-condition sources for this entity.
+     */
+    public function getConditionRelations(): array
+    {
+        return $this->conditionRelations;
     }
 
     public function getFeatures(): array
@@ -315,6 +325,7 @@ final class EntityConfigurationData extends Data
             features: $properties['features'] ?? collect(),
             priority: $properties['priority'] ?? 999,
             metadata: $properties['metadata'] ?? [],
+            conditionRelations: $properties['conditionRelations'] ?? [],
             avatarConfiguration: $properties['avatarConfiguration'] ?? null,
         );
     }

--- a/src/Data/VisibilityConditionData.php
+++ b/src/Data/VisibilityConditionData.php
@@ -29,4 +29,9 @@ class VisibilityConditionData extends Data
     {
         return $this->source === ConditionSource::CustomField;
     }
+
+    public function isRelationAttribute(): bool
+    {
+        return $this->source === ConditionSource::RelationAttribute;
+    }
 }

--- a/src/Data/VisibilityData.php
+++ b/src/Data/VisibilityData.php
@@ -49,10 +49,10 @@ class VisibilityData extends Data
         $results = [];
 
         foreach ($this->conditions as $condition) {
-            // MODEL_ATTRIBUTE_CONDITIONS is the master switch for every non-custom-field
-            // condition source (model-attribute and relation-attribute). Finer per-source
-            // and per-entity exposure is controlled by the visibility.sources config, not here.
-            if (($condition->isModelAttribute() || $condition->isRelationAttribute()) && ! $modelAttributesEnabled) {
+            // MODEL_ATTRIBUTE_CONDITIONS gates only the own-column (model-attribute) source.
+            // Relation-attribute conditions are gated per-entity at authoring time (a path is
+            // offered only when the entity declares conditionRelations), so they always evaluate.
+            if ($condition->isModelAttribute() && ! $modelAttributesEnabled) {
                 continue;
             }
 

--- a/src/Data/VisibilityData.php
+++ b/src/Data/VisibilityData.php
@@ -9,6 +9,7 @@ use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Services\RelationConditionResolver;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
@@ -48,7 +49,10 @@ class VisibilityData extends Data
         $results = [];
 
         foreach ($this->conditions as $condition) {
-            if ($condition->isModelAttribute() && ! $modelAttributesEnabled) {
+            // MODEL_ATTRIBUTE_CONDITIONS is the master switch for every non-custom-field
+            // condition source (model-attribute and relation-attribute). Finer per-source
+            // and per-entity exposure is controlled by the visibility.sources config, not here.
+            if (($condition->isModelAttribute() || $condition->isRelationAttribute()) && ! $modelAttributesEnabled) {
                 continue;
             }
 
@@ -69,6 +73,19 @@ class VisibilityData extends Data
      */
     private function evaluateCondition(VisibilityConditionData $condition, array $fieldValues, ?Model $record = null): bool
     {
+        if ($condition->isRelationAttribute()) {
+            if (! $record instanceof Model) {
+                return true;
+            }
+
+            // Walks the relation path on the record (lazy-loads relations). Fine for
+            // single-record forms/infolists; table/export surfaces evaluating per row
+            // should eager-load the configured paths to avoid N+1.
+            $relatedKeys = app(RelationConditionResolver::class)->resolveRelatedKeys($record, $condition->field_code);
+
+            return $condition->operator->evaluate($relatedKeys, $condition->value);
+        }
+
         if ($condition->isModelAttribute()) {
             if (! $record instanceof Model) {
                 return true;
@@ -112,6 +129,21 @@ class VisibilityData extends Data
 
         foreach ($this->conditions as $condition) {
             if ($condition->isModelAttribute()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasRelationAttributeConditions(): bool
+    {
+        if (! $this->conditions instanceof DataCollection) {
+            return false;
+        }
+
+        foreach ($this->conditions as $condition) {
+            if ($condition->isRelationAttribute()) {
                 return true;
             }
         }

--- a/src/EntitySystem/EntityModel.php
+++ b/src/EntitySystem/EntityModel.php
@@ -29,6 +29,9 @@ final class EntityModel
 
     /**
      * Configure entity with custom settings
+     *
+     * @param  array<string, string>  $conditionRelations  path => label allowlist of relation paths usable as
+     *                                                     cross-record visibility-condition sources for this entity.
      */
     public static function configure(
         string $modelClass,
@@ -43,6 +46,7 @@ final class EntityModel
         array $features = [EntityFeature::CUSTOM_FIELDS, EntityFeature::LOOKUP_SOURCE],
         int $priority = 999,
         array $metadata = [],
+        array $conditionRelations = [],
         ?AvatarConfiguration $avatarConfiguration = null,
     ): array {
         self::validateModelClass($modelClass);
@@ -64,6 +68,7 @@ final class EntityModel
             'features' => array_map(fn (mixed $feature) => $feature instanceof EntityFeature ? $feature->value : $feature, $features),
             'priority' => max(0, $priority),
             'metadata' => $metadata,
+            'conditionRelations' => $conditionRelations,
             'avatarConfiguration' => $avatarConfiguration,
         ];
     }
@@ -119,6 +124,7 @@ final class EntityModel
             'features' => [EntityFeature::CUSTOM_FIELDS->value, EntityFeature::LOOKUP_SOURCE->value],
             'priority' => 999,
             'metadata' => [],
+            'conditionRelations' => [],
             'avatarConfiguration' => null,
         ];
     }

--- a/src/Enums/ConditionSource.php
+++ b/src/Enums/ConditionSource.php
@@ -10,12 +10,14 @@ enum ConditionSource: string implements HasLabel
 {
     case CustomField = 'custom_field';
     case ModelAttribute = 'model_attribute';
+    case RelationAttribute = 'relation_attribute';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::CustomField => __('custom-fields::custom-fields.enums.condition_source.custom_field'),
             self::ModelAttribute => __('custom-fields::custom-fields.enums.condition_source.model_attribute'),
+            self::RelationAttribute => __('custom-fields::custom-fields.enums.condition_source.relation_attribute'),
         };
     }
 }

--- a/src/Enums/VisibilityOperator.php
+++ b/src/Enums/VisibilityOperator.php
@@ -19,6 +19,8 @@ enum VisibilityOperator: string
     case LESS_THAN = 'less_than';
     case IS_EMPTY = 'is_empty';
     case IS_NOT_EMPTY = 'is_not_empty';
+    case IS_IN = 'is_in';
+    case IS_NOT_IN = 'is_not_in';
 
     public function getLabel(): string
     {
@@ -31,6 +33,8 @@ enum VisibilityOperator: string
             self::LESS_THAN => __('custom-fields::custom-fields.enums.visibility_operator.less_than'),
             self::IS_EMPTY => __('custom-fields::custom-fields.enums.visibility_operator.is_empty'),
             self::IS_NOT_EMPTY => __('custom-fields::custom-fields.enums.visibility_operator.is_not_empty'),
+            self::IS_IN => __('custom-fields::custom-fields.enums.visibility_operator.is_in'),
+            self::IS_NOT_IN => __('custom-fields::custom-fields.enums.visibility_operator.is_not_in'),
         };
     }
 
@@ -53,6 +57,8 @@ enum VisibilityOperator: string
             self::LESS_THAN => $this->evaluateLessThan($fieldValue, $expectedValue),
             self::IS_EMPTY => $this->evaluateIsEmpty($fieldValue),
             self::IS_NOT_EMPTY => ! $this->evaluateIsEmpty($fieldValue),
+            self::IS_IN => $this->evaluateIsIn($fieldValue, $expectedValue),
+            self::IS_NOT_IN => ! $this->evaluateIsIn($fieldValue, $expectedValue),
         };
     }
 
@@ -153,6 +159,32 @@ enum VisibilityOperator: string
         }
 
         return false;
+    }
+
+    private function evaluateIsIn(mixed $fieldValue, mixed $expectedValue): bool
+    {
+        $haystack = $this->normalizeToStringSet($fieldValue);
+        $needles = $this->normalizeToStringSet($expectedValue);
+
+        if ($needles === []) {
+            return false;
+        }
+
+        return array_intersect($haystack, $needles) !== [];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeToStringSet(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        $items = is_array($value) ? $value : [$value];
+
+        return array_values(array_unique(array_map(static fn (mixed $item): string => (string) $item, $items)));
     }
 
     /**

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Filament\Integration\Base;
 
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Text;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Contracts\FormComponentInterface;
@@ -14,6 +15,7 @@ use Relaticle\CustomFields\Enums\DescriptionPosition;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Services\ValidationService;
+use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
 
@@ -40,19 +42,20 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
      * @param  array<string>  $dependentFieldCodes
      * @param  Collection<int, CustomField>|null  $allFields
      */
-    public function make(CustomField $customField, array $dependentFieldCodes = [], ?Collection $allFields = null): Field
+    public function make(CustomField $customField, array $dependentFieldCodes = [], ?Collection $allFields = null, ?Model $record = null): Field
     {
         $field = $this->create($customField);
         $allFields ??= collect();
 
-        return $this->configure($field, $customField, $allFields, $dependentFieldCodes);
+        return $this->configure($field, $customField, $allFields, $dependentFieldCodes, $record);
     }
 
     protected function configure(
         Field $field,
         CustomField $customField,
         Collection $allFields,
-        array $dependentFieldCodes
+        array $dependentFieldCodes,
+        ?Model $record = null
     ): Field {
         $field
             ->name($customField->getFieldName())
@@ -105,7 +108,8 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
                 fn (Field $field): Field => $this->applyVisibility(
                     $field,
                     $customField,
-                    $allFields
+                    $allFields,
+                    $record
                 )
             )
             ->when(
@@ -181,7 +185,8 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
     private function applyVisibility(
         Field $field,
         CustomField $customField,
-        Collection $allFields
+        Collection $allFields,
+        ?Model $record
     ): Field {
         $jsExpression = $this->frontendVisibilityService->buildVisibilityExpression(
             $customField,
@@ -189,6 +194,13 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         );
 
         if (blank($jsExpression) || $jsExpression === '0') {
+            // Task 7 guarantees a blank/null expression when relation-attribute conditions are present.
+            // For those fields, fall back to server-side evaluation against the loaded record.
+            if ($record instanceof Model && $this->coreVisibilityLogic->getVisibilityData($customField)->hasRelationAttributeConditions()) {
+                return $field->visible(fn (): bool => app(BackendVisibilityService::class)
+                    ->isFieldVisible($record, $customField, $allFields));
+            }
+
             return $field;
         }
 

--- a/src/Filament/Integration/Builders/FormBuilder.php
+++ b/src/Filament/Integration/Builders/FormBuilder.php
@@ -76,10 +76,14 @@ class FormBuilder extends BaseBuilder
         $allFields = $this->getAllFields();
         $dependentFieldCodes = $this->getDependentFieldCodes($allFields);
 
+        // Resolve record for visibility (null for create forms — fail-open)
+        $record = isset($this->model) && $this->model->exists ? $this->model : null;
+
         $createField = fn (CustomField $customField) => $fieldComponentFactory->create(
             $customField,
             $dependentFieldCodes,
-            $allFields
+            $allFields,
+            $record
         );
 
         // Return flat fields if sections are disabled or withoutSections is set
@@ -87,9 +91,6 @@ class FormBuilder extends BaseBuilder
         if ($this->withoutSections || $sectionsDisabled) {
             return $allFields->map($createField);
         }
-
-        // Resolve record for section visibility (null for create forms)
-        $record = isset($this->model) && $this->model->exists ? $this->model : null;
 
         return $this->getFilteredSections()
             ->map(function (CustomFieldSection $section) use ($sectionComponentFactory, $createField, $allFields, $record) {

--- a/src/Filament/Integration/Factories/FieldComponentFactory.php
+++ b/src/Filament/Integration/Factories/FieldComponentFactory.php
@@ -37,10 +37,17 @@ final class FieldComponentFactory extends AbstractComponentFactory
             ]);
         } else {
             // Handle traditional component class
-            /** @var AbstractFormComponent $component */
-            $component = $this->createComponent($customField, 'form_component', AbstractFormComponent::class);
+            /** @var FormComponentInterface $component */
+            $component = $this->createComponent($customField, 'form_component', FormComponentInterface::class);
         }
 
-        return $component->make($customField, $dependentFieldCodes, $allFields, $record);
+        // Only AbstractFormComponent consumes the optional $record (server-side relation-attribute
+        // visibility). Third-party FormComponentInterface implementers keep the original 3-arg contract,
+        // so the package stays backward compatible for that public extension point.
+        if ($component instanceof AbstractFormComponent) {
+            return $component->make($customField, $dependentFieldCodes, $allFields, $record);
+        }
+
+        return $component->make($customField, $dependentFieldCodes, $allFields);
     }
 }

--- a/src/Filament/Integration/Factories/FieldComponentFactory.php
+++ b/src/Filament/Integration/Factories/FieldComponentFactory.php
@@ -7,8 +7,10 @@ namespace Relaticle\CustomFields\Filament\Integration\Factories;
 use Closure;
 use Filament\Forms\Components\Field;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Contracts\FormComponentInterface;
+use Relaticle\CustomFields\Filament\Integration\Base\AbstractFormComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\ClosureFormAdapter;
 use Relaticle\CustomFields\Models\CustomField;
 
@@ -23,22 +25,22 @@ final class FieldComponentFactory extends AbstractComponentFactory
      *
      * @throws BindingResolutionException
      */
-    public function create(CustomField $customField, array $dependentFieldCodes = [], ?Collection $allFields = null): Field
+    public function create(CustomField $customField, array $dependentFieldCodes = [], ?Collection $allFields = null, ?Model $record = null): Field
     {
         $formComponentDefinition = $customField->typeData->formComponent;
 
         // Handle inline component (Closure) - use ClosureFormAdapter for full AbstractFormComponent benefits
         if ($formComponentDefinition instanceof Closure) {
-            /** @var FormComponentInterface $component */
+            /** @var AbstractFormComponent $component */
             $component = $this->container->make(ClosureFormAdapter::class, [
                 'closure' => $formComponentDefinition,
             ]);
         } else {
             // Handle traditional component class
-            /** @var FormComponentInterface $component */
-            $component = $this->createComponent($customField, 'form_component', FormComponentInterface::class);
+            /** @var AbstractFormComponent $component */
+            $component = $this->createComponent($customField, 'form_component', AbstractFormComponent::class);
         }
 
-        return $component->make($customField, $dependentFieldCodes, $allFields);
+        return $component->make($customField, $dependentFieldCodes, $allFields, $record);
     }
 }

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -521,6 +521,7 @@ final class VisibilityComponent extends Component
                 ->first(fn (string $column): bool => $related->getConnection()->getSchemaBuilder()->hasColumn($related->getTable(), $column))
                 ?? $related->getKeyName();
         }
+
         $labelColumn = $labelColumns[$modelClass];
 
         return $related::query()->pluck($labelColumn, $related->getKeyName())->all();

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Database\Eloquent\Model;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\ConditionSource;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
@@ -25,7 +26,9 @@ use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Services\ModelAttributeDiscoveryService;
+use Relaticle\CustomFields\Services\RelationConditionResolver;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
+use Relaticle\CustomFields\Support\RelationConditionConfig;
 
 final class VisibilityComponent extends Component
 {
@@ -105,7 +108,7 @@ final class VisibilityComponent extends Component
         if ($modelAttrsEnabled) {
             $schema[] = Select::make('source')
                 ->label(__('custom-fields::custom-fields.visibility.source'))
-                ->options(ConditionSource::class)
+                ->options(fn (Get $get): array => $this->getAvailableSourceOptions($get))
                 ->default(ConditionSource::CustomField)
                 ->required()
                 ->live()
@@ -188,18 +191,64 @@ final class VisibilityComponent extends Component
                 ->afterStateHydrated(fn (TextInput $component, Get $get): TextInput => $component->state($get('value') ?? ''))
                 ->afterStateUpdated(fn (mixed $state, Set $set): mixed => $set('value', $state))
                 ->columnSpan($columnSpan),
+
+            Select::make('relation_values')
+                ->label(__('custom-fields::custom-fields.visibility.value'))
+                ->multiple()
+                ->searchable()
+                ->options(fn (Get $get): array => $this->getRelationValueOptions($get))
+                ->visible(fn (Get $get): bool => $this->isRelationAttributeSource($get) && $this->operatorRequiresValue($get))
+                ->afterStateHydrated(fn (Select $component, Get $get): Select => $component->state(value($get('value')) ? (array) $get('value') : []))
+                ->afterStateUpdated(fn (mixed $state, Set $set): mixed => $set('value', $state))
+                ->columnSpan($columnSpan),
         ];
     }
 
-    private function isModelAttributeSource(Get $get): bool
+    /**
+     * @return array<string, string>
+     */
+    private function getAvailableSourceOptions(Get $get): array
+    {
+        $entityType = $this->getEntityType($get);
+
+        $options = [
+            ConditionSource::CustomField->value => ConditionSource::CustomField->getLabel(),
+        ];
+
+        $config = app(RelationConditionConfig::class);
+
+        // Show the model-attribute option while entity_type is not yet resolved (e.g. a blank form),
+        // preserving the legacy behavior where the source was always available.
+        if (blank($entityType) || $config->isModelAttributeSourceAvailable($entityType)) {
+            $options[ConditionSource::ModelAttribute->value] = ConditionSource::ModelAttribute->getLabel();
+        }
+
+        if (! blank($entityType) && $config->isRelationSourceAvailable($entityType)) {
+            $options[ConditionSource::RelationAttribute->value] = ConditionSource::RelationAttribute->getLabel();
+        }
+
+        return $options;
+    }
+
+    private function sourceIs(Get $get, ConditionSource $expected): bool
     {
         $source = $get('source');
 
         if ($source instanceof ConditionSource) {
-            return $source === ConditionSource::ModelAttribute;
+            return $source === $expected;
         }
 
-        return $source === ConditionSource::ModelAttribute->value;
+        return $source === $expected->value;
+    }
+
+    private function isModelAttributeSource(Get $get): bool
+    {
+        return $this->sourceIs($get, ConditionSource::ModelAttribute);
+    }
+
+    private function isRelationAttributeSource(Get $get): bool
+    {
+        return $this->sourceIs($get, ConditionSource::RelationAttribute);
     }
 
     private function shouldShowSingleSelect(Get $get): bool
@@ -209,6 +258,10 @@ final class VisibilityComponent extends Component
         }
 
         if ($this->isModelAttributeSource($get)) {
+            return false;
+        }
+
+        if ($this->isRelationAttributeSource($get)) {
             return false;
         }
 
@@ -236,6 +289,10 @@ final class VisibilityComponent extends Component
             return false;
         }
 
+        if ($this->isRelationAttributeSource($get)) {
+            return false;
+        }
+
         $fieldData = $this->getFieldTypeData($get);
         if ($fieldData === null) {
             return false;
@@ -248,6 +305,10 @@ final class VisibilityComponent extends Component
     private function shouldShowToggle(Get $get): bool
     {
         if (! $this->operatorRequiresValue($get)) {
+            return false;
+        }
+
+        if ($this->isRelationAttributeSource($get)) {
             return false;
         }
 
@@ -275,6 +336,10 @@ final class VisibilityComponent extends Component
     private function shouldShowTextInput(Get $get): bool
     {
         if (! $this->operatorRequiresValue($get)) {
+            return false;
+        }
+
+        if ($this->isRelationAttributeSource($get)) {
             return false;
         }
 
@@ -379,6 +444,10 @@ final class VisibilityComponent extends Component
             return [];
         }
 
+        if ($this->isRelationAttributeSource($get)) {
+            return app(RelationConditionConfig::class)->relationsFor($entityType);
+        }
+
         if ($this->isModelAttributeSource($get)) {
             return rescue(
                 fn (): array => app(ModelAttributeDiscoveryService::class)->getAttributeOptions($entityType),
@@ -403,8 +472,17 @@ final class VisibilityComponent extends Component
      */
     private function getCompatibleOperators(Get $get): array
     {
+        if ($this->isRelationAttributeSource($get)) {
+            return [
+                VisibilityOperator::IS_IN->value => VisibilityOperator::IS_IN->getLabel(),
+                VisibilityOperator::IS_NOT_IN->value => VisibilityOperator::IS_NOT_IN->getLabel(),
+            ];
+        }
+
         if ($this->isModelAttributeSource($get)) {
-            return VisibilityOperator::options();
+            return collect(VisibilityOperator::options())
+                ->except([VisibilityOperator::IS_IN->value, VisibilityOperator::IS_NOT_IN->value])
+                ->all();
         }
 
         $fieldData = $this->getFieldTypeData($get);
@@ -412,6 +490,40 @@ final class VisibilityComponent extends Component
         return $fieldData
             ? $fieldData->getCompatibleOperatorOptions()
             : VisibilityOperator::options();
+    }
+
+    /**
+     * @return array<int|string, string>
+     */
+    private function getRelationValueOptions(Get $get): array
+    {
+        $path = $get('field_code');
+
+        if (blank($path)) {
+            return [];
+        }
+
+        $entityType = $this->getEntityType($get);
+        if (blank($entityType)) {
+            return [];
+        }
+
+        $related = app(RelationConditionResolver::class)->resolveTerminalRelatedModel($entityType, (string) $path);
+
+        if (! $related instanceof Model) {
+            return [];
+        }
+
+        static $labelColumns = [];
+        $modelClass = $related::class;
+        if (! isset($labelColumns[$modelClass])) {
+            $labelColumns[$modelClass] = collect(['name', 'title', 'label'])
+                ->first(fn (string $column): bool => $related->getConnection()->getSchemaBuilder()->hasColumn($related->getTable(), $column))
+                ?? $related->getKeyName();
+        }
+        $labelColumn = $labelColumns[$modelClass];
+
+        return $related::query()->pluck($labelColumn, $related->getKeyName())->all();
     }
 
     private function getFieldTypeData(Get $get): ?object
@@ -480,6 +592,7 @@ final class VisibilityComponent extends Component
         $set('boolean_value', false);
         $set('single_value', null);
         $set('multiple_values', []);
+        $set('relation_values', []);
     }
 
     private function isContainsOperator(?string $operator): bool

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -491,7 +491,9 @@ final class VisibilityComponent extends Component
 
         return $fieldData
             ? $fieldData->getCompatibleOperatorOptions()
-            : VisibilityOperator::options();
+            : collect(VisibilityOperator::options())
+                ->except([VisibilityOperator::IS_IN->value, VisibilityOperator::IS_NOT_IN->value])
+                ->all();
     }
 
     /**

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -104,8 +104,12 @@ final class VisibilityComponent extends Component
         $schema = [];
 
         $modelAttrsEnabled = FeatureManager::isEnabled(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS);
+        $relationsAvailable = app(RelationConditionConfig::class)
+            ->isRelationSourceAvailable((string) $this->getEntityType());
 
-        if ($modelAttrsEnabled) {
+        $showSourceSelect = $modelAttrsEnabled || $relationsAvailable;
+
+        if ($showSourceSelect) {
             $schema[] = Select::make('source')
                 ->label(__('custom-fields::custom-fields.visibility.source'))
                 ->options(fn (Get $get): array => $this->getAvailableSourceOptions($get))
@@ -118,9 +122,9 @@ final class VisibilityComponent extends Component
             $schema[] = Hidden::make('source')->default(ConditionSource::CustomField->value);
         }
 
-        $fieldCodeSpan = $modelAttrsEnabled ? 3 : 4;
-        $operatorSpan = $modelAttrsEnabled ? 2 : 3;
-        $valueSpan = $modelAttrsEnabled ? 4 : 5;
+        $fieldCodeSpan = $showSourceSelect ? 3 : 4;
+        $operatorSpan = $showSourceSelect ? 2 : 3;
+        $valueSpan = $showSourceSelect ? 4 : 5;
 
         $schema[] = Select::make('field_code')
             ->label(__('custom-fields::custom-fields.visibility.field'))
@@ -217,15 +221,11 @@ final class VisibilityComponent extends Component
             ConditionSource::CustomField->value => ConditionSource::CustomField->getLabel(),
         ];
 
-        $config = app(RelationConditionConfig::class);
-
-        // Show the model-attribute option while entity_type is not yet resolved (e.g. a blank form),
-        // preserving the legacy behavior where the source was always available.
-        if (blank($entityType) || $config->isModelAttributeSourceAvailable($entityType)) {
+        if (FeatureManager::isEnabled(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS)) {
             $options[ConditionSource::ModelAttribute->value] = ConditionSource::ModelAttribute->getLabel();
         }
 
-        if (! blank($entityType) && $config->isRelationSourceAvailable($entityType)) {
+        if (! blank($entityType) && app(RelationConditionConfig::class)->isRelationSourceAvailable($entityType)) {
             $options[ConditionSource::RelationAttribute->value] = ConditionSource::RelationAttribute->getLabel();
         }
 
@@ -563,13 +563,13 @@ final class VisibilityComponent extends Component
         });
     }
 
-    private function getEntityType(Get $get): ?string
+    private function getEntityType(?Get $get = null): ?string
     {
         if ($this->forSection && $this->sectionEntityType) {
             return $this->sectionEntityType;
         }
 
-        return $get('../../../../entity_type')
+        return ($get instanceof Get ? $get('../../../../entity_type') : null)
             ?? request('entityType')
             ?? request()->route('entityType');
     }

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -103,28 +103,19 @@ final class VisibilityComponent extends Component
     {
         $schema = [];
 
-        $modelAttrsEnabled = FeatureManager::isEnabled(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS);
-        $relationsAvailable = app(RelationConditionConfig::class)
-            ->isRelationSourceAvailable((string) $this->getEntityType());
-
-        $showSourceSelect = $modelAttrsEnabled || $relationsAvailable;
-
-        if ($showSourceSelect) {
-            $schema[] = Select::make('source')
-                ->label(__('custom-fields::custom-fields.visibility.source'))
-                ->options(fn (Get $get): array => $this->getAvailableSourceOptions($get))
-                ->default(ConditionSource::CustomField)
-                ->required()
-                ->live()
-                ->afterStateUpdated(fn (Set $set) => $this->resetConditionValues(null, $set))
-                ->columnSpan(3);
-        } else {
-            $schema[] = Hidden::make('source')->default(ConditionSource::CustomField->value);
-        }
-
-        $fieldCodeSpan = $showSourceSelect ? 3 : 4;
-        $operatorSpan = $showSourceSelect ? 2 : 3;
-        $valueSpan = $showSourceSelect ? 4 : 5;
+        $schema[] = Select::make('source')
+            ->label(__('custom-fields::custom-fields.visibility.source'))
+            ->options(fn (Get $get): array => $this->getAvailableSourceOptions($get))
+            ->default(ConditionSource::CustomField->value)
+            ->required()
+            ->live()
+            ->afterStateUpdated(fn (Set $set) => $this->resetConditionValues(null, $set))
+            // Show the source picker only when more than the default CustomField source is available
+            // (model-attribute flag on, or the entity has configured relation paths). Decided per-render
+            // via $get so it works in Livewire action contexts where the entity is not known at build time.
+            // When hidden, the default keeps source = custom_field.
+            ->visible(fn (Get $get): bool => count($this->getAvailableSourceOptions($get)) > 1)
+            ->columnSpan(3);
 
         $schema[] = Select::make('field_code')
             ->label(__('custom-fields::custom-fields.visibility.field'))
@@ -132,7 +123,7 @@ final class VisibilityComponent extends Component
             ->required()
             ->live()
             ->afterStateUpdated(fn (Get $get, Set $set) => $this->resetValuesAndOperator($get, $set))
-            ->columnSpan($fieldCodeSpan);
+            ->columnSpan(3);
 
         $schema[] = Select::make('operator')
             ->label(__('custom-fields::custom-fields.visibility.operator'))
@@ -140,9 +131,9 @@ final class VisibilityComponent extends Component
             ->required()
             ->live()
             ->afterStateUpdated(fn (Set $set) => $this->clearAllValueFields($set))
-            ->columnSpan($operatorSpan);
+            ->columnSpan(2);
 
-        $schema = [...$schema, ...$this->getValueInputComponents($valueSpan)];
+        $schema = [...$schema, ...$this->getValueInputComponents(4)];
 
         $schema[] = Hidden::make('value')->default(null);
 

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -160,7 +160,9 @@ final class VisibilityComponent extends Component
                 ->options(fn (Get $get): array => $this->getFieldOptions($get))
                 ->visible(fn (Get $get): bool => $this->shouldShowSingleSelect($get))
                 ->placeholder(fn (Get $get): string => $this->getPlaceholder($get))
-                ->afterStateHydrated(fn (Select $component, Get $get): Select => $component->state($get('value')))
+                // Scalar value inputs must ignore array values (relation/multi-choice conditions), else hydrating
+                // an array into a single-select throws "Array to string conversion".
+                ->afterStateHydrated(fn (Select $component, Get $get): Select => $component->state(is_array($get('value')) ? null : $get('value')))
                 ->afterStateUpdated(fn (mixed $state, Set $set): mixed => $set('value', $state))
                 ->columnSpan($columnSpan),
 
@@ -180,7 +182,7 @@ final class VisibilityComponent extends Component
                 ->inline(false)
                 ->label(__('custom-fields::custom-fields.visibility.value'))
                 ->visible(fn (Get $get): bool => $this->shouldShowToggle($get))
-                ->afterStateHydrated(fn (Toggle $component, Get $get): Toggle => $component->state($get('value')))
+                ->afterStateHydrated(fn (Toggle $component, Get $get): Toggle => $component->state(is_array($get('value')) ? false : $get('value')))
                 ->afterStateUpdated(fn (bool $state, Set $set): mixed => $set('value', $state))
                 ->columnSpan($columnSpan),
 
@@ -188,7 +190,7 @@ final class VisibilityComponent extends Component
                 ->label(__('custom-fields::custom-fields.visibility.value'))
                 ->placeholder(fn (Get $get): string => $this->getPlaceholder($get))
                 ->visible(fn (Get $get): bool => $this->shouldShowTextInput($get))
-                ->afterStateHydrated(fn (TextInput $component, Get $get): TextInput => $component->state($get('value') ?? ''))
+                ->afterStateHydrated(fn (TextInput $component, Get $get): TextInput => $component->state(is_array($get('value')) ? '' : ($get('value') ?? '')))
                 ->afterStateUpdated(fn (mixed $state, Set $set): mixed => $set('value', $state))
                 ->columnSpan($columnSpan),
 

--- a/src/Services/RelationConditionResolver.php
+++ b/src/Services/RelationConditionResolver.php
@@ -6,6 +6,7 @@ namespace Relaticle\CustomFields\Services;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Throwable;
 
 final class RelationConditionResolver
 {
@@ -58,7 +59,7 @@ final class RelationConditionResolver
             }
 
             return $model;
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return null;
         }
     }

--- a/src/Services/RelationConditionResolver.php
+++ b/src/Services/RelationConditionResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+final class RelationConditionResolver
+{
+    /**
+     * Resolve a dotted relation path on a record to the unique set of
+     * terminal related-record keys, as strings.
+     *
+     * @return array<int, string>
+     */
+    public function resolveRelatedKeys(Model $record, string $path): array
+    {
+        $current = new Collection([$record]);
+
+        foreach (explode('.', $path) as $segment) {
+            $current = $current->flatMap(function (mixed $model) use ($segment): array {
+                if (! $model instanceof Model) {
+                    return [];
+                }
+
+                $related = $model->getAttribute($segment);
+
+                if ($related === null) {
+                    return [];
+                }
+
+                return $related instanceof Collection ? $related->all() : [$related];
+            });
+        }
+
+        return $current
+            ->filter(fn (mixed $model): bool => $model instanceof Model)
+            ->map(fn (Model $model): string => (string) $model->getKey())
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Reflect the terminal related model of a path without hitting the DB.
+     * Returns null if any segment is not a valid relation.
+     */
+    public function resolveTerminalRelatedModel(string $entityClass, string $path): ?Model
+    {
+        try {
+            /** @var Model $model */
+            $model = new $entityClass;
+
+            foreach (explode('.', $path) as $segment) {
+                $model = $model->{$segment}()->getRelated();
+            }
+
+            return $model;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Services/Visibility/FrontendVisibilityService.php
+++ b/src/Services/Visibility/FrontendVisibilityService.php
@@ -52,6 +52,11 @@ final readonly class FrontendVisibilityService
             return null;
         }
 
+        // Relation conditions have no client-side $get equivalent; force whole-set server-side evaluation.
+        if ($visibility->hasRelationAttributeConditions()) {
+            return null;
+        }
+
         $conditions = $visibility->conditions->all();
         $mode = $visibility->mode;
         $logic = $visibility->logic;
@@ -80,6 +85,10 @@ final readonly class FrontendVisibilityService
         VisibilityConditionData $condition,
         ?Collection $allFields
     ): bool {
+        if ($condition->isRelationAttribute()) {
+            return false;
+        }
+
         if ($condition->isModelAttribute()) {
             return FeatureManager::isEnabled(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS);
         }
@@ -101,6 +110,13 @@ final readonly class FrontendVisibilityService
             ! $this->coreLogic->hasVisibilityConditions($field) ||
             ! $allFields instanceof Collection
         ) {
+            return null;
+        }
+
+        $visibility = $this->coreLogic->getVisibilityData($field);
+
+        // Relation conditions have no client-side $get equivalent; force whole-set server-side evaluation.
+        if ($visibility->hasRelationAttributeConditions()) {
             return null;
         }
 
@@ -199,6 +215,10 @@ final readonly class FrontendVisibilityService
         VisibilityMode $mode,
         ?Collection $allFields
     ): ?string {
+        if ($condition->isRelationAttribute()) {
+            return null;
+        }
+
         $isModelAttribute = $condition->isModelAttribute();
         $escapedCode = addslashes($condition->field_code);
 
@@ -281,6 +301,10 @@ final readonly class FrontendVisibilityService
                 $fieldValue,
                 false
             ),
+            // IS_IN / IS_NOT_IN are relation-only operators evaluated server-side.
+            // The set-level guard already returns null for relation conditions; this
+            // arm keeps the match exhaustive and emits no JS if one ever leaks through.
+            VisibilityOperator::IS_IN, VisibilityOperator::IS_NOT_IN => null,
         };
     }
 

--- a/src/Support/RelationConditionConfig.php
+++ b/src/Support/RelationConditionConfig.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Support;
+
+final class RelationConditionConfig
+{
+    public function restrictToConfigured(): bool
+    {
+        return (bool) config('custom-fields.visibility.restrict_to_configured', false);
+    }
+
+    /**
+     * @return array<string, string> path => label
+     */
+    public function relationsFor(string $entityClass): array
+    {
+        return $this->sourcesFor($entityClass)['relations'] ?? [];
+    }
+
+    /**
+     * @return array<string, string> code => label
+     */
+    public function attributesFor(string $entityClass): array
+    {
+        return $this->sourcesFor($entityClass)['attributes'] ?? [];
+    }
+
+    /**
+     * Relation sources are never auto-discovered; available only when a path is
+     * configured, independent of restrict_to_configured.
+     */
+    public function isRelationSourceAvailable(string $entityClass): bool
+    {
+        return $this->relationsFor($entityClass) !== [];
+    }
+
+    public function isModelAttributeSourceAvailable(string $entityClass): bool
+    {
+        if (! $this->restrictToConfigured()) {
+            return true;
+        }
+
+        return $this->attributesFor($entityClass) !== [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourcesFor(string $entityClass): array
+    {
+        $sources = config('custom-fields.visibility.sources', []);
+
+        return is_array($sources) ? ($sources[$entityClass] ?? []) : [];
+    }
+}

--- a/src/Support/RelationConditionConfig.php
+++ b/src/Support/RelationConditionConfig.php
@@ -4,54 +4,28 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Support;
 
+use Relaticle\CustomFields\EntitySystem\EntityManager;
+
 final class RelationConditionConfig
 {
-    public function restrictToConfigured(): bool
-    {
-        return (bool) config('custom-fields.visibility.restrict_to_configured', false);
-    }
-
     /**
+     * Allowed cross-record relation paths for an entity, read from its
+     * per-entity configuration (EntityModel::configure(conditionRelations: ...)).
+     *
      * @return array<string, string> path => label
      */
     public function relationsFor(string $entityClass): array
     {
-        return $this->sourcesFor($entityClass)['relations'] ?? [];
+        return app(EntityManager::class)
+            ->getEntity($entityClass)?->getConditionRelations() ?? [];
     }
 
     /**
-     * @return array<string, string> code => label
-     */
-    public function attributesFor(string $entityClass): array
-    {
-        return $this->sourcesFor($entityClass)['attributes'] ?? [];
-    }
-
-    /**
-     * Relation sources are never auto-discovered; available only when a path is
-     * configured, independent of restrict_to_configured.
+     * Relation sources are never auto-discovered; they are available only when
+     * the entity declares at least one relation path in its configuration.
      */
     public function isRelationSourceAvailable(string $entityClass): bool
     {
         return $this->relationsFor($entityClass) !== [];
-    }
-
-    public function isModelAttributeSourceAvailable(string $entityClass): bool
-    {
-        if (! $this->restrictToConfigured()) {
-            return true;
-        }
-
-        return $this->attributesFor($entityClass) !== [];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function sourcesFor(string $entityClass): array
-    {
-        $sources = config('custom-fields.visibility.sources', []);
-
-        return is_array($sources) ? ($sources[$entityClass] ?? []) : [];
     }
 }

--- a/tests/Feature/Admin/Pages/VisibilityConditionHydrationTest.php
+++ b/tests/Feature/Admin/Pages/VisibilityConditionHydrationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\Livewire\ManageCustomField;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->entityType = User::class;
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType($this->entityType)
+        ->create();
+
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(
+            CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY,
+            CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS,
+            CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+            CustomFieldsFeature::SYSTEM_SECTIONS,
+        )
+    );
+});
+
+it('mounts the edit action without error when a visibility condition has an array value (IS_IN regression)', function (): void {
+    $tag1 = Tag::factory()->create();
+    $tag2 = Tag::factory()->create();
+
+    $field = CustomField::factory()
+        ->ofType('text')
+        ->withVisibility([
+            [
+                'field_code' => 'some_relation_field',
+                'operator' => VisibilityOperator::IS_IN->value,
+                'value' => [$tag1->id, $tag2->id],
+            ],
+        ])
+        ->create([
+            'custom_field_section_id' => $this->section->getKey(),
+            'entity_type' => $this->entityType,
+            'name' => 'Relation-gated field',
+            'code' => 'relation_gated_field',
+        ]);
+
+    livewire(ManageCustomField::class, ['field' => $field])
+        ->mountAction('edit')
+        ->assertActionMounted('edit');
+});

--- a/tests/Feature/Data/VisibilityDataTest.php
+++ b/tests/Feature/Data/VisibilityDataTest.php
@@ -356,6 +356,21 @@ describe('VisibilityData getDependentFields', function (): void {
     });
 });
 
+describe('VisibilityConditionData RelationAttribute source', function (): void {
+    it('recognizes the relation-attribute condition source', function (): void {
+        $condition = VisibilityConditionData::from([
+            'field_code' => 'household.projects',
+            'operator' => VisibilityOperator::IS_IN,
+            'value' => [1, 2],
+            'source' => ConditionSource::RelationAttribute,
+        ]);
+
+        expect($condition->isRelationAttribute())->toBeTrue()
+            ->and($condition->isCustomField())->toBeFalse()
+            ->and($condition->isModelAttribute())->toBeFalse();
+    });
+});
+
 describe('VisibilityData hasModelAttributeConditions', function (): void {
     it('returns true when model attribute conditions exist', function (): void {
         $visibility = VisibilityData::from([

--- a/tests/Feature/Data/VisibilityOperatorTest.php
+++ b/tests/Feature/Data/VisibilityOperatorTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 use Relaticle\CustomFields\Enums\VisibilityOperator;
 
-it('matches is_in when the related set intersects the selected list', function () {
+it('matches is_in when the related set intersects the selected list', function (): void {
     expect(VisibilityOperator::IS_IN->evaluate([5, 9], [9, 12]))->toBeTrue()
         ->and(VisibilityOperator::IS_IN->evaluate([5, 9], [12, 13]))->toBeFalse()
         ->and(VisibilityOperator::IS_IN->evaluate([], [9]))->toBeFalse()
         ->and(VisibilityOperator::IS_IN->evaluate([9], []))->toBeFalse();
 });
 
-it('matches is_not_in as the negation of is_in', function () {
+it('matches is_not_in as the negation of is_in', function (): void {
     expect(VisibilityOperator::IS_NOT_IN->evaluate([5, 9], [12]))->toBeTrue()
         ->and(VisibilityOperator::IS_NOT_IN->evaluate([5, 9], [9]))->toBeFalse()
         ->and(VisibilityOperator::IS_NOT_IN->evaluate([], [9]))->toBeTrue();
 });
 
-it('normalizes int vs string keys before intersecting', function () {
+it('normalizes int vs string keys before intersecting', function (): void {
     expect(VisibilityOperator::IS_IN->evaluate([5, 9], ['9']))->toBeTrue()
         ->and(VisibilityOperator::IS_IN->evaluate(['5'], [5]))->toBeTrue();
 });

--- a/tests/Feature/Data/VisibilityOperatorTest.php
+++ b/tests/Feature/Data/VisibilityOperatorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+
+it('matches is_in when the related set intersects the selected list', function () {
+    expect(VisibilityOperator::IS_IN->evaluate([5, 9], [9, 12]))->toBeTrue()
+        ->and(VisibilityOperator::IS_IN->evaluate([5, 9], [12, 13]))->toBeFalse()
+        ->and(VisibilityOperator::IS_IN->evaluate([], [9]))->toBeFalse()
+        ->and(VisibilityOperator::IS_IN->evaluate([9], []))->toBeFalse();
+});
+
+it('matches is_not_in as the negation of is_in', function () {
+    expect(VisibilityOperator::IS_NOT_IN->evaluate([5, 9], [12]))->toBeTrue()
+        ->and(VisibilityOperator::IS_NOT_IN->evaluate([5, 9], [9]))->toBeFalse()
+        ->and(VisibilityOperator::IS_NOT_IN->evaluate([], [9]))->toBeTrue();
+});
+
+it('normalizes int vs string keys before intersecting', function () {
+    expect(VisibilityOperator::IS_IN->evaluate([5, 9], ['9']))->toBeTrue()
+        ->and(VisibilityOperator::IS_IN->evaluate(['5'], [5]))->toBeTrue();
+});

--- a/tests/Feature/FieldVisibilityIntegrationTest.php
+++ b/tests/Feature/FieldVisibilityIntegrationTest.php
@@ -111,7 +111,7 @@ describe('Field-level server-side visibility for relation-attribute conditions',
         // Simulate what applyVisibility does when $record is null: no closure is attached,
         // field is returned plain (visible by default). Verify evaluate([], null) is true.
         $visibilityData = $field->settings->visibility;
-        expect($visibilityData->evaluate([], null))->toBeTrue();
+        expect($visibilityData->evaluate([]))->toBeTrue();
     });
 
     it('attaches a visible() closure (not visibleJs) when a relation condition field is built with a record', function (): void {
@@ -205,7 +205,7 @@ describe('Field-level server-side visibility for relation-attribute conditions',
         $factory = app(FieldComponentFactory::class);
         $allFields = collect([$triggerField, $conditionalField]);
 
-        $built = $factory->create($conditionalField, [], $allFields, null);
+        $built = $factory->create($conditionalField, [], $allFields);
 
         // Pure custom-field conditions must drive visibility through the reactive client-side JS
         // path (visibleJs + live), NOT a server-side visible() closure. Asserting only isVisible()

--- a/tests/Feature/FieldVisibilityIntegrationTest.php
+++ b/tests/Feature/FieldVisibilityIntegrationTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\VisibilityLogic;
+use Relaticle\CustomFields\Enums\VisibilityMode;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\Filament\Integration\Factories\FieldComponentFactory;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
+use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
+
+beforeEach(function (): void {
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS)
+        ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)
+        ->enable(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
+    );
+});
+
+afterEach(function (): void {
+    BackendVisibilityService::clearCache();
+});
+
+describe('Field-level server-side visibility for relation-attribute conditions', function (): void {
+    it('reports isFieldVisible true for a matching record and false for a non-matching record', function (): void {
+        $matchingTag = Tag::factory()->create();
+        $otherTag = Tag::factory()->create();
+
+        $postMatch = Post::factory()->create();
+        $postMatch->tagModels()->attach($matchingTag);
+        $commentMatch = Comment::factory()->create(['post_id' => $postMatch->id]);
+
+        $postNoMatch = Post::factory()->create();
+        $postNoMatch->tagModels()->attach($otherTag);
+        $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Field Visibility Section',
+            'entity_type' => Comment::class,
+            'active' => true,
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Relation-gated field',
+            'code' => 'relation_gated',
+            'type' => 'text',
+            'entity_type' => Comment::class,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [[
+                        'field_code' => 'post.tagModels',
+                        'operator' => VisibilityOperator::IS_IN,
+                        'value' => [$matchingTag->id],
+                        'source' => ConditionSource::RelationAttribute,
+                    ]],
+                ],
+            ],
+        ]);
+
+        $backendService = app(BackendVisibilityService::class);
+        $allFields = collect([$field]);
+
+        expect($backendService->isFieldVisible($commentMatch, $field, $allFields))->toBeTrue()
+            ->and($backendService->isFieldVisible($commentNoMatch, $field, $allFields))->toBeFalse();
+    });
+
+    it('fails open (field visible) when no record is present (create form)', function (): void {
+        $matchingTag = Tag::factory()->create();
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Create Form Section',
+            'entity_type' => Comment::class,
+            'active' => true,
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Create-form field',
+            'code' => 'create_form_field',
+            'type' => 'text',
+            'entity_type' => Comment::class,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [[
+                        'field_code' => 'post.tagModels',
+                        'operator' => VisibilityOperator::IS_IN,
+                        'value' => [$matchingTag->id],
+                        'source' => ConditionSource::RelationAttribute,
+                    ]],
+                ],
+            ],
+        ]);
+
+        // Passing null record → VisibilityData::evaluate() returns true (fail-open)
+        $backendService = app(BackendVisibilityService::class);
+        $allFields = collect([$field]);
+
+        // Simulate what applyVisibility does when $record is null: no closure is attached,
+        // field is returned plain (visible by default). Verify evaluate([], null) is true.
+        $visibilityData = $field->settings->visibility;
+        expect($visibilityData->evaluate([], null))->toBeTrue();
+    });
+
+    it('attaches a visible() closure (not visibleJs) when a relation condition field is built with a record', function (): void {
+        $matchingTag = Tag::factory()->create();
+        $otherTag = Tag::factory()->create();
+
+        $postMatch = Post::factory()->create();
+        $postMatch->tagModels()->attach($matchingTag);
+        $commentMatch = Comment::factory()->create(['post_id' => $postMatch->id]);
+
+        $postNoMatch = Post::factory()->create();
+        $postNoMatch->tagModels()->attach($otherTag);
+        $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Closure Test Section',
+            'entity_type' => Comment::class,
+            'active' => true,
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Closure-gated field',
+            'code' => 'closure_gated',
+            'type' => 'text',
+            'entity_type' => Comment::class,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [[
+                        'field_code' => 'post.tagModels',
+                        'operator' => VisibilityOperator::IS_IN,
+                        'value' => [$matchingTag->id],
+                        'source' => ConditionSource::RelationAttribute,
+                    ]],
+                ],
+            ],
+        ]);
+
+        $factory = app(FieldComponentFactory::class);
+        $allFields = collect([$field]);
+
+        $builtForMatch = $factory->create($field, [], $allFields, $commentMatch);
+        $builtForNoMatch = $factory->create($field, [], $allFields, $commentNoMatch);
+
+        // The visible closure is the authoritative check here; evaluate it directly.
+        // Filament stores ->visible() as a Closure on the component — invoke it to assert result.
+        $isVisibleForMatch = value($builtForMatch->isVisible());
+        $isVisibleForNoMatch = value($builtForNoMatch->isVisible());
+
+        expect($isVisibleForMatch)->toBeTrue()
+            ->and($isVisibleForNoMatch)->toBeFalse();
+    });
+
+    it('keeps visibleJs reactive behavior for pure same-record custom-field conditions (no regression)', function (): void {
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Same-record Section',
+            'entity_type' => Post::class,
+            'active' => true,
+        ]);
+
+        $triggerField = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Trigger',
+            'code' => 'trigger_field',
+            'type' => 'text',
+            'entity_type' => Post::class,
+        ]);
+
+        $conditionalField = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Conditional',
+            'code' => 'conditional_field',
+            'type' => 'text',
+            'entity_type' => Post::class,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [[
+                        'field_code' => 'trigger_field',
+                        'operator' => VisibilityOperator::EQUALS,
+                        'value' => 'active',
+                        'source' => ConditionSource::CustomField,
+                    ]],
+                ],
+            ],
+        ]);
+
+        $factory = app(FieldComponentFactory::class);
+        $allFields = collect([$triggerField, $conditionalField]);
+
+        $built = $factory->create($conditionalField, [], $allFields, null);
+
+        // Pure custom-field conditions must drive visibility through the reactive client-side JS
+        // path (visibleJs + live), NOT a server-side visible() closure. Asserting only isVisible()
+        // would pass even if no JS were attached, so we assert the JS expression itself is present.
+        $visibleJs = $built->getVisibleJs();
+
+        expect($visibleJs)
+            ->toBeString()
+            ->not->toBeEmpty()
+            ->and($built->isLive())->toBeTrue();
+
+        // It must also match what the frontend service builds for this field, proving the
+        // same-record JS path (not the relation-condition server-side fallback) was taken.
+        $expectedJs = app(FrontendVisibilityService::class)
+            ->buildVisibilityExpression($conditionalField, $allFields);
+
+        expect($expectedJs)
+            ->toBeString()
+            ->not->toBeEmpty()
+            ->and($visibleJs)->toBe($expectedJs);
+    });
+});

--- a/tests/Feature/Integration/FieldComponentFactoryBackCompatTest.php
+++ b/tests/Feature/Integration/FieldComponentFactoryBackCompatTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Support\Collection;
+use Relaticle\CustomFields\Contracts\FormComponentInterface;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
+use Relaticle\CustomFields\Filament\Integration\Factories\FieldComponentFactory;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+/**
+ * Regression test: FieldComponentFactory must accept third-party form components
+ * that implement FormComponentInterface directly without extending AbstractFormComponent.
+ * Previously the factory validated against AbstractFormComponent::class, which is a
+ * backward-incompatible restriction on a public extension point.
+ */
+
+// Inline bare-interface implementation — does NOT extend AbstractFormComponent.
+class BareInterfaceFormComponent implements FormComponentInterface
+{
+    public function make(CustomField $customField, array $dependentFieldCodes = [], ?Collection $allFields = null): Field
+    {
+        return TextInput::make($customField->getFieldName());
+    }
+}
+
+// Field type that wires up the bare-interface component.
+class BareInterfaceFieldType extends BaseFieldType
+{
+    public function configure(): FieldSchema
+    {
+        return FieldSchema::text()
+            ->key('bare-interface-type')
+            ->label('Bare Interface Type')
+            ->icon('heroicon-o-pencil')
+            ->formComponent(BareInterfaceFormComponent::class);
+    }
+}
+
+describe('FieldComponentFactory backward-compat: bare FormComponentInterface implementer', function (): void {
+    it('accepts a form component that implements FormComponentInterface without extending AbstractFormComponent', function (): void {
+        CustomFieldsType::register([
+            'bare-interface-type' => BareInterfaceFieldType::class,
+        ]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'BC Test Section',
+            'entity_type' => Post::class,
+            'active' => true,
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'BC Field',
+            'code' => 'bc_field',
+            'type' => 'bare-interface-type',
+        ]);
+
+        $factory = app(FieldComponentFactory::class);
+
+        $result = $factory->create($field);
+
+        expect($result)->toBeInstanceOf(Field::class);
+    });
+
+    it('does NOT throw RuntimeException for bare FormComponentInterface implementers', function (): void {
+        CustomFieldsType::register([
+            'bare-interface-type' => BareInterfaceFieldType::class,
+        ]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'BC Test Section 2',
+            'entity_type' => Post::class,
+            'active' => true,
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'BC Field 2',
+            'code' => 'bc_field_2',
+            'type' => 'bare-interface-type',
+        ]);
+
+        $factory = app(FieldComponentFactory::class);
+
+        expect(fn () => $factory->create($field))->not->toThrow(RuntimeException::class);
+    });
+});

--- a/tests/Feature/ModelAttributeConditionsTest.php
+++ b/tests/Feature/ModelAttributeConditionsTest.php
@@ -388,6 +388,104 @@ describe('Create form fail-open', function (): void {
     });
 });
 
+describe('Frontend JS generation for relation attribute conditions', function (): void {
+    it('returns null JS for field with a relation attribute condition', function (): void {
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $this->section->id,
+            'name' => 'Relation Guarded Field',
+            'code' => 'relation_guarded',
+            'type' => 'text',
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [
+                        [
+                            'field_code' => 'tagModels',
+                            'operator' => VisibilityOperator::IS_IN,
+                            'value' => [1],
+                            'source' => ConditionSource::RelationAttribute,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $fields = collect([$field]);
+        $jsExpression = $this->frontendService->buildVisibilityExpression($field, $fields);
+
+        expect($jsExpression)->toBeNull();
+    });
+
+    it('returns null JS for section with a relation attribute condition', function (): void {
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Relation Section',
+            'entity_type' => Post::class,
+            'active' => true,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [
+                        [
+                            'field_code' => 'tagModels',
+                            'operator' => VisibilityOperator::IS_IN,
+                            'value' => [1],
+                            'source' => ConditionSource::RelationAttribute,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $jsExpression = $this->frontendService->buildSectionVisibilityExpression($section, collect());
+
+        expect($jsExpression)->toBeNull();
+    });
+
+    it('returns null JS for field with mixed custom field and relation attribute conditions', function (): void {
+        $triggerField = CustomField::factory()->create([
+            'custom_field_section_id' => $this->section->id,
+            'name' => 'Trigger For Relation',
+            'code' => 'trigger_for_relation',
+            'type' => 'text',
+        ]);
+
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $this->section->id,
+            'name' => 'Mixed Relation Guarded',
+            'code' => 'mixed_relation_guarded',
+            'type' => 'text',
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [
+                        [
+                            'field_code' => 'trigger_for_relation',
+                            'operator' => VisibilityOperator::EQUALS,
+                            'value' => 'yes',
+                            'source' => ConditionSource::CustomField,
+                        ],
+                        [
+                            'field_code' => 'tagModels',
+                            'operator' => VisibilityOperator::IS_IN,
+                            'value' => [1],
+                            'source' => ConditionSource::RelationAttribute,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $fields = collect([$triggerField, $field]);
+        $jsExpression = $this->frontendService->buildVisibilityExpression($field, $fields);
+
+        // Entire set emits null because a relation condition is present (server-side only)
+        expect($jsExpression)->toBeNull();
+    });
+});
+
 describe('Frontend JS generation for model attributes', function (): void {
     it('generates correct JS path for model attribute conditions', function (): void {
         $field = CustomField::factory()->create([

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use Relaticle\CustomFields\Data\VisibilityData;
 use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Services\RelationConditionResolver;
 use Relaticle\CustomFields\Support\RelationConditionConfig;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
@@ -127,36 +129,64 @@ it('returns null when reflecting an invalid path', function (): void {
     expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.nonExistentRelation'))->toBeNull();
 });
 
-it('reads per-entity relation and scoping config', function (): void {
-    config()->set('custom-fields.visibility', [
-        'restrict_to_configured' => true,
-        'sources' => [
-            Comment::class => [
-                'relations' => ['post.tagModels' => 'Post → Tags'],
-            ],
+it('reads per-entity relation config from the entity registry', function (): void {
+    $config = app(RelationConditionConfig::class);
+
+    expect($config->relationsFor(Comment::class))->toBe(['post.tagModels' => 'Post → Tags'])
+        ->and($config->isRelationSourceAvailable(Comment::class))->toBeTrue();
+});
+
+it('does not expose the relation source for an entity without configured paths', function (): void {
+    $config = app(RelationConditionConfig::class);
+
+    expect($config->relationsFor(Post::class))->toBe([])
+        ->and($config->isRelationSourceAvailable(Post::class))->toBeFalse();
+});
+
+it('reflects per-entity relation overrides registered at runtime', function (): void {
+    $this->setEntityConditionRelations([
+        Comment::class => [
+            'post.tagModels' => 'Post → Tags',
+            'post' => 'Post',
         ],
     ]);
 
     $config = app(RelationConditionConfig::class);
 
-    expect($config->restrictToConfigured())->toBeTrue()
-        ->and($config->relationsFor(Comment::class))->toBe(['post.tagModels' => 'Post → Tags'])
-        ->and($config->isRelationSourceAvailable(Comment::class))->toBeTrue()
-        ->and($config->isRelationSourceAvailable(Post::class))->toBeFalse()
-        ->and($config->isModelAttributeSourceAvailable(Post::class))->toBeFalse(); // restricted + no attributes
+    expect($config->relationsFor(Comment::class))->toBe([
+        'post.tagModels' => 'Post → Tags',
+        'post' => 'Post',
+    ]);
 });
 
-it('defaults to legacy behavior (model-attribute available everywhere) when not restricted', function (): void {
-    config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
+it('evaluates relation conditions even when MODEL_ATTRIBUTE_CONDITIONS is disabled', function (): void {
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)
+        ->disable(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS)
+    );
 
-    expect(app(RelationConditionConfig::class)->isModelAttributeSourceAvailable(Post::class))->toBeTrue();
-});
+    $matching = Tag::factory()->create();
+    $other = Tag::factory()->create();
 
-it('does not expose the relation source unless a path is configured, even when unrestricted', function (): void {
-    config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
+    $postWithMatch = Post::factory()->create();
+    $postWithMatch->tagModels()->attach($matching);
+    $commentMatch = Comment::factory()->create(['post_id' => $postWithMatch->id]);
 
-    $config = app(RelationConditionConfig::class);
+    $postNoMatch = Post::factory()->create();
+    $postNoMatch->tagModels()->attach($other);
+    $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
 
-    expect($config->isRelationSourceAvailable(Post::class))->toBeFalse()
-        ->and($config->isModelAttributeSourceAvailable(Post::class))->toBeTrue();
+    $visibility = VisibilityData::from([
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'post.tagModels',
+            'operator' => VisibilityOperator::IS_IN,
+            'value' => [$matching->id],
+            'source' => ConditionSource::RelationAttribute,
+        ]],
+    ]);
+
+    expect($visibility->evaluate([], $commentMatch))->toBeTrue()
+        ->and($visibility->evaluate([], $commentNoMatch))->toBeFalse();
 });

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -13,7 +13,7 @@ use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 
-it('shows when the related set matches, hides when it does not (the 3 AC cases)', function () {
+it('shows when the related set matches, hides when it does not (the 3 AC cases)', function (): void {
     $matching = Tag::factory()->create();
     $other = Tag::factory()->create();
 
@@ -42,10 +42,10 @@ it('shows when the related set matches, hides when it does not (the 3 AC cases)'
     expect($visibility->evaluate([], $commentMatch))->toBeTrue()
         ->and($visibility->evaluate([], $commentNoMatch))->toBeFalse()
         ->and($visibility->evaluate([], $commentNoTags))->toBeFalse()
-        ->and($visibility->evaluate([], null))->toBeTrue(); // create form: fail-open
+        ->and($visibility->evaluate([]))->toBeTrue(); // create form: fail-open
 });
 
-it('is_not_in shows for a member with no related records', function () {
+it('is_not_in shows for a member with no related records', function (): void {
     $tag = Tag::factory()->create();
     $postNoTags = Post::factory()->create();
     $comment = Comment::factory()->create(['post_id' => $postNoTags->id]);
@@ -64,7 +64,7 @@ it('is_not_in shows for a member with no related records', function () {
     expect($visibility->evaluate([], $comment))->toBeTrue();
 });
 
-it('has a helper to detect relation-attribute conditions', function () {
+it('has a helper to detect relation-attribute conditions', function (): void {
     $visibility = VisibilityData::from([
         'mode' => VisibilityMode::SHOW_WHEN,
         'logic' => VisibilityLogic::ALL,
@@ -79,7 +79,7 @@ it('has a helper to detect relation-attribute conditions', function () {
     expect($visibility->hasRelationAttributeConditions())->toBeTrue();
 });
 
-it('wires the Post belongsToMany Tag fixture', function () {
+it('wires the Post belongsToMany Tag fixture', function (): void {
     $post = Post::factory()->create();
     $tag = Tag::factory()->create();
     $post->tagModels()->attach($tag);
@@ -87,7 +87,7 @@ it('wires the Post belongsToMany Tag fixture', function () {
     expect($post->fresh()->tagModels->pluck('id')->all())->toBe([$tag->id]);
 });
 
-it('resolves related keys across a two-hop path', function () {
+it('resolves related keys across a two-hop path', function (): void {
     $resolver = app(RelationConditionResolver::class);
 
     $tagA = Tag::factory()->create();
@@ -100,14 +100,14 @@ it('resolves related keys across a two-hop path', function () {
         ->toEqualCanonicalizing([(string) $tagA->id, (string) $tagB->id]);
 });
 
-it('returns an empty set when an intermediate relation is null', function () {
+it('returns an empty set when an intermediate relation is null', function (): void {
     $resolver = app(RelationConditionResolver::class);
     $comment = Comment::factory()->create(['post_id' => 999999]); // non-existent post, no FK constraint
 
     expect($resolver->resolveRelatedKeys($comment, 'post.tagModels'))->toBe([]);
 });
 
-it('returns an empty set when the terminal relation is empty', function () {
+it('returns an empty set when the terminal relation is empty', function (): void {
     $resolver = app(RelationConditionResolver::class);
     $post = Post::factory()->create(); // no tags attached
     $comment = Comment::factory()->create(['post_id' => $post->id]);
@@ -115,19 +115,19 @@ it('returns an empty set when the terminal relation is empty', function () {
     expect($resolver->resolveRelatedKeys($comment, 'post.tagModels'))->toBe([]);
 });
 
-it('reflects the terminal related model from a path', function () {
+it('reflects the terminal related model from a path', function (): void {
     $resolver = app(RelationConditionResolver::class);
 
     expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.tagModels'))->toBeInstanceOf(Tag::class);
 });
 
-it('returns null when reflecting an invalid path', function () {
+it('returns null when reflecting an invalid path', function (): void {
     $resolver = app(RelationConditionResolver::class);
 
     expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.nonExistentRelation'))->toBeNull();
 });
 
-it('reads per-entity relation and scoping config', function () {
+it('reads per-entity relation and scoping config', function (): void {
     config()->set('custom-fields.visibility', [
         'restrict_to_configured' => true,
         'sources' => [
@@ -146,13 +146,13 @@ it('reads per-entity relation and scoping config', function () {
         ->and($config->isModelAttributeSourceAvailable(Post::class))->toBeFalse(); // restricted + no attributes
 });
 
-it('defaults to legacy behavior (model-attribute available everywhere) when not restricted', function () {
+it('defaults to legacy behavior (model-attribute available everywhere) when not restricted', function (): void {
     config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
 
     expect(app(RelationConditionConfig::class)->isModelAttributeSourceAvailable(Post::class))->toBeTrue();
 });
 
-it('does not expose the relation source unless a path is configured, even when unrestricted', function () {
+it('does not expose the relation source unless a path is configured, even when unrestricted', function (): void {
     config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
 
     $config = app(RelationConditionConfig::class);

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -8,6 +8,7 @@ use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Relaticle\CustomFields\Services\RelationConditionResolver;
+use Relaticle\CustomFields\Support\RelationConditionConfig;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
@@ -124,4 +125,38 @@ it('returns null when reflecting an invalid path', function () {
     $resolver = app(RelationConditionResolver::class);
 
     expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.nonExistentRelation'))->toBeNull();
+});
+
+it('reads per-entity relation and scoping config', function () {
+    config()->set('custom-fields.visibility', [
+        'restrict_to_configured' => true,
+        'sources' => [
+            Comment::class => [
+                'relations' => ['post.tagModels' => 'Post → Tags'],
+            ],
+        ],
+    ]);
+
+    $config = app(RelationConditionConfig::class);
+
+    expect($config->restrictToConfigured())->toBeTrue()
+        ->and($config->relationsFor(Comment::class))->toBe(['post.tagModels' => 'Post → Tags'])
+        ->and($config->isRelationSourceAvailable(Comment::class))->toBeTrue()
+        ->and($config->isRelationSourceAvailable(Post::class))->toBeFalse()
+        ->and($config->isModelAttributeSourceAvailable(Post::class))->toBeFalse(); // restricted + no attributes
+});
+
+it('defaults to legacy behavior (model-attribute available everywhere) when not restricted', function () {
+    config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
+
+    expect(app(RelationConditionConfig::class)->isModelAttributeSourceAvailable(Post::class))->toBeTrue();
+});
+
+it('does not expose the relation source unless a path is configured, even when unrestricted', function () {
+    config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
+
+    $config = app(RelationConditionConfig::class);
+
+    expect($config->isRelationSourceAvailable(Post::class))->toBeFalse()
+        ->and($config->isModelAttributeSourceAvailable(Post::class))->toBeTrue();
 });

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Services\RelationConditionResolver;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 
@@ -11,4 +13,44 @@ it('wires the Post belongsToMany Tag fixture', function () {
     $post->tagModels()->attach($tag);
 
     expect($post->fresh()->tagModels->pluck('id')->all())->toBe([$tag->id]);
+});
+
+it('resolves related keys across a two-hop path', function () {
+    $resolver = app(RelationConditionResolver::class);
+
+    $tagA = Tag::factory()->create();
+    $tagB = Tag::factory()->create();
+    $post = Post::factory()->create();
+    $post->tagModels()->attach([$tagA->id, $tagB->id]);
+    $comment = Comment::factory()->create(['post_id' => $post->id]);
+
+    expect($resolver->resolveRelatedKeys($comment, 'post.tagModels'))
+        ->toEqualCanonicalizing([(string) $tagA->id, (string) $tagB->id]);
+});
+
+it('returns an empty set when an intermediate relation is null', function () {
+    $resolver = app(RelationConditionResolver::class);
+    $comment = Comment::factory()->create(['post_id' => 999999]); // non-existent post, no FK constraint
+
+    expect($resolver->resolveRelatedKeys($comment, 'post.tagModels'))->toBe([]);
+});
+
+it('returns an empty set when the terminal relation is empty', function () {
+    $resolver = app(RelationConditionResolver::class);
+    $post = Post::factory()->create(); // no tags attached
+    $comment = Comment::factory()->create(['post_id' => $post->id]);
+
+    expect($resolver->resolveRelatedKeys($comment, 'post.tagModels'))->toBe([]);
+});
+
+it('reflects the terminal related model from a path', function () {
+    $resolver = app(RelationConditionResolver::class);
+
+    expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.tagModels'))->toBeInstanceOf(Tag::class);
+});
+
+it('returns null when reflecting an invalid path', function () {
+    $resolver = app(RelationConditionResolver::class);
+
+    expect($resolver->resolveTerminalRelatedModel(Comment::class, 'post.nonExistentRelation'))->toBeNull();
 });

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
+
+it('wires the Post belongsToMany Tag fixture', function () {
+    $post = Post::factory()->create();
+    $tag = Tag::factory()->create();
+    $post->tagModels()->attach($tag);
+
+    expect($post->fresh()->tagModels->pluck('id')->all())->toBe([$tag->id]);
+});

--- a/tests/Feature/RelationConditionsTest.php
+++ b/tests/Feature/RelationConditionsTest.php
@@ -2,10 +2,81 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Data\VisibilityData;
+use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\VisibilityLogic;
+use Relaticle\CustomFields\Enums\VisibilityMode;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Relaticle\CustomFields\Services\RelationConditionResolver;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
+
+it('shows when the related set matches, hides when it does not (the 3 AC cases)', function () {
+    $matching = Tag::factory()->create();
+    $other = Tag::factory()->create();
+
+    $postWithMatch = Post::factory()->create();
+    $postWithMatch->tagModels()->attach($matching);
+    $commentMatch = Comment::factory()->create(['post_id' => $postWithMatch->id]);
+
+    $postNoMatch = Post::factory()->create();
+    $postNoMatch->tagModels()->attach($other);
+    $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+    $postNoTags = Post::factory()->create();
+    $commentNoTags = Comment::factory()->create(['post_id' => $postNoTags->id]);
+
+    $visibility = VisibilityData::from([
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'post.tagModels',
+            'operator' => VisibilityOperator::IS_IN,
+            'value' => [$matching->id],
+            'source' => ConditionSource::RelationAttribute,
+        ]],
+    ]);
+
+    expect($visibility->evaluate([], $commentMatch))->toBeTrue()
+        ->and($visibility->evaluate([], $commentNoMatch))->toBeFalse()
+        ->and($visibility->evaluate([], $commentNoTags))->toBeFalse()
+        ->and($visibility->evaluate([], null))->toBeTrue(); // create form: fail-open
+});
+
+it('is_not_in shows for a member with no related records', function () {
+    $tag = Tag::factory()->create();
+    $postNoTags = Post::factory()->create();
+    $comment = Comment::factory()->create(['post_id' => $postNoTags->id]);
+
+    $visibility = VisibilityData::from([
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'post.tagModels',
+            'operator' => VisibilityOperator::IS_NOT_IN,
+            'value' => [$tag->id],
+            'source' => ConditionSource::RelationAttribute,
+        ]],
+    ]);
+
+    expect($visibility->evaluate([], $comment))->toBeTrue();
+});
+
+it('has a helper to detect relation-attribute conditions', function () {
+    $visibility = VisibilityData::from([
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'post.tagModels',
+            'operator' => VisibilityOperator::IS_IN,
+            'value' => [1],
+            'source' => ConditionSource::RelationAttribute,
+        ]],
+    ]);
+
+    expect($visibility->hasRelationAttributeConditions())->toBeTrue();
+});
 
 it('wires the Post belongsToMany Tag fixture', function () {
     $post = Post::factory()->create();

--- a/tests/Feature/SectionVisibilityIntegrationTest.php
+++ b/tests/Feature/SectionVisibilityIntegrationTest.php
@@ -14,7 +14,9 @@ use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 
 beforeEach(function (): void {
     config()->set('custom-fields.features', FeatureConfigurator::configure()
@@ -231,5 +233,41 @@ describe('Section visibility with always_visible mode', function (): void {
 
         $post = Post::factory()->create(['is_published' => false]);
         expect($this->coreLogic->evaluateSectionVisibility($section, [], $post))->toBeTrue();
+    });
+});
+
+describe('Section visibility with relation conditions', function (): void {
+    it('evaluates a relation condition on a section server-side', function (): void {
+        $matching = Tag::factory()->create();
+
+        $postMatch = Post::factory()->create();
+        $postMatch->tagModels()->attach($matching);
+        $commentMatch = Comment::factory()->create(['post_id' => $postMatch->id]);
+
+        $postNoMatch = Post::factory()->create();
+        $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Relation Condition Section',
+            'entity_type' => Comment::class,
+            'active' => true,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [
+                        [
+                            'field_code' => 'post.tagModels',
+                            'operator' => VisibilityOperator::IS_IN,
+                            'value' => [$matching->id],
+                            'source' => ConditionSource::RelationAttribute,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        expect($this->backendService->isSectionVisible($commentMatch, $section, collect()))->toBeTrue()
+            ->and($this->backendService->isSectionVisible($commentNoMatch, $section, collect()))->toBeFalse();
     });
 });

--- a/tests/Feature/UnifiedVisibilityConsistencyTest.php
+++ b/tests/Feature/UnifiedVisibilityConsistencyTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Relaticle\CustomFields\Data\VisibilityData;
+use Relaticle\CustomFields\Enums\ConditionSource;
 use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
@@ -14,7 +15,9 @@ use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 
 beforeEach(function (): void {
@@ -383,6 +386,71 @@ test('field types without operator override use dataType defaults', function ():
 
     expect($fieldTypeData->getCompatibleOperators())
         ->toBe($fieldTypeData->dataType->getCompatibleOperators());
+});
+
+test('relation condition is consistent across field, section, backend and JS surfaces', function (): void {
+    $matchingTag = Tag::factory()->create();
+    $otherTag = Tag::factory()->create();
+
+    $postMatch = Post::factory()->create();
+    $postMatch->tagModels()->attach($matchingTag);
+    $commentMatch = Comment::factory()->create(['post_id' => $postMatch->id]);
+
+    $postNoMatch = Post::factory()->create();
+    $postNoMatch->tagModels()->attach($otherTag);
+    $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+    $section = CustomFieldSection::factory()->create([
+        'name' => 'Parity Section',
+        'entity_type' => Comment::class,
+        'active' => true,
+        'settings' => [
+            'visibility' => [
+                'mode' => VisibilityMode::SHOW_WHEN,
+                'logic' => VisibilityLogic::ALL,
+                'conditions' => [[
+                    'field_code' => 'post.tagModels',
+                    'operator' => VisibilityOperator::IS_IN,
+                    'value' => [$matchingTag->id],
+                    'source' => ConditionSource::RelationAttribute,
+                ]],
+            ],
+        ],
+    ]);
+
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Parity Field',
+        'code' => 'parity_field',
+        'type' => 'text',
+        'entity_type' => Comment::class,
+        'settings' => [
+            'visibility' => [
+                'mode' => VisibilityMode::SHOW_WHEN,
+                'logic' => VisibilityLogic::ALL,
+                'conditions' => [[
+                    'field_code' => 'post.tagModels',
+                    'operator' => VisibilityOperator::IS_IN,
+                    'value' => [$matchingTag->id],
+                    'source' => ConditionSource::RelationAttribute,
+                ]],
+            ],
+        ],
+    ]);
+
+    $allFields = collect([$field]);
+
+    // Backend field visibility agrees with match vs no-match
+    expect($this->backendService->isFieldVisible($commentMatch, $field, $allFields))->toBeTrue()
+        ->and($this->backendService->isFieldVisible($commentNoMatch, $field, $allFields))->toBeFalse();
+
+    // Backend section visibility agrees with match vs no-match
+    expect($this->backendService->isSectionVisible($commentMatch, $section, $allFields))->toBeTrue()
+        ->and($this->backendService->isSectionVisible($commentNoMatch, $section, $allFields))->toBeFalse();
+
+    // Relation conditions must never generate client JS
+    expect($this->frontendService->buildVisibilityExpression($field, $allFields))->toBeNull()
+        ->and($this->frontendService->buildSectionVisibilityExpression($section, $allFields))->toBeNull();
 });
 
 class TestRepeaterFieldType extends BaseFieldType

--- a/tests/Feature/VisibilityComponentSourcesTest.php
+++ b/tests/Feature/VisibilityComponentSourcesTest.php
@@ -16,7 +16,7 @@ describe('IS_IN / IS_NOT_IN are not offered by any field data type', function ()
         foreach (FieldDataType::cases() as $dataType) {
             foreach ($forbidden as $operator) {
                 expect($dataType->getCompatibleOperators())
-                    ->not->toContain($operator, "FieldDataType::{$dataType->name} must not include {$operator->name}");
+                    ->not->toContain($operator, sprintf('FieldDataType::%s must not include %s', $dataType->name, $operator->name));
             }
         }
     });
@@ -28,12 +28,12 @@ describe('IS_IN / IS_NOT_IN are not offered by any field data type', function ()
         foreach ($fieldTypes as $type) {
             $fieldTypeData = CustomFieldsType::getFieldType($type);
 
-            expect($fieldTypeData)->not->toBeNull("Field type '{$type}' must be registered");
+            expect($fieldTypeData)->not->toBeNull(sprintf("Field type '%s' must be registered", $type));
 
             $operatorKeys = array_keys($fieldTypeData->getCompatibleOperatorOptions());
 
             foreach ($forbiddenValues as $value) {
-                expect($operatorKeys)->not->toContain($value, "Field type '{$type}' must not include operator '{$value}'");
+                expect($operatorKeys)->not->toContain($value, sprintf("Field type '%s' must not include operator '%s'", $type, $value));
             }
         }
     });

--- a/tests/Feature/VisibilityComponentSourcesTest.php
+++ b/tests/Feature/VisibilityComponentSourcesTest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Utilities\Get;
 use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
 use Relaticle\CustomFields\Support\RelationConditionConfig;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
@@ -100,5 +103,37 @@ describe('RelationConditionConfig source availability', function (): void {
             'post.tagModels' => 'Post → Tags',
             'post' => 'Post',
         ])->and($config->relationsFor(Post::class))->toBe([]);
+    });
+});
+
+describe('custom-field fallback operator set excludes relation-only operators', function (): void {
+    it('does not include IS_IN or IS_NOT_IN when no field type data is available (custom-field source with blank field_code)', function (): void {
+        // VisibilityComponent::getCompatibleOperators() is private; we reach it via reflection
+        // to verify the fallback branch (no $fieldData) excludes relation-only operators.
+        $component = new VisibilityComponent;
+
+        $method = new ReflectionMethod($component, 'getCompatibleOperators');
+        $method->setAccessible(true);
+
+        // Build a minimal Get stub that returns null/blank for all keys (simulates blank field_code,
+        // CustomField source), forcing $fieldData to be null so the fallback branch executes.
+        $get = new class extends Get
+        {
+            public function __construct()
+            {
+                // Skip parent constructor (which needs a Component) — we only need __invoke.
+            }
+
+            public function __invoke(string|Component $path = '', bool $isAbsolute = false): mixed
+            {
+                return null;
+            }
+        };
+
+        $operators = $method->invoke($component, $get);
+
+        expect(array_keys($operators))
+            ->not->toContain(VisibilityOperator::IS_IN->value, 'IS_IN must be excluded from the custom-field fallback operator list')
+            ->not->toContain(VisibilityOperator::IS_NOT_IN->value, 'IS_NOT_IN must be excluded from the custom-field fallback operator list');
     });
 });

--- a/tests/Feature/VisibilityComponentSourcesTest.php
+++ b/tests/Feature/VisibilityComponentSourcesTest.php
@@ -44,56 +44,17 @@ describe('IS_IN / IS_NOT_IN are not offered by any field data type', function ()
 
 describe('RelationConditionConfig source availability', function (): void {
     it('relation source is only offered when paths are configured for the entity', function (): void {
-        config()->set('custom-fields.visibility', [
-            'restrict_to_configured' => false,
-            'sources' => [
-                Comment::class => [
-                    'relations' => ['post.tagModels' => 'Post → Tags'],
-                ],
-            ],
-        ]);
-
         $config = app(RelationConditionConfig::class);
 
         expect($config->isRelationSourceAvailable(Comment::class))->toBeTrue()
             ->and($config->isRelationSourceAvailable(Post::class))->toBeFalse();
     });
 
-    it('model-attribute source is available for all entities when not restricted', function (): void {
-        config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
-
-        $config = app(RelationConditionConfig::class);
-
-        expect($config->isModelAttributeSourceAvailable(Post::class))->toBeTrue()
-            ->and($config->isModelAttributeSourceAvailable(Comment::class))->toBeTrue();
-    });
-
-    it('model-attribute source is unavailable when restricted with no configured attributes', function (): void {
-        config()->set('custom-fields.visibility', [
-            'restrict_to_configured' => true,
-            'sources' => [
-                Comment::class => [
-                    'relations' => ['post.tagModels' => 'Post → Tags'],
-                ],
-            ],
-        ]);
-
-        $config = app(RelationConditionConfig::class);
-
-        expect($config->isModelAttributeSourceAvailable(Post::class))->toBeFalse()
-            ->and($config->isModelAttributeSourceAvailable(Comment::class))->toBeFalse();
-    });
-
     it('relationsFor returns configured paths for the entity', function (): void {
-        config()->set('custom-fields.visibility', [
-            'restrict_to_configured' => false,
-            'sources' => [
-                Comment::class => [
-                    'relations' => [
-                        'post.tagModels' => 'Post → Tags',
-                        'post' => 'Post',
-                    ],
-                ],
+        $this->setEntityConditionRelations([
+            Comment::class => [
+                'post.tagModels' => 'Post → Tags',
+                'post' => 'Post',
             ],
         ]);
 

--- a/tests/Feature/VisibilityComponentSourcesTest.php
+++ b/tests/Feature/VisibilityComponentSourcesTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\FieldDataType;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\Support\RelationConditionConfig;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+describe('IS_IN / IS_NOT_IN are not offered by any field data type', function (): void {
+    it('excludes IS_IN and IS_NOT_IN from all FieldDataType compatible operator sets', function (): void {
+        $forbidden = [VisibilityOperator::IS_IN, VisibilityOperator::IS_NOT_IN];
+
+        foreach (FieldDataType::cases() as $dataType) {
+            foreach ($forbidden as $operator) {
+                expect($dataType->getCompatibleOperators())
+                    ->not->toContain($operator, "FieldDataType::{$dataType->name} must not include {$operator->name}");
+            }
+        }
+    });
+
+    it('excludes IS_IN and IS_NOT_IN from every registered field type compatible operator options', function (): void {
+        $forbiddenValues = [VisibilityOperator::IS_IN->value, VisibilityOperator::IS_NOT_IN->value];
+        $fieldTypes = ['text', 'textarea', 'number', 'select', 'checkbox', 'radio', 'date', 'date-time', 'toggle', 'tags-input'];
+
+        foreach ($fieldTypes as $type) {
+            $fieldTypeData = CustomFieldsType::getFieldType($type);
+
+            expect($fieldTypeData)->not->toBeNull("Field type '{$type}' must be registered");
+
+            $operatorKeys = array_keys($fieldTypeData->getCompatibleOperatorOptions());
+
+            foreach ($forbiddenValues as $value) {
+                expect($operatorKeys)->not->toContain($value, "Field type '{$type}' must not include operator '{$value}'");
+            }
+        }
+    });
+});
+
+describe('RelationConditionConfig source availability', function (): void {
+    it('relation source is only offered when paths are configured for the entity', function (): void {
+        config()->set('custom-fields.visibility', [
+            'restrict_to_configured' => false,
+            'sources' => [
+                Comment::class => [
+                    'relations' => ['post.tagModels' => 'Post → Tags'],
+                ],
+            ],
+        ]);
+
+        $config = app(RelationConditionConfig::class);
+
+        expect($config->isRelationSourceAvailable(Comment::class))->toBeTrue()
+            ->and($config->isRelationSourceAvailable(Post::class))->toBeFalse();
+    });
+
+    it('model-attribute source is available for all entities when not restricted', function (): void {
+        config()->set('custom-fields.visibility', ['restrict_to_configured' => false, 'sources' => []]);
+
+        $config = app(RelationConditionConfig::class);
+
+        expect($config->isModelAttributeSourceAvailable(Post::class))->toBeTrue()
+            ->and($config->isModelAttributeSourceAvailable(Comment::class))->toBeTrue();
+    });
+
+    it('model-attribute source is unavailable when restricted with no configured attributes', function (): void {
+        config()->set('custom-fields.visibility', [
+            'restrict_to_configured' => true,
+            'sources' => [
+                Comment::class => [
+                    'relations' => ['post.tagModels' => 'Post → Tags'],
+                ],
+            ],
+        ]);
+
+        $config = app(RelationConditionConfig::class);
+
+        expect($config->isModelAttributeSourceAvailable(Post::class))->toBeFalse()
+            ->and($config->isModelAttributeSourceAvailable(Comment::class))->toBeFalse();
+    });
+
+    it('relationsFor returns configured paths for the entity', function (): void {
+        config()->set('custom-fields.visibility', [
+            'restrict_to_configured' => false,
+            'sources' => [
+                Comment::class => [
+                    'relations' => [
+                        'post.tagModels' => 'Post → Tags',
+                        'post' => 'Post',
+                    ],
+                ],
+            ],
+        ]);
+
+        $config = app(RelationConditionConfig::class);
+
+        expect($config->relationsFor(Comment::class))->toBe([
+            'post.tagModels' => 'Post → Tags',
+            'post' => 'Post',
+        ])->and($config->relationsFor(Post::class))->toBe([]);
+    });
+});

--- a/tests/Feature/VisibilityComponentSourcesTest.php
+++ b/tests/Feature/VisibilityComponentSourcesTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
+use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
 use Relaticle\CustomFields\Support\RelationConditionConfig;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
@@ -96,5 +99,47 @@ describe('custom-field fallback operator set excludes relation-only operators', 
         expect(array_keys($operators))
             ->not->toContain(VisibilityOperator::IS_IN->value, 'IS_IN must be excluded from the custom-field fallback operator list')
             ->not->toContain(VisibilityOperator::IS_NOT_IN->value, 'IS_NOT_IN must be excluded from the custom-field fallback operator list');
+    });
+});
+
+describe('source picker visibility is resolved per-render (regression: build-time gate missed relation sources)', function (): void {
+    it('getAvailableSourceOptions returns relation_attribute for a relation-configured entity even when MODEL_ATTRIBUTE_CONDITIONS is disabled', function (): void {
+        // Disable the model-attribute flag — the old build-time code would fall back to
+        // Hidden::make('source') here because $relationsAvailable was computed with a null
+        // entity (no $get in Livewire action context). The fix evaluates per-render via $get.
+        config()->set('custom-fields.features',
+            FeatureConfigurator::configure()
+                ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)
+                ->disable(CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS)
+        );
+
+        // Comment is registered with conditionRelations in the test harness (post.tagModels => ...).
+        $component = VisibilityComponent::makeForSection(Comment::class);
+
+        $method = new ReflectionMethod($component, 'getAvailableSourceOptions');
+        $method->setAccessible(true);
+
+        $get = new class extends Get
+        {
+            public function __construct()
+            {
+                // Skip parent constructor (which needs a Component) — we only need __invoke.
+            }
+
+            public function __invoke(string|Component $path = '', bool $isAbsolute = false): mixed
+            {
+                return null;
+            }
+        };
+
+        $options = $method->invoke($component, $get);
+
+        expect(array_keys($options))
+            ->toContain(ConditionSource::RelationAttribute->value)
+            ->not->toContain(ConditionSource::ModelAttribute->value);
+
+        // The source Select's visible() closure uses count($options) > 1 — verify that condition holds,
+        // proving the picker would be rendered (not hidden) for this entity configuration.
+        expect(count($options))->toBeGreaterThan(1);
     });
 });

--- a/tests/Fixtures/Models/Post.php
+++ b/tests/Fixtures/Models/Post.php
@@ -5,6 +5,7 @@ namespace Relaticle\CustomFields\Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Relaticle\CustomFields\Models\Concerns\UsesCustomFields;
 use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
@@ -27,6 +28,11 @@ class Post extends Model implements HasCustomFields
     public function author(): BelongsTo
     {
         return $this->belongsTo(User::class, 'author_id');
+    }
+
+    public function tagModels(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'post_tag');
     }
 
     protected static function newFactory()

--- a/tests/Fixtures/Models/Tag.php
+++ b/tests/Fixtures/Models/Tag.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Relaticle\CustomFields\Tests\Database\Factories\TagFactory;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function posts(): BelongsToMany
+    {
+        return $this->belongsToMany(Post::class, 'post_tag');
+    }
+
+    protected static function newFactory()
+    {
+        return TagFactory::new();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,6 +126,7 @@ class TestCase extends BaseTestCase
         config()->set('custom-fields.features', FeatureConfigurator::configure()
             ->enable(
                 CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY,
+                CustomFieldsFeature::MODEL_ATTRIBUTE_CONDITIONS,
                 CustomFieldsFeature::UI_TABLE_COLUMNS,
                 CustomFieldsFeature::UI_TOGGLEABLE_COLUMNS,
                 CustomFieldsFeature::UI_TABLE_FILTERS,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,8 +29,10 @@ use Relaticle\CustomFields\EntitySystem\EntityModel;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\EntityFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\Tests\Database\Factories\TagFactory;
 use Relaticle\CustomFields\Tests\database\factories\UserFactory;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 use Relaticle\CustomFields\Tests\Fixtures\Providers\AdminPanelProvider;
 use Spatie\LaravelData\LaravelDataServiceProvider;
@@ -52,6 +54,7 @@ class TestCase extends BaseTestCase
 
         Factory::guessFactoryNamesUsing(
             fn (string $modelName): string => match ($modelName) {
+                Tag::class => TagFactory::class,
                 User::class => UserFactory::class,
                 default => 'Relaticle\\CustomFields\\Database\\Factories\\'.class_basename($modelName).'Factory'
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,14 +23,17 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 use Override;
 use Postare\BladeMdi\BladeMdiServiceProvider;
 use Propaganistas\LaravelPhone\PhoneServiceProvider;
+use Relaticle\CustomFields\Contracts\EntityManagerInterface;
 use Relaticle\CustomFields\CustomFieldsServiceProvider;
 use Relaticle\CustomFields\EntitySystem\EntityConfigurator;
+use Relaticle\CustomFields\EntitySystem\EntityManager;
 use Relaticle\CustomFields\EntitySystem\EntityModel;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\EntityFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Tests\Database\Factories\TagFactory;
 use Relaticle\CustomFields\Tests\database\factories\UserFactory;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
@@ -136,18 +139,7 @@ class TestCase extends BaseTestCase
         );
 
         // Entity configuration for tests using the new builder
-        config()->set('custom-fields.entity_configuration',
-            EntityConfigurator::configure()
-                ->autoDiscover(false)
-                ->models([
-                    EntityModel::configure(
-                        modelClass: Post::class,
-                        labelSingular: 'Post',
-                        searchAttributes: ['title', 'content'],
-                        features: [EntityFeature::CUSTOM_FIELDS, EntityFeature::LOOKUP_SOURCE]
-                    ),
-                ])
-        );
+        $this->registerTestEntities();
 
         // Filament configuration
         config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
@@ -174,5 +166,61 @@ class TestCase extends BaseTestCase
             $table->string('name');
             $table->timestamps();
         });
+    }
+
+    /**
+     * Register the default test entities. The Comment entity declares a cross-record
+     * relation path so RelationAttribute condition tests can resolve it via the registry.
+     *
+     * @param  array<class-string, array<string, string>>  $conditionRelationOverrides  modelClass => (path => label)
+     */
+    protected function registerTestEntities(array $conditionRelationOverrides = []): void
+    {
+        $commentRelations = $conditionRelationOverrides[Comment::class]
+            ?? ['post.tagModels' => 'Post → Tags'];
+
+        $postRelations = $conditionRelationOverrides[Post::class] ?? [];
+
+        config()->set('custom-fields.entity_configuration',
+            EntityConfigurator::configure()
+                ->autoDiscover(false)
+                ->cache(false)
+                ->models([
+                    EntityModel::configure(
+                        modelClass: Post::class,
+                        labelSingular: 'Post',
+                        searchAttributes: ['title', 'content'],
+                        features: [EntityFeature::CUSTOM_FIELDS, EntityFeature::LOOKUP_SOURCE],
+                        conditionRelations: $postRelations,
+                    ),
+                    EntityModel::configure(
+                        modelClass: Comment::class,
+                        labelSingular: 'Comment',
+                        features: [EntityFeature::CUSTOM_FIELDS, EntityFeature::LOOKUP_SOURCE],
+                        conditionRelations: $commentRelations,
+                    ),
+                ])
+        );
+    }
+
+    /**
+     * Re-register test entities with custom cross-record relation paths and rebuild the registry.
+     * Use inside a test to override the defaults set by defineEnvironment().
+     *
+     * @param  array<class-string, array<string, string>>  $conditionRelations  modelClass => (path => label)
+     */
+    protected function setEntityConditionRelations(array $conditionRelations): void
+    {
+        $this->registerTestEntities($conditionRelations);
+        $this->refreshEntityManager();
+    }
+
+    /**
+     * Forget the EntityManager singletons so the next resolution rebuilds from current config.
+     */
+    protected function refreshEntityManager(): void
+    {
+        $this->app->forgetInstance(EntityManager::class);
+        $this->app->forgetInstance(EntityManagerInterface::class);
     }
 }

--- a/tests/database/factories/TagFactory.php
+++ b/tests/database/factories/TagFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Tests\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
+
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+        ];
+    }
+}

--- a/tests/database/migrations/create_post_tag_table.php
+++ b/tests/database/migrations/create_post_tag_table.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('post_tag', function (Blueprint $table): void {
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+        });
+    }
+};

--- a/tests/database/migrations/create_tags_table.php
+++ b/tests/database/migrations/create_tags_table.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Extends the package so a custom-field/section visibility condition can reference a **related record** via a one/two-hop relation path (e.g. `household.projects`), not just a field on the same record.

Driving use case (ClickUp 868jtwph3, customer: Los Angeles): show an external-ID Section on Household Member only when the member's Household is associated with specific Projects — i.e. `HouseholdMember → Household → Projects`.

## What's new

- **New condition source** `ConditionSource::RelationAttribute` — the dotted relation path is stored in the existing `field_code` (no schema/migration change).
- **New operators** `IS_IN` / `IS_NOT_IN`, set-intersection semantics (string-normalized), exposed only for the relation source.
- **`RelationConditionResolver`** — walks a ≤2-hop dotted path on a record to the set of terminal related keys; reflects the terminal related model (no DB query) for the value picker.
- **Server-side evaluation** (`VisibilityData::evaluateCondition`) — relation conditions resolve against the record's relations and never emit client JS (`FrontendVisibilityService` bails to null); form fields/sections fall back to a server-side `visible()` closure. Create form (no record) → fail-open.
- **Management UI** (`VisibilityComponent`) — relation source option, path picker (from config allowlist), `IS_IN`/`IS_NOT_IN` operator menu, and a related-record multi-select value picker (with edit-time hydration).
- **Opt-in scoping** (`RelationConditionConfig`, `config('custom-fields.visibility')`) — per-entity allowlist of relation paths; `restrict_to_configured` (default `false`) governs the own-column model-attribute source so existing flag behavior is unchanged.

## Backward compatibility

- No public interface/contract signature changed (the `?Model $record` param is on concrete classes only, optional).
- Inert by default: shipped config does not enable `MODEL_ATTRIBUTE_CONDITIONS`; `restrict_to_configured` defaults to legacy behavior.
- Same-record custom-field conditions keep their exact reactive client-JS path.
- Ships as a **minor** (intended `v3.2.0`).

## Test plan

- `vendor/bin/pest --parallel` → 685 passed, 0 failed (2633 assertions)
- `vendor/bin/phpstan analyse` → no errors (254 files)
- `vendor/bin/pest --type-coverage --min=100` → 100%
- `vendor/bin/pint --test` / `vendor/bin/rector --dry-run` → clean

New coverage: operator set-intersection; resolver (2-hop, null intermediate, empty terminal, invalid path); backend eval (matching / non-matching / no-relation / fail-open); section + field server-side wiring; JS exclusion; per-entity scoping + backward-compat defaults; and a consolidated field/section/backend/JS parity test. Adds a `Post belongsToMany Tag` test fixture (prior fixtures had only `BelongsTo`).

## Notes

- N+1 if a relation-conditioned field is placed in a table/export (evaluated per row) — documented inline; eager-load the configured paths there if needed.
