### PR TITLE
feat: extensible section form schema via extendSchemaUsing [3.x]

### DIFF
--- a/src/Data/CustomFieldSectionSettingsData.php
+++ b/src/Data/CustomFieldSectionSettingsData.php
@@ -11,7 +11,11 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 #[MapName(SnakeCaseMapper::class)]
 class CustomFieldSectionSettingsData extends Data
 {
+    /**
+     * @param  array<string, mixed>  $extra  Free-form bag for consumer-defined section settings.
+     */
     public function __construct(
         public ?VisibilityData $visibility = null,
+        public array $extra = [],
     ) {}
 }

--- a/src/Filament/Management/Schemas/SectionForm.php
+++ b/src/Filament/Management/Schemas/SectionForm.php
@@ -29,6 +29,9 @@ class SectionForm implements FormInterface, SectionFormInterface
     /** @var ?Closure(Unique, Get):Unique */
     private static ?Closure $modifyUniqueRuleUsing = null;
 
+    /** @var array<int, Closure(array<int, Component>, string): array<int, Component>> */
+    private static array $schemaExtensions = [];
+
     public static function entityType(string $entityType): self
     {
         self::$entityType = $entityType;
@@ -42,6 +45,27 @@ class SectionForm implements FormInterface, SectionFormInterface
         self::$modifyUniqueRuleUsing = $callback;
 
         return $this;
+    }
+
+    /**
+     * Register a callback that can append to or modify the section form schema.
+     * Applies to both the create and edit section modals. The callback receives
+     * the current schema and the section's entity type. Register once (e.g. from
+     * a service provider); extensions persist until flushed.
+     *
+     * @param  Closure(array<int, Component>, string): array<int, Component>  $callback
+     */
+    public static function extendSchemaUsing(Closure $callback): void
+    {
+        self::$schemaExtensions[] = $callback;
+    }
+
+    /**
+     * Clear all registered schema extensions. Primarily for testing.
+     */
+    public static function flushSchemaExtensions(): void
+    {
+        self::$schemaExtensions = [];
     }
 
     private static function buildUniqueRule(Unique $rule, Get $get): Unique
@@ -66,7 +90,7 @@ class SectionForm implements FormInterface, SectionFormInterface
      */
     public static function schema(): array
     {
-        return [
+        $schema = [
             Grid::make(12)->schema([
                 TextInput::make('name')
                     ->label(
@@ -153,6 +177,12 @@ class SectionForm implements FormInterface, SectionFormInterface
                 ...self::visibilitySchema(),
             ]),
         ];
+
+        foreach (self::$schemaExtensions as $extension) {
+            $schema = $extension($schema, self::$entityType);
+        }
+
+        return $schema;
     }
 
     /**

--- a/src/Filament/Management/Schemas/SectionFormInterface.php
+++ b/src/Filament/Management/Schemas/SectionFormInterface.php
@@ -4,7 +4,15 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Filament\Management\Schemas;
 
+use Closure;
+use Filament\Schemas\Components\Component;
+
 interface SectionFormInterface
 {
     public static function entityType(string $entityType): self;
+
+    /**
+     * @param  Closure(array<int, Component>, string): array<int, Component>  $callback
+     */
+    public static function extendSchemaUsing(Closure $callback): void;
 }

--- a/tests/Feature/Admin/Pages/CustomFieldsSectionManagementTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsSectionManagementTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use Filament\Forms\Components\Toggle;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage as CustomFieldsPage;
+use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -281,5 +283,75 @@ describe('ManageCustomFieldSection - Section Actions', function (): void {
             'entityType' => $this->userEntityType,
         ])->assertActionVisible('delete')
             ->assertActionEnabled('delete');
+    });
+});
+
+describe('SectionForm - extendSchemaUsing', function (): void {
+    afterEach(function (): void {
+        SectionForm::flushSchemaExtensions();
+    });
+
+    it('passes the section entity type to the extension callback', function (): void {
+        $captured = null;
+
+        SectionForm::extendSchemaUsing(function (array $schema, string $entityType) use (&$captured): array {
+            $captured = $entityType;
+
+            return $schema;
+        });
+
+        SectionForm::entityType($this->userEntityType)->schema();
+
+        expect($captured)->toBe($this->userEntityType);
+    });
+
+    it('persists a field added via extendSchemaUsing into the settings extra bag on create', function (): void {
+        SectionForm::extendSchemaUsing(fn (array $schema): array => [
+            ...$schema,
+            Toggle::make('settings.extra.render_as_tab')->label('Render as own tab'),
+        ]);
+
+        livewire(CustomFieldsPage::class)
+            ->call('setCurrentEntityType', $this->userEntityType)
+            ->callAction('createSection', [
+                'name' => 'Tabbed Section',
+                'code' => 'tabbed_section',
+                'settings' => ['extra' => ['render_as_tab' => true]],
+            ])
+            ->assertHasNoFormErrors();
+
+        $section = CustomFieldSection::query()
+            ->where('code', 'tabbed_section')
+            ->where('entity_type', $this->userEntityType)
+            ->sole();
+
+        expect($section->settings->extra)->toBe(['render_as_tab' => true]);
+    });
+
+    it('keeps the extra bag value when the section is edited', function (): void {
+        $section = CustomFieldSection::factory()
+            ->forEntityType($this->userEntityType)
+            ->create([
+                'code' => 'tabbed_section',
+                'settings' => ['extra' => ['render_as_tab' => true]],
+            ]);
+
+        SectionForm::extendSchemaUsing(fn (array $schema): array => [
+            ...$schema,
+            Toggle::make('settings.extra.render_as_tab')->label('Render as own tab'),
+        ]);
+
+        livewire(ManageCustomFieldSection::class, [
+            'section' => $section,
+            'entityType' => $this->userEntityType,
+        ])
+            ->callAction('edit', [
+                'name' => 'Renamed Section',
+                'code' => $section->code,
+                'settings' => ['extra' => ['render_as_tab' => true]],
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($section->refresh()->settings->extra)->toBe(['render_as_tab' => true]);
     });
 });


### PR DESCRIPTION
## What

Adds an extension point to the Custom Fields **section management** form.

- **`SectionForm::extendSchemaUsing(Closure $callback)`** — register a callback (e.g. from a service provider) that appends to / modifies the section form schema. A single registration covers **both** the Add and Edit section modals. The callback receives `(array $schema, string $entityType)`, so extensions can be scoped per entity.
- **`SectionForm::flushSchemaExtensions()`** — clears registrations (test isolation).
- **`CustomFieldSectionSettingsData`** gains a free-form `array $extra` bag, so arbitrary consumer-defined settings bound under `settings.extra.*` round-trip through the typed DTO (and through `CustomFieldSectionData` import/export). The typed DTO silently drops unknown keys, so a bag is required for arbitrary flags to survive hydration.

## Why

Applications consuming `CustomFields::infolist()` need to attach their own per-section metadata — e.g. "render this section as its own tab" — without subclassing the form or patching the vendor.

## Usage

```php
// AppServiceProvider::boot()
use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
use Filament\Forms\Components\Toggle;

SectionForm::extendSchemaUsing(fn (array $schema, string $entityType): array => [
    ...$schema,
    Toggle::make('settings.extra.render_as_tab')
        ->label('Render as own tab')
        ->visible($entityType === 'contact'),
]);

// read it back
$renderAsTab = $section->settings->extra['render_as_tab'] ?? false;
```

## Test plan

New tests in `CustomFieldsSectionManagementTest`:
- extension callback receives the section entity type
- a field added via `extendSchemaUsing` persists into `settings.extra` on create
- the `extra` value survives an edit round-trip

Verified locally: full suite **694 passed**; Pint, PHPStan, Rector `--dry-run`, and arch tests all green. (Type coverage sits at 99.4% on `3.x` already — pre-existing, in unrelated files.)

## Notes

- Additive and backward-compatible: the new DTO property defaults to `[]`; the hook is opt-in.
- No migration — `settings` is already JSON.
