### PR TITLE
fix: apply section-level conditional visibility on infolists

### DIFF
--- a/src/Filament/Integration/Builders/InfolistBuilder.php
+++ b/src/Filament/Integration/Builders/InfolistBuilder.php
@@ -75,8 +75,21 @@ final class InfolistBuilder extends BaseBuilder
             ->filter(fn (CustomField $field): bool => $field->typeData->infolistEntry !== null)
             ->map($createField);
 
+        // Section-level conditional visibility is evaluated server-side per record, mirroring
+        // SectionComponentFactory on the form. Without this the infolist would render a section
+        // whenever it has any visible field, ignoring the section's own visibility condition.
+        $sectionConditionalVisibilityEnabled = FeatureManager::isEnabled(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY);
+        $allFields = $this->getAllFields();
+
         return $this->getFilteredSections()
-            ->map(function (CustomFieldSection $section) use ($sectionInfolistsFactory, $getVisibleFields) {
+            ->map(function (CustomFieldSection $section) use ($sectionInfolistsFactory, $getVisibleFields, $backendVisibilityService, $sectionConditionalVisibilityEnabled, $allFields) {
+                if (
+                    $sectionConditionalVisibilityEnabled
+                    && ! $backendVisibilityService->isSectionVisible($this->model, $section, $allFields)
+                ) {
+                    return null;
+                }
+
                 $fields = $getVisibleFields($section);
 
                 return $fields->isEmpty()

--- a/tests/Feature/SectionVisibilityIntegrationTest.php
+++ b/tests/Feature/SectionVisibilityIntegrationTest.php
@@ -8,6 +8,7 @@ use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\VisibilityLogic;
 use Relaticle\CustomFields\Enums\VisibilityMode;
 use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -269,5 +270,58 @@ describe('Section visibility with relation conditions', function (): void {
 
         expect($this->backendService->isSectionVisible($commentMatch, $section, collect()))->toBeTrue()
             ->and($this->backendService->isSectionVisible($commentNoMatch, $section, collect()))->toBeFalse();
+    });
+
+    it('honors a section relation condition when building the infolist (regression)', function (): void {
+        // The infolist builder previously ignored section-level visibility and rendered a
+        // section whenever it had any visible field, so a relation-conditioned section showed
+        // for every record. Here the section carries an always-visible field, so the only thing
+        // that can hide it is the section-level relation condition itself.
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(CustomFieldsFeature::SYSTEM_SECTIONS)
+            ->enable(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
+        );
+
+        $matching = Tag::factory()->create();
+
+        $postMatch = Post::factory()->create();
+        $postMatch->tagModels()->attach($matching);
+        $commentMatch = Comment::factory()->create(['post_id' => $postMatch->id]);
+
+        $postNoMatch = Post::factory()->create();
+        $commentNoMatch = Comment::factory()->create(['post_id' => $postNoMatch->id]);
+
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Relation Infolist Section',
+            'entity_type' => Comment::class,
+            'active' => true,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [
+                        [
+                            'field_code' => 'post.tagModels',
+                            'operator' => VisibilityOperator::IS_IN,
+                            'value' => [$matching->id],
+                            'source' => ConditionSource::RelationAttribute,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'entity_type' => Comment::class,
+            'name' => 'External Id',
+            'code' => 'external_id',
+            'type' => 'text',
+        ]);
+
+        $sectionsFor = fn (Comment $comment) => CustomFields::infolist()->forModel($comment)->values();
+
+        expect($sectionsFor($commentMatch))->toHaveCount(1)
+            ->and($sectionsFor($commentNoMatch))->toHaveCount(0);
     });
 });


### PR DESCRIPTION
## Problem

Section-level conditional visibility (`SECTION_CONDITIONAL_VISIBILITY`) was applied on **forms** (`SectionComponentFactory`, which receives the record and applies a server-side `visible()` for relation conditions) but **never on infolists**.

`InfolistBuilder::values()` only filtered **fields** (`getVisibleFields`) and dropped a section when it had no visible fields. `SectionInfolistsFactory::create()` builds a plain `Section` with no visibility logic. As a result, a section with a section-level condition rendered for **every** record as long as it had at least one visible field — the section's own condition was ignored on the read/view surface.

This is most visible with **cross-record relation conditions** (e.g. `household.projects IS IN [...]`): the section appeared whenever its configured value matched *anything in the tenant*, regardless of the record being viewed, instead of being scoped to that record.

## Fix

Evaluate the section against the record in `InfolistBuilder::values()`, mirroring the form path:

```php
$sectionConditionalVisibilityEnabled = FeatureManager::isEnabled(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY);
$allFields = $this->getAllFields();

// ...
if ($sectionConditionalVisibilityEnabled
    && ! $backendVisibilityService->isSectionVisible($this->model, $section, $allFields)) {
    return null;
}
```

- Gated on `SECTION_CONDITIONAL_VISIBILITY` (consistent with `SectionComponentFactory`).
- Sections without conditions are unaffected — `evaluateSectionVisibility()` returns `true` when a section has no conditions.
- Field-level visibility behaviour is unchanged.

## Test

Adds a regression test in `SectionVisibilityIntegrationTest` that builds the infolist via `CustomFields::infolist()->forModel($record)->values()` for a relation-conditioned section carrying an always-visible field, and asserts the section is **included for a matching record** and **excluded for a non-matching one**. The test fails on `3.x` without this change and passes with it. Full visibility suite (45 tests / 198 assertions) green.

## Context

Found during a review of a downstream Journey integration enabling cross-record section visibility for Household Member (`household.projects`). On the member view (an infolist) the section showed for every member regardless of the household's projects; this is the upstream root cause.
