### PR TITLE
fix: preserve condition value on operator change + configurable section modal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `custom-fields` will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Visibility condition value no longer wiped when only the operator changes.** Editing a saved section/field visibility condition and changing its operator (e.g. `Is in` → `Is not in`) reset the stored value to `null`, silently turning the condition into an "is in / is not in nothing" match. The value is now preserved whenever the new operator still takes one, and only cleared for value-less operators (`is set` / `is empty`).
+
+### Added
+
+- **Configurable section modal width.** The add/edit section modal width is now resolved through `CustomFieldsPlugin::make()->sectionModalWidth(...)` (a `Width` case or closure) or the `custom-fields.management.section_modal_width` config key. The default widens to `screen-lg` when section conditional visibility is enabled — previously the add-section modal stayed at `2xl`, cramping the conditions row — and the create/edit modals now resolve to the same width.
+
 ## v3.3.0 - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to `custom-fields` will be documented in this file.
 
 ### Fixed
 
-- **Visibility condition value no longer wiped when only the operator changes.** Editing a saved section/field visibility condition and changing its operator (e.g. `Is in` → `Is not in`) reset the stored value to `null`, silently turning the condition into an "is in / is not in nothing" match. The value is now preserved whenever the new operator still takes one, and only cleared for value-less operators (`is set` / `is empty`).
+- **Visibility condition value no longer wiped when only the operator changes.** Editing a saved section/field visibility condition and changing its operator (e.g. `Is in` → `Is not in`) reset the stored value to `null`, silently turning the condition into an "is in / is not in nothing" match. The value is now preserved whenever the new operator still takes one, and only cleared for value-less operators (`is empty` / `is not empty`).
 
 ### Added
 

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -77,6 +77,11 @@ return [
         'navigation_sort' => -1,
         'navigation_group' => true,
         'cluster' => null,
+
+        // Width of the add/edit section modal. Accepts a Filament\Support\Enums\Width case or its
+        // string value (e.g. 'screen-lg'). Null falls back to a width based on conditional visibility.
+        // Overridable per panel via CustomFieldsPlugin::make()->sectionModalWidth(...).
+        'section_modal_width' => null,
     ],
 
     /*

--- a/src/CustomFieldsPlugin.php
+++ b/src/CustomFieldsPlugin.php
@@ -9,6 +9,7 @@ use Filament\Actions\Action;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
+use Filament\Support\Enums\Width;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -25,6 +26,8 @@ class CustomFieldsPlugin implements Plugin
     protected ?string $dateDisplayFormat = null;
 
     protected ?string $dateTimeDisplayFormat = null;
+
+    protected Width|Closure|null $sectionModalWidth = null;
 
     public function getId(): string
     {
@@ -107,5 +110,34 @@ class CustomFieldsPlugin implements Plugin
         $this->dateTimeDisplayFormat = $format;
 
         return $this;
+    }
+
+    public function sectionModalWidth(Width|Closure|null $width): static
+    {
+        $this->sectionModalWidth = $width;
+
+        return $this;
+    }
+
+    public function getSectionModalWidth(): Width
+    {
+        $width = $this->evaluate($this->sectionModalWidth);
+
+        if (! $width instanceof Width) {
+            $configured = config('custom-fields.management.section_modal_width');
+
+            $width = match (true) {
+                $configured instanceof Width => $configured,
+                is_string($configured) => Width::tryFrom($configured),
+                default => null,
+            };
+        }
+
+        // The conditional-visibility editor adds a four-column conditions row that is unreadable
+        // at the narrower default width, so it gets the wider modal unless overridden.
+        return $width
+            ?? (FeatureManager::isEnabled(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
+                ? Width::ScreenLarge
+                : Width::TwoExtraLarge);
     }
 }

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -130,7 +130,7 @@ final class VisibilityComponent extends Component
             ->options(fn (Get $get): array => $this->getCompatibleOperators($get))
             ->required()
             ->live()
-            ->afterStateUpdated(fn (Set $set) => $this->clearAllValueFields($set))
+            ->afterStateUpdated(fn (Get $get, Set $set) => $this->clearValuesForOperatorChange($get, $set))
             ->columnSpan(2);
 
         $schema = [...$schema, ...$this->getValueInputComponents(4)];
@@ -579,6 +579,18 @@ final class VisibilityComponent extends Component
     {
         $this->clearAllValueFields($set);
         $set('operator', array_key_first($this->getCompatibleOperators($get)));
+    }
+
+    private function clearValuesForOperatorChange(Get $get, Set $set): void
+    {
+        // Switching between value-taking operators (e.g. Is in -> Is not in) must keep the value;
+        // clearing unconditionally here previously wiped a saved condition's value on any operator
+        // change, silently turning it into an "is in / is not in nothing" match.
+        if ($this->operatorRequiresValue($get)) {
+            return;
+        }
+
+        $this->clearAllValueFields($set);
     }
 
     private function clearAllValueFields(Set $set): void

--- a/src/Filament/Management/Pages/CustomFieldsManagementPage.php
+++ b/src/Filament/Management/Pages/CustomFieldsManagementPage.php
@@ -9,7 +9,6 @@ use Filament\Actions\Action;
 use Filament\Pages\Page;
 use Filament\Panel;
 use Filament\Support\Enums\Size;
-use Filament\Support\Enums\Width;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
@@ -156,7 +155,7 @@ class CustomFieldsManagementPage extends Page
             ->schema(SectionForm::entityType($this->currentEntityType)->schema())
             ->action(fn (array $data): CustomFieldSection => $this->storeSection($data))
             ->successNotificationTitle(__('custom-fields::custom-fields.section.notifications.created'))
-            ->modalWidth(Width::TwoExtraLarge);
+            ->modalWidth(CustomFieldsPlugin::get()->getSectionModalWidth());
     }
 
     /**

--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -16,8 +16,7 @@ use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
-use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\CustomFieldsPlugin;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Livewire\Concerns\CreatesCustomFields;
@@ -98,11 +97,7 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
             ->fillForm($this->section->toArray())
             ->action(fn (array $data): bool => ! $this->section->hasSystemDefinedFields() && $this->section->update($data))
             ->visible(fn (CustomFieldSection $record): bool => ! $record->hasSystemDefinedFields())
-            ->modalWidth(
-                FeatureManager::isEnabled(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
-                    ? Width::ScreenLarge
-                    : Width::TwoExtraLarge
-            );
+            ->modalWidth(CustomFieldsPlugin::get()->getSectionModalWidth());
     }
 
     public function activateAction(): Action

--- a/tests/Feature/Admin/Pages/CustomFieldsSectionManagementTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsSectionManagementTest.php
@@ -3,14 +3,22 @@
 declare(strict_types=1);
 
 use Filament\Forms\Components\Toggle;
+use Relaticle\CustomFields\Enums\ConditionSource;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\VisibilityLogic;
+use Relaticle\CustomFields\Enums\VisibilityMode;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage as CustomFieldsPage;
 use Relaticle\CustomFields\Filament\Management\Schemas\SectionForm;
 use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Tag;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 
 beforeEach(function (): void {
@@ -283,6 +291,68 @@ describe('ManageCustomFieldSection - Section Actions', function (): void {
             'entityType' => $this->userEntityType,
         ])->assertActionVisible('delete')
             ->assertActionEnabled('delete');
+    });
+});
+
+describe('ManageCustomFieldSection - condition value persistence', function (): void {
+    it('keeps a saved condition value when only the operator changes on edit', function (): void {
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(
+                CustomFieldsFeature::SYSTEM_SECTIONS,
+                CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+                CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY,
+                CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY,
+            )
+        );
+
+        $this->setEntityConditionRelations([
+            Comment::class => ['post.tagModels' => 'Post → Tags'],
+        ]);
+
+        $tag = Tag::factory()->create();
+
+        $section = CustomFieldSection::factory()
+            ->forEntityType(Comment::class)
+            ->create([
+                'name' => 'Conditional Section',
+                'code' => 'conditional_section',
+                'settings' => [
+                    'visibility' => [
+                        'mode' => VisibilityMode::SHOW_WHEN,
+                        'logic' => VisibilityLogic::ALL,
+                        'conditions' => [
+                            [
+                                'field_code' => 'post.tagModels',
+                                'operator' => VisibilityOperator::IS_IN,
+                                'value' => [$tag->id],
+                                'source' => ConditionSource::RelationAttribute,
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $statePath = 'mountedActions.0.data';
+
+        $component = livewire(ManageCustomFieldSection::class, [
+            'section' => $section,
+            'entityType' => Comment::class,
+        ])->mountAction('edit');
+
+        $conditionKey = array_key_first($component->get($statePath.'.settings.visibility.conditions'));
+
+        $component
+            ->set(sprintf('%s.settings.visibility.conditions.%s.operator', $statePath, $conditionKey), VisibilityOperator::IS_NOT_IN->value)
+            ->callMountedAction()
+            ->assertHasNoFormErrors();
+
+        $condition = app(CoreVisibilityLogicService::class)
+            ->getVisibilityDataFromSection($section->refresh())
+            ->conditions
+            ->first();
+
+        expect($condition->operator)->toBe(VisibilityOperator::IS_NOT_IN)
+            ->and($condition->value)->toBe([$tag->id]);
     });
 });
 

--- a/tests/Feature/SectionModalWidthTest.php
+++ b/tests/Feature/SectionModalWidthTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Enums\Width;
+use Relaticle\CustomFields\CustomFieldsPlugin;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+
+it('widens the section modal to screen-lg when conditional visibility is enabled', function (): void {
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
+    );
+
+    expect(CustomFieldsPlugin::make()->getSectionModalWidth())->toBe(Width::ScreenLarge);
+});
+
+it('keeps the narrower 2xl section modal when conditional visibility is disabled', function (): void {
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS)
+    );
+
+    expect(CustomFieldsPlugin::make()->getSectionModalWidth())->toBe(Width::TwoExtraLarge);
+});
+
+it('honors an explicit plugin override regardless of feature state', function (): void {
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SECTION_CONDITIONAL_VISIBILITY)
+    );
+
+    expect(CustomFieldsPlugin::make()->sectionModalWidth(Width::FourExtraLarge)->getSectionModalWidth())
+        ->toBe(Width::FourExtraLarge);
+});
+
+it('resolves a string width configured via config', function (): void {
+    config()->set('custom-fields.management.section_modal_width', Width::ThreeExtraLarge->value);
+
+    expect(CustomFieldsPlugin::make()->getSectionModalWidth())->toBe(Width::ThreeExtraLarge);
+});
+
+it('prefers the plugin override over the config value', function (): void {
+    config()->set('custom-fields.management.section_modal_width', Width::Medium->value);
+
+    expect(CustomFieldsPlugin::make()->sectionModalWidth(fn (): Width => Width::FiveExtraLarge)->getSectionModalWidth())
+        ->toBe(Width::FiveExtraLarge);
+});


### PR DESCRIPTION
Two related fixes for the section **Conditional Visibility** editor.

## 1. Fix: visibility condition value wiped when only the operator changes (data loss)

Editing a saved section/field visibility condition and changing **only** its operator (e.g. `Is in` → `Is not in`) reset the persisted `value` to `null` — silently turning the condition into an "is in / is not in nothing" match that shows/hides for everyone, with no error.

**Root cause:** the `operator` field's `afterStateUpdated` called `clearAllValueFields()` unconditionally on every change. Since the saved condition stores `field_code / operator / value / source` and `value` is the source of truth, any operator change nulled it.

**Fix:** the value is now preserved whenever the new operator still takes one (`Is in` ↔ `Is not in`, `equals` ↔ `not equals`, …) and is only cleared for value-less operators (`is empty` / `is not empty`). `field_code` / `source` changes still reset the value as before.

## 2. Feat: configurable section modal width (fixes the cramped conditions row)

The add-section modal was hardcoded to `2xl` while the edit-section modal already widened to `screen-lg` for conditional visibility — so the four-column conditions row (Source / Field / Operator / Value) was cramped **only** when adding a section.

Both modals now resolve their width through:

- `CustomFieldsPlugin::make()->sectionModalWidth(Width::ScreenLarge)` (a `Width` case or a closure), or
- the `custom-fields.management.section_modal_width` config key,

defaulting to `screen-lg` when section conditional visibility is enabled (otherwise `2xl`). This also removes the create/edit width inconsistency.

## Test plan

- `tests/Feature/Admin/Pages/CustomFieldsSectionManagementTest.php` — new test mounts the section edit action with a saved relation condition (`Is in`, value `[tag]`), reactively changes the operator to `Is not in`, submits, and asserts the value survives. Verified it **fails** on the old behavior (asserts `null` vs the array) and passes with the fix.
- `tests/Feature/SectionModalWidthTest.php` — covers the width resolution: feature-based default, plugin override, config string, and override precedence.
- Full affected suites green (`Admin`, visibility, section, relation): 173 passed.
- `pint`, `phpstan`, `rector --dry-run` clean. (Type-coverage sits at the pre-existing 99.4% baseline from untouched console commands; all changed files are 100%.)
