### PR TITLE
chore: update CHANGELOG for v3.3.0 [3.x]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `custom-fields` will be documented in this file.
 
+## v3.3.0 - 2026-06-14
+
+### Added
+
+- `SectionForm::extendSchemaUsing()` for extending the custom-field section management form from application code (e.g. a service provider), with no subclassing or vendor patching (#165). A single registration applies to both the Add and Edit section modals, and the callback receives the current schema plus the section's entity type, so extensions can be scoped per entity.
+- A free-form `extra` bag on `CustomFieldSectionSettingsData` (#165). Consumer-defined section settings bound under `settings.extra.*` now round-trip through the typed settings DTO (and through config import/export) — enabling, for example, flagging a section to render as its own tab.
+
 ## v3.2.1 - 2026-06-10
 
 ### Fixed


### PR DESCRIPTION
Documents v3.3.0 in CHANGELOG.md (release already tagged). Routed via PR per the 3.x branch ruleset.