### PR TITLE
fix: populate date reference dropdown when creating a custom field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `custom-fields` will be documented in this file.
 
+## v3.4.1 - 2026-06-18
+
+### Fixed
+
+- **Date validation "After another field" reference dropdown now populates when creating a field.** The reference-field selector showed "No options available" while creating a new date custom field — it only worked when editing an existing one. The options closure resolved the entity type through the relative state path `$get('../../../entity_type')`, which inside the field-management action modal (`mountedActions.0.data.*`) climbed past the form-data scope to the Livewire root and returned `null`, short-circuiting to an empty list. It now resolves `entity_type`/`code` via absolute data-scope paths, correct in both the action-modal and page-form contexts (#172).
+
+**Full Changelog**: https://github.com/relaticle/custom-fields/compare/v3.4.0...v3.4.1
+
 ## v3.4.0 - 2026-06-17
 
 ### Fixed

--- a/src/Filament/Management/Forms/Components/DateConstraintField.php
+++ b/src/Filament/Management/Forms/Components/DateConstraintField.php
@@ -85,8 +85,8 @@ final class DateConstraintField
                     Select::make($statePath.'.field_reference')
                         ->label(__('custom-fields::custom-fields.date_constraint.reference_field'))
                         ->options(function (Get $get, ?CustomField $record): array {
-                            $entityType = $record?->entity_type ?? $get('../../../entity_type'); // @phpstan-ignore nullsafe.neverNull
-                            $currentCode = $record?->code ?? $get('../../../code'); // @phpstan-ignore nullsafe.neverNull
+                            $entityType = $record?->entity_type ?? $get('entity_type'); // @phpstan-ignore nullsafe.neverNull
+                            $currentCode = $record?->code ?? $get('code'); // @phpstan-ignore nullsafe.neverNull
 
                             if (! $entityType) {
                                 return [];
@@ -107,13 +107,13 @@ final class DateConstraintField
                                     return;
                                 }
 
-                                $currentCode = $record?->code ?? $get('../../../code'); // @phpstan-ignore nullsafe.neverNull
+                                $currentCode = $record?->code ?? $get('code'); // @phpstan-ignore nullsafe.neverNull
 
                                 if (! $currentCode) {
                                     return;
                                 }
 
-                                $entityType = $record?->entity_type ?? $get('../../../entity_type'); // @phpstan-ignore nullsafe.neverNull
+                                $entityType = $record?->entity_type ?? $get('entity_type'); // @phpstan-ignore nullsafe.neverNull
 
                                 if (! $entityType) {
                                     return;

--- a/tests/Feature/Admin/Pages/DateFieldReferenceOptionsTest.php
+++ b/tests/Feature/Admin/Pages/DateFieldReferenceOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Schema;
+use Livewire\Component;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\Livewire\ManageCustomField;
+use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+function mountedActionReferenceOptions(Component $instance): array
+{
+    $method = new ReflectionMethod($instance, 'getMountedActionSchema');
+    $method->setAccessible(true);
+
+    /** @var Schema $schema */
+    $schema = $method->invoke($instance);
+
+    /** @var Select $select */
+    $select = $schema->getComponent(
+        fn ($component): bool => $component instanceof Select
+            && str($component->getStatePath())->endsWith('validation_rules.min_date.field_reference'),
+        withHidden: true,
+    );
+
+    return $select->getOptions();
+}
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->entityType = User::class;
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType($this->entityType)
+        ->create();
+
+    config()->set('custom-fields.features', FeatureConfigurator::configure()
+        ->enable(
+            CustomFieldsFeature::FIELD_VALIDATION_RULES,
+            CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+            CustomFieldsFeature::SYSTEM_SECTIONS,
+        )
+    );
+
+    $this->startField = CustomField::factory()
+        ->ofType('date')
+        ->create([
+            'custom_field_section_id' => $this->section->getKey(),
+            'entity_type' => $this->entityType,
+            'name' => 'Start Date',
+            'code' => 'start_date',
+        ]);
+});
+
+it('lists sibling date fields in the reference dropdown when creating a new field', function (): void {
+    $component = livewire(ManageCustomFieldSection::class, [
+        'section' => $this->section,
+        'entityType' => $this->entityType,
+    ])->mountAction('createField')->setActionData([
+        'type' => 'date',
+        'name' => 'End Date',
+        'code' => 'end_date',
+        'validation_rules' => [
+            'min_date' => ['preset' => 'custom_field', 'anchor' => 'custom_field'],
+        ],
+    ])->instance();
+
+    expect(mountedActionReferenceOptions($component))
+        ->toBe(['start_date' => 'Start Date']);
+});
+
+it('lists sibling date fields in the reference dropdown when editing a field', function (): void {
+    $endField = CustomField::factory()
+        ->ofType('date')
+        ->create([
+            'custom_field_section_id' => $this->section->getKey(),
+            'entity_type' => $this->entityType,
+            'name' => 'End Date',
+            'code' => 'end_date',
+        ]);
+
+    $component = livewire(ManageCustomField::class, ['field' => $endField])
+        ->mountAction('edit')
+        ->setActionData([
+            'validation_rules' => [
+                'min_date' => ['preset' => 'custom_field', 'anchor' => 'custom_field'],
+            ],
+        ])->instance();
+
+    expect(mountedActionReferenceOptions($component))
+        ->toBe(['start_date' => 'Start Date']);
+});


### PR DESCRIPTION
## Problem

When creating a new date custom field, the **"After another field…"** date
validation constraint shows **"No options available"** in its *Reference field*
dropdown. The same dropdown works correctly when **editing** an existing field.

This forces users to create the field first, save it, then re-open it in edit
mode to wire up the cross-field reference, even when sibling date fields already
exist.

## Root cause

In `DateConstraintField`, the `field_reference` Select's `options()` closure (and
the circular-reference rule closure) resolve the entity type like this:

```php
$entityType = $record?->entity_type ?? $get('../../../entity_type');
```

- On **edit**, `$record` is the loaded `CustomField`, so `$record->entity_type` is
  used and `$get` is never reached → the dropdown populates.
- On **create**, `$record` is `null`, so it falls back to the relative state path.
  The field-management form is rendered inside a Filament **action modal**, where
  form state lives under `mountedActions.0.data.*`. Filament's
  `resolveRelativeStatePath` starts from the container path `mountedActions.0.data`
  and strips one segment per `../`:

  ```
  mountedActions.0.data → mountedActions.0 → mountedActions → (null, overshoots)
  ```

  The three `../` segments climb out of the form-data scope to the Livewire root,
  where no `entity_type` exists, so `$get('../../../entity_type')` returns `null`.
  With `$entityType` null the closure short-circuits to `return []` → an empty list.

The existing date-validation tests didn't catch this because they inject
`field_reference` directly as data and configure the reference via the edit path
(where `$record` provides the entity type), so the create-time dropdown options
were never exercised.

## Fix

Resolve `entity_type` and `code` with **absolute** (data-scope) paths:

```php
$entityType = $record?->entity_type ?? $get('entity_type');
$currentCode = $record?->code ?? $get('code');
```

`entity_type` and `code` are always top-level keys of the field form's data, so
absolute resolution is correct in both the action-modal and page-form contexts
(and is unaffected by how deep the constraint fields are nested). Applied to both
the `options()` closure and the circular-reference rule closure.

## Tests

Added `tests/Feature/Admin/Pages/DateFieldReferenceOptionsTest.php`, which mounts
the real create/edit actions and asserts the reference dropdown lists a sibling
date field. The create case fails on the previous code and passes with the fix;
the edit case is the control. Full date-validation suite (104 tests) is green.