### PR TITLE
fix(i18n): replace hardcoded UI strings with translation keys

### DIFF
--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -78,6 +78,8 @@ return [
             ],
             'add_field' => 'Add Field',
             'search_placeholder' => 'Search fields...',
+            'type_search_prompt' => 'Search field types...',
+            'type_no_results' => 'No field types found',
             'system_defined_cannot_delete' => 'System-defined fields cannot be deleted.',
             'allow_multiple' => 'Allow Multiple Values',
             'allow_multiple_help' => 'When enabled, users can enter multiple values for this field.',
@@ -400,6 +402,9 @@ return [
         'required' => 'Required',
         'system' => 'System',
         'archived' => 'Archived',
+        'add' => 'Add',
+        'click_to_add' => 'Click to add',
+        'searching' => 'Searching...',
     ],
 
     'email' => [
@@ -412,6 +417,8 @@ return [
 
     'phone' => [
         'add_phone_placeholder' => 'Add phone number...',
+        'add_label' => 'Add phone number',
+        'empty_state_label' => 'Enter phone number',
         'search_country' => 'Search country...',
         'no_results' => 'No countries found',
         'one_result' => '1 country found',
@@ -429,6 +436,7 @@ return [
     'record' => [
         'search_placeholder' => 'Search records...',
         'add_record_placeholder' => 'Add record...',
+        'empty_state_label' => 'Select record...',
     ],
 
     'enums' => [

--- a/src/Filament/Integration/Components/Forms/MultiValueInput/MultiValueInputComponent.php
+++ b/src/Filament/Integration/Components/Forms/MultiValueInput/MultiValueInputComponent.php
@@ -112,7 +112,7 @@ class MultiValueInputComponent extends Field implements HasNestedRecursiveValida
 
     public function getAddLabel(): string
     {
-        return $this->evaluate($this->addLabel) ?? __('Add');
+        return $this->evaluate($this->addLabel) ?? __('custom-fields::custom-fields.common.add');
     }
 
     public function emptyStateLabel(string|Closure|null $label): static
@@ -124,7 +124,7 @@ class MultiValueInputComponent extends Field implements HasNestedRecursiveValida
 
     public function getEmptyStateLabel(): string
     {
-        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('Click to add');
+        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('custom-fields::custom-fields.common.click_to_add');
     }
 
     /**

--- a/src/Filament/Integration/Components/Forms/PhoneInput/PhoneInputComponent.php
+++ b/src/Filament/Integration/Components/Forms/PhoneInput/PhoneInputComponent.php
@@ -158,7 +158,7 @@ class PhoneInputComponent extends Field implements HasNestedRecursiveValidationR
 
     public function getAddLabel(): string
     {
-        return $this->evaluate($this->addLabel) ?? __('Add phone number');
+        return $this->evaluate($this->addLabel) ?? __('custom-fields::custom-fields.phone.add_label');
     }
 
     public function emptyStateLabel(string|Closure|null $label): static
@@ -170,7 +170,7 @@ class PhoneInputComponent extends Field implements HasNestedRecursiveValidationR
 
     public function getEmptyStateLabel(): string
     {
-        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('Enter phone number');
+        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('custom-fields::custom-fields.phone.empty_state_label');
     }
 
     /**

--- a/src/Filament/Integration/Components/Forms/RecordSelectInput/RecordSelectInputComponent.php
+++ b/src/Filament/Integration/Components/Forms/RecordSelectInput/RecordSelectInputComponent.php
@@ -124,7 +124,7 @@ class RecordSelectInputComponent extends Field implements HasNestedRecursiveVali
 
     public function getAddLabel(): string
     {
-        return $this->evaluate($this->addLabel) ?? __('Add');
+        return $this->evaluate($this->addLabel) ?? __('custom-fields::custom-fields.common.add');
     }
 
     public function emptyStateLabel(string|Closure|null $label): static
@@ -136,7 +136,7 @@ class RecordSelectInputComponent extends Field implements HasNestedRecursiveVali
 
     public function getEmptyStateLabel(): string
     {
-        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('Select record...');
+        return $this->evaluate($this->emptyStateLabel) ?? $this->getPlaceholder() ?? __('custom-fields::custom-fields.record.empty_state_label');
     }
 
     public function maxVisiblePills(int|Closure $max): static

--- a/src/Filament/Management/Forms/Components/TypeField.php
+++ b/src/Filament/Management/Forms/Components/TypeField.php
@@ -23,9 +23,9 @@ class TypeField extends Select
             ->searchable()
             ->selectablePlaceholder(false)
             ->searchDebounce(300)
-            ->searchPrompt(__('Search field types...'))
-            ->noSearchResultsMessage(__('No field types found'))
-            ->searchingMessage(__('Searching...'))
+            ->searchPrompt(__('custom-fields::custom-fields.field.form.type_search_prompt'))
+            ->noSearchResultsMessage(__('custom-fields::custom-fields.field.form.type_no_results'))
+            ->searchingMessage(__('custom-fields::custom-fields.common.searching'))
             ->getSearchResultsUsing(fn (string $search): array => $this->getSearchResults($search))
             ->options(fn (): array => $this->getAllFormattedOptions());
     }

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -503,8 +503,9 @@ class FieldForm implements FormInterface
         }
 
         if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)) {
-            $additionalTabs[] = Tab::make('Visibility')
-                ->schema([VisibilityComponent::make()]);
+            $additionalTabs[] = Tab::make(
+                __('custom-fields::custom-fields.field.form.visibility_settings')
+            )->schema([VisibilityComponent::make()]);
         }
 
         // If no additional tabs, return schema directly without tabs wrapper


### PR DESCRIPTION
## What

Replace hardcoded user facing strings with namespaced translation keys.

## Why

A few strings were passed to `__()` as raw English text without a `custom-fields::` key, and the Visibility tab label was rendered with no translation at all. As a result they could not be localized and triggered "missing translation key" warnings under non English locales.

## Changes

Added 8 English entries and reused the existing `field.form.visibility_settings` key. Updated 10 call sites. The displayed English text is unchanged.

| File | String | Key |
| --- | --- | --- |
| `MultiValueInputComponent` | `Add` | `common.add` |
| `MultiValueInputComponent` | `Click to add` | `common.click_to_add` |
| `PhoneInputComponent` | `Add phone number` | `phone.add_label` |
| `PhoneInputComponent` | `Enter phone number` | `phone.empty_state_label` |
| `RecordSelectInputComponent` | `Add` | `common.add` |
| `RecordSelectInputComponent` | `Select record...` | `record.empty_state_label` |
| `TypeField` | `Search field types...` | `field.form.type_search_prompt` |
| `TypeField` | `No field types found` | `field.form.type_no_results` |
| `TypeField` | `Searching...` | `common.searching` |
| `FieldForm` (tab) | `Visibility` | `field.form.visibility_settings` (existing) |

## Notes

`pest` passes (703 passed). The `test:type-coverage` stage reports 99.4% on `3.x` before this change too, so it is pre existing and unrelated to this PR.
