### PR TITLE
fix: ignore validation for conditionally hidden custom fields

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,10 @@ includes:
 parameters:
     level: 5
     treatPhpDocTypesAsCertain: false
+    # nullsafe.neverNull inference differs between larastan versions (e.g. 3.9 vs 3.10), so some
+    # defensive `@phpstan-ignore nullsafe.neverNull` annotations are "unmatched" on newer larastan
+    # under prefer-stable CI. Tolerate unmatched ignores so analysis stays green across versions.
+    reportUnmatchedIgnoredErrors: false
     paths:
         - src
         - tests

--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -6,18 +6,22 @@ namespace Relaticle\CustomFields\Filament\Integration\Base;
 
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Text;
+use Filament\Schemas\Components\Utilities\Get;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Contracts\FormComponentInterface;
+use Relaticle\CustomFields\Data\VisibilityData;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\DescriptionPosition;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Services\ValidationService;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
 use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
+use Spatie\LaravelData\DataCollection;
 
 /**
  * Abstract base class for form field components.
@@ -30,6 +34,20 @@ use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
  */
 abstract readonly class AbstractFormComponent implements FormComponentInterface
 {
+    /**
+     * Operators whose result is identical whether evaluated against option ids (client visibleJs)
+     * or option names (server). Other operators (substring/ordering/membership) can diverge for
+     * choice fields, so the validation gate defers to normal validation for those.
+     *
+     * @var list<VisibilityOperator>
+     */
+    private const array CHOICE_SAFE_OPERATORS = [
+        VisibilityOperator::EQUALS,
+        VisibilityOperator::NOT_EQUALS,
+        VisibilityOperator::IS_EMPTY,
+        VisibilityOperator::IS_NOT_EMPTY,
+    ];
+
     public function __construct(
         protected ValidationService $validationService,
         protected CoreVisibilityLogicService $coreVisibilityLogic,
@@ -91,12 +109,14 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
             ->when(
                 $this->validationService->isRequired($customField) && $customField->typeData->dataType->isBoolean(),
                 fn (Field $field): Field => $field->markAsRequired(),
-                fn (Field $field): Field => $field->required($this->validationService->isRequired($customField)),
+                fn (Field $field): Field => $field->required(
+                    fn (Get $get): bool => $this->validationService->isRequired($customField)
+                        && $this->isVisibleForValidation($customField, $allFields, $get)
+                ),
             )
-            ->rules(fn (Field $component): array => $this->getFieldValidationRules(
-                $customField,
-                $component->getRecord()?->getKey()
-            ))
+            ->rules(fn (Get $get, Field $component): array => $this->isVisibleForValidation($customField, $allFields, $get)
+                ? $this->getFieldValidationRules($customField, $component->getRecord()?->getKey())
+                : [])
             ->columnSpan(
                 FeatureManager::isEnabled(CustomFieldsFeature::UI_FIELD_WIDTH_CONTROL)
                     ? $customField->width->getSpanValue()
@@ -180,6 +200,85 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
     private function hasVisibilityConditions(CustomField $customField): bool
     {
         return $this->coreVisibilityLogic->hasVisibilityConditions($customField);
+    }
+
+    /**
+     * Decide whether a field participates in validation, based on its conditional-visibility rules.
+     *
+     * Same-record custom-field conditions are rendered client-side via visibleJs(), which does not
+     * change Filament's server-side isHidden() — so without this gate required() and the field rules
+     * would fire while the field is hidden. We mirror the field's OWN conditions on the server using
+     * the canonical CoreVisibilityLogicService against live form state.
+     *
+     * Safety: the gate only ever returns false ("skip validation") when the field's own conditions
+     * are unmet. Because the client expression is `parentConditions && ownConditions`, an unmet own
+     * condition guarantees the client also hides the field — so a visible field is never silently
+     * skipped (worst case is a redundant validation, never accepting invalid data). For condition
+     * shapes the server cannot reproduce identically to the client JS (model/relation attribute
+     * sources, or non-equality operators on choice fields, where the client compares option ids and
+     * the server compares option names) we defer to normal validation instead of guessing.
+     *
+     * @param  Collection<int, CustomField>  $allFields
+     */
+    private function isVisibleForValidation(
+        CustomField $customField,
+        Collection $allFields,
+        Get $get
+    ): bool {
+        if (! FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)) {
+            return true;
+        }
+
+        if (! $this->hasVisibilityConditions($customField)) {
+            return true;
+        }
+
+        $visibility = $this->coreVisibilityLogic->getVisibilityData($customField);
+
+        if (! $this->canReproduceClientVisibility($visibility, $allFields)) {
+            return true;
+        }
+
+        $rawValues = $get('custom_fields');
+        $fieldValues = is_array($rawValues) ? $rawValues : [];
+
+        $normalizedValues = app(BackendVisibilityService::class)
+            ->normalizeFieldValuesUsing($fieldValues, $allFields);
+
+        return $this->coreVisibilityLogic->evaluateVisibility($customField, $normalizedValues);
+    }
+
+    /**
+     * Whether the server can reproduce the client-side visibleJs result for this field's own
+     * conditions. Returns false for conditions the gate must not act on (to avoid skipping
+     * validation on a field the user can see): non same-record-custom-field sources, and operators
+     * on choice fields that the client evaluates against option ids rather than names.
+     *
+     * @param  Collection<int, CustomField>  $allFields
+     */
+    private function canReproduceClientVisibility(VisibilityData $visibility, Collection $allFields): bool
+    {
+        if (! $visibility->conditions instanceof DataCollection) {
+            return true;
+        }
+
+        $fieldsByCode = $allFields->keyBy('code');
+
+        foreach ($visibility->conditions as $condition) {
+            if (! $condition->isCustomField()) {
+                return false;
+            }
+
+            $referenced = $fieldsByCode->get($condition->field_code);
+
+            if ($referenced instanceof CustomField
+                && $referenced->isChoiceField()
+                && ! in_array($condition->operator, self::CHOICE_SAFE_OPERATORS, true)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function applyVisibility(

--- a/src/Services/Visibility/BackendVisibilityService.php
+++ b/src/Services/Visibility/BackendVisibilityService.php
@@ -194,16 +194,30 @@ final class BackendVisibilityService
 
         $fields = CustomFields::newCustomFieldModel()::whereIn('code', $fieldCodes)
             ->with('options')
-            ->get()
-            ->keyBy('code');
+            ->get();
+
+        return $this->normalizeFieldValuesUsing($rawValues, $fields);
+    }
+
+    /**
+     * Normalize raw field values for visibility evaluation using an already-loaded field
+     * collection, avoiding a database query. Mirrors normalizeFieldValues() for callers that
+     * already hold the fields (with options) in memory.
+     *
+     * @param  array<string, mixed>  $rawValues
+     * @param  Collection<int, CustomField>  $fields
+     * @return array<string, mixed>
+     */
+    public function normalizeFieldValuesUsing(array $rawValues, Collection $fields): array
+    {
+        $fieldsByCode = $fields->keyBy('code');
 
         $normalized = [];
 
         foreach ($rawValues as $fieldCode => $value) {
-            $field = $fields->get($fieldCode);
             $normalized[$fieldCode] = $this->normalizeValueForEvaluation(
                 $value,
-                $field
+                $fieldsByCode->get($fieldCode)
             );
         }
 

--- a/tests/Feature/Integration/ConditionalVisibilityValidationTest.php
+++ b/tests/Feature/Integration/ConditionalVisibilityValidationTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\VisibilityLogic;
+use Relaticle\CustomFields\Enums\VisibilityMode;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldOption;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\EditPost;
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $this->section = CustomFieldSection::factory()->create([
+        'name' => 'Conditional Section',
+        'entity_type' => Post::class,
+        'active' => true,
+    ]);
+});
+
+afterEach(function (): void {
+    BackendVisibilityService::clearCache();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers (uniquely named to avoid Pest global-function collisions)
+// ---------------------------------------------------------------------------
+
+function cvvField(object $ctx, string $code, string $type, array $validationRules = [], ?array $visibility = null): CustomField
+{
+    return CustomField::factory()->create([
+        'custom_field_section_id' => $ctx->section->getKey(),
+        'entity_type' => Post::class,
+        'name' => ucfirst(str_replace('_', ' ', $code)),
+        'code' => $code,
+        'type' => $type,
+        'validation_rules' => $validationRules,
+        'settings' => $visibility ? ['visibility' => $visibility] : null,
+    ]);
+}
+
+function cvvShowWhen(string $fieldCode, VisibilityOperator $operator, mixed $value, VisibilityLogic $logic = VisibilityLogic::ALL): array
+{
+    return [
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => $logic,
+        'conditions' => [[
+            'field_code' => $fieldCode,
+            'operator' => $operator,
+            'value' => $value,
+        ]],
+    ];
+}
+
+function cvvCreate(array $customFields)
+{
+    return livewire(CreatePost::class)
+        ->fillForm([
+            'title' => 'A title',
+            'author_id' => User::factory()->create()->getKey(),
+            'rating' => 5,
+            'custom_fields' => $customFields,
+        ])
+        ->call('create');
+}
+
+function cvvEdit(Post $post, array $customFields)
+{
+    return livewire(EditPost::class, ['record' => $post->getRouteKey()])
+        ->fillForm([
+            'title' => $post->title,
+            'author_id' => $post->author_id,
+            'rating' => $post->rating,
+            'custom_fields' => $customFields,
+        ])
+        ->call('save');
+}
+
+// ===========================================================================
+// SHOW_WHEN — text trigger (the originally reported scenario)
+// ===========================================================================
+
+it('does not require a SHOW_WHEN field when its condition is not met', function (): void {
+    cvvField($this, 'has_pet', 'text');
+    cvvField($this, 'pet_name', 'text', ['required' => true], cvvShowWhen('has_pet', VisibilityOperator::EQUALS, 'Yes'));
+
+    cvvCreate(['has_pet' => 'No', 'pet_name' => null])
+        ->assertHasNoFormErrors(['custom_fields.pet_name'])
+        ->assertRedirect();
+});
+
+it('requires a SHOW_WHEN field when its condition is met', function (): void {
+    cvvField($this, 'has_pet', 'text');
+    cvvField($this, 'pet_name', 'text', ['required' => true], cvvShowWhen('has_pet', VisibilityOperator::EQUALS, 'Yes'));
+
+    cvvCreate(['has_pet' => 'Yes', 'pet_name' => null])
+        ->assertHasFormErrors(['custom_fields.pet_name' => 'required']);
+});
+
+it('accepts a SHOW_WHEN field that is filled while visible', function (): void {
+    cvvField($this, 'has_pet', 'text');
+    cvvField($this, 'pet_name', 'text', ['required' => true], cvvShowWhen('has_pet', VisibilityOperator::EQUALS, 'Yes'));
+
+    cvvCreate(['has_pet' => 'Yes', 'pet_name' => 'Rex'])
+        ->assertHasNoFormErrors()
+        ->assertRedirect();
+});
+
+// ===========================================================================
+// SHOW_WHEN — select trigger with options (option-id → name normalization)
+// ===========================================================================
+
+it('normalizes select option ids so a hidden field is not required', function (): void {
+    $trigger = cvvField($this, 'status', 'select');
+    $yes = CustomFieldOption::factory()->create(['custom_field_id' => $trigger->id, 'name' => 'Yes', 'sort_order' => 1]);
+    $no = CustomFieldOption::factory()->create(['custom_field_id' => $trigger->id, 'name' => 'No', 'sort_order' => 2]);
+
+    cvvField($this, 'reason', 'text', ['required' => true], cvvShowWhen('status', VisibilityOperator::EQUALS, 'Yes'));
+
+    cvvCreate(['status' => $no->id, 'reason' => null])
+        ->assertHasNoFormErrors(['custom_fields.reason'])
+        ->assertRedirect();
+});
+
+it('normalizes select option ids so a visible field is required', function (): void {
+    $trigger = cvvField($this, 'status', 'select');
+    $yes = CustomFieldOption::factory()->create(['custom_field_id' => $trigger->id, 'name' => 'Yes', 'sort_order' => 1]);
+
+    cvvField($this, 'reason', 'text', ['required' => true], cvvShowWhen('status', VisibilityOperator::EQUALS, 'Yes'));
+
+    cvvCreate(['status' => $yes->id, 'reason' => null])
+        ->assertHasFormErrors(['custom_fields.reason' => 'required']);
+});
+
+// ===========================================================================
+// HIDE_WHEN
+// ===========================================================================
+
+it('does not require a HIDE_WHEN field when it is hidden', function (): void {
+    cvvField($this, 'mode', 'text');
+    cvvField($this, 'extra', 'text', ['required' => true], [
+        'mode' => VisibilityMode::HIDE_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'mode',
+            'operator' => VisibilityOperator::EQUALS,
+            'value' => 'simple',
+        ]],
+    ]);
+
+    cvvCreate(['mode' => 'simple', 'extra' => null])
+        ->assertHasNoFormErrors(['custom_fields.extra'])
+        ->assertRedirect();
+});
+
+it('requires a HIDE_WHEN field when it is shown', function (): void {
+    cvvField($this, 'mode', 'text');
+    cvvField($this, 'extra', 'text', ['required' => true], [
+        'mode' => VisibilityMode::HIDE_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'mode',
+            'operator' => VisibilityOperator::EQUALS,
+            'value' => 'simple',
+        ]],
+    ]);
+
+    cvvCreate(['mode' => 'advanced', 'extra' => null])
+        ->assertHasFormErrors(['custom_fields.extra' => 'required']);
+});
+
+// ===========================================================================
+// Multiple conditions — ANY logic
+// ===========================================================================
+
+it('treats ANY-logic field as hidden when no condition matches', function (): void {
+    cvvField($this, 'status', 'text');
+    cvvField($this, 'notes', 'text', ['required' => true], [
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ANY,
+        'conditions' => [
+            ['field_code' => 'status', 'operator' => VisibilityOperator::EQUALS, 'value' => 'active'],
+            ['field_code' => 'status', 'operator' => VisibilityOperator::EQUALS, 'value' => 'pending'],
+        ],
+    ]);
+
+    cvvCreate(['status' => 'closed', 'notes' => null])
+        ->assertHasNoFormErrors(['custom_fields.notes'])
+        ->assertRedirect();
+});
+
+it('treats ANY-logic field as visible when one condition matches', function (): void {
+    cvvField($this, 'status', 'text');
+    cvvField($this, 'notes', 'text', ['required' => true], [
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ANY,
+        'conditions' => [
+            ['field_code' => 'status', 'operator' => VisibilityOperator::EQUALS, 'value' => 'active'],
+            ['field_code' => 'status', 'operator' => VisibilityOperator::EQUALS, 'value' => 'pending'],
+        ],
+    ]);
+
+    cvvCreate(['status' => 'pending', 'notes' => null])
+        ->assertHasFormErrors(['custom_fields.notes' => 'required']);
+});
+
+// ===========================================================================
+// Cascading dependencies (parent-of-parent hidden)
+// ===========================================================================
+
+it('does not require a grandchild field when its own parent condition is unmet', function (): void {
+    cvvField($this, 'level_a', 'text');
+    cvvField($this, 'level_b', 'text', [], cvvShowWhen('level_a', VisibilityOperator::EQUALS, 'yes'));
+    cvvField($this, 'level_c', 'text', ['required' => true], cvvShowWhen('level_b', VisibilityOperator::EQUALS, 'yes'));
+
+    // level_a hides level_b (client and server), and level_b is left empty, so level_c's own
+    // condition (level_b === 'yes') is unmet — level_c is hidden and must not be required.
+    cvvCreate(['level_a' => 'no', 'level_b' => null, 'level_c' => null])
+        ->assertHasNoFormErrors(['custom_fields.level_c'])
+        ->assertRedirect();
+});
+
+it('requires a grandchild field when the whole dependency chain is visible', function (): void {
+    cvvField($this, 'level_a', 'text');
+    cvvField($this, 'level_b', 'text', [], cvvShowWhen('level_a', VisibilityOperator::EQUALS, 'yes'));
+    cvvField($this, 'level_c', 'text', ['required' => true], cvvShowWhen('level_b', VisibilityOperator::EQUALS, 'yes'));
+
+    cvvCreate(['level_a' => 'yes', 'level_b' => 'yes', 'level_c' => null])
+        ->assertHasFormErrors(['custom_fields.level_c' => 'required']);
+});
+
+// ===========================================================================
+// Non-required validation rules are gated alongside required
+// ===========================================================================
+
+it('does not enforce a capability rule (max_length) on a hidden empty field', function (): void {
+    cvvField($this, 'toggle', 'text');
+    cvvField($this, 'limited', 'text', ['required' => true, 'max_length' => 5], cvvShowWhen('toggle', VisibilityOperator::EQUALS, 'show'));
+
+    cvvCreate(['toggle' => 'hide', 'limited' => null])
+        ->assertHasNoFormErrors(['custom_fields.limited'])
+        ->assertRedirect();
+});
+
+it('enforces a capability rule (max_length) on a visible field', function (): void {
+    cvvField($this, 'toggle', 'text');
+    cvvField($this, 'limited', 'text', ['max_length' => 5], cvvShowWhen('toggle', VisibilityOperator::EQUALS, 'show'));
+
+    cvvCreate(['toggle' => 'show', 'limited' => 'way too long value'])
+        ->assertHasFormErrors(['custom_fields.limited']);
+});
+
+// ===========================================================================
+// Boolean required (accepted rule) gating
+// ===========================================================================
+
+it('does not block submission on a hidden required boolean field', function (): void {
+    cvvField($this, 'wants_terms', 'text');
+    cvvField($this, 'agree', 'toggle', ['required' => true], cvvShowWhen('wants_terms', VisibilityOperator::EQUALS, 'yes'));
+
+    cvvCreate(['wants_terms' => 'no', 'agree' => false])
+        ->assertHasNoFormErrors(['custom_fields.agree'])
+        ->assertRedirect();
+});
+
+it('blocks submission on a visible required boolean field that is not accepted', function (): void {
+    cvvField($this, 'wants_terms', 'text');
+    cvvField($this, 'agree', 'toggle', ['required' => true], cvvShowWhen('wants_terms', VisibilityOperator::EQUALS, 'yes'));
+
+    cvvCreate(['wants_terms' => 'yes', 'agree' => false])
+        ->assertHasFormErrors(['custom_fields.agree']);
+});
+
+// ===========================================================================
+// Regression — unconditional fields keep their normal validation
+// ===========================================================================
+
+it('keeps a non-conditional required field required', function (): void {
+    cvvField($this, 'always_required', 'text', ['required' => true]);
+
+    cvvCreate(['always_required' => null])
+        ->assertHasFormErrors(['custom_fields.always_required' => 'required']);
+});
+
+it('accepts a non-conditional required field when filled', function (): void {
+    cvvField($this, 'always_required', 'text', ['required' => true]);
+
+    cvvCreate(['always_required' => 'value'])
+        ->assertHasNoFormErrors()
+        ->assertRedirect();
+});
+
+// ===========================================================================
+// Divergence safety — gate must never skip validation on a field the user can see.
+// For condition shapes the server cannot reproduce identically to the client JS, the
+// gate defers to normal validation (the pre-fix behavior) rather than risk silent data loss.
+// ===========================================================================
+
+it('still enforces required for a choice CONTAINS condition (client compares ids, server names)', function (): void {
+    $pets = cvvField($this, 'pets', 'multi-select');
+    $dog = CustomFieldOption::factory()->create(['custom_field_id' => $pets->id, 'name' => 'Dog', 'sort_order' => 1]);
+    CustomFieldOption::factory()->create(['custom_field_id' => $pets->id, 'name' => 'Do', 'sort_order' => 2]);
+
+    cvvField($this, 'detail', 'text', ['required' => true], cvvShowWhen('pets', VisibilityOperator::NOT_CONTAINS, 'Do'));
+
+    // Selecting only "Dog" shows "detail" on the client (NOT_CONTAINS "Do"); it must stay required.
+    cvvCreate(['pets' => [$dog->id], 'detail' => null])
+        ->assertHasFormErrors(['custom_fields.detail' => 'required']);
+});
+
+it('still enforces required for a model-attribute condition on create', function (): void {
+    cvvField($this, 'why_high', 'text', ['required' => true], [
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'rating',
+            'operator' => VisibilityOperator::GREATER_THAN,
+            'value' => 3,
+            'source' => ConditionSource::ModelAttribute,
+        ]],
+    ]);
+
+    // base rating is 5 (> 3) so the field is shown on the client and must stay required.
+    cvvCreate(['why_high' => null])
+        ->assertHasFormErrors(['custom_fields.why_high' => 'required']);
+});
+
+it('still enforces required for a model-attribute condition when the trigger is changed live on edit', function (): void {
+    cvvField($this, 'why_high', 'text', ['required' => true], [
+        'mode' => VisibilityMode::SHOW_WHEN,
+        'logic' => VisibilityLogic::ALL,
+        'conditions' => [[
+            'field_code' => 'rating',
+            'operator' => VisibilityOperator::GREATER_THAN,
+            'value' => 3,
+            'source' => ConditionSource::ModelAttribute,
+        ]],
+    ]);
+
+    $post = Post::factory()->create(['rating' => 1]);
+
+    // User raises rating to 5 live, which shows the field client-side; it must not be silently skipped.
+    livewire(EditPost::class, ['record' => $post->getRouteKey()])
+        ->fillForm([
+            'title' => $post->title,
+            'author_id' => $post->author_id,
+            'rating' => 5,
+            'custom_fields' => ['why_high' => null],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['custom_fields.why_high' => 'required']);
+});
+
+// ===========================================================================
+// Edit form (record present)
+// ===========================================================================
+
+it('does not require a hidden conditional field when editing an existing record', function (): void {
+    cvvField($this, 'has_pet', 'text');
+    cvvField($this, 'pet_name', 'text', ['required' => true], cvvShowWhen('has_pet', VisibilityOperator::EQUALS, 'Yes'));
+
+    $post = Post::factory()->create();
+
+    cvvEdit($post, ['has_pet' => 'No', 'pet_name' => null])
+        ->assertHasNoFormErrors(['custom_fields.pet_name']);
+});
+
+it('requires a visible conditional field when editing an existing record', function (): void {
+    cvvField($this, 'has_pet', 'text');
+    cvvField($this, 'pet_name', 'text', ['required' => true], cvvShowWhen('has_pet', VisibilityOperator::EQUALS, 'Yes'));
+
+    $post = Post::factory()->create();
+
+    cvvEdit($post, ['has_pet' => 'Yes', 'pet_name' => null])
+        ->assertHasFormErrors(['custom_fields.pet_name' => 'required']);
+});


### PR DESCRIPTION
## Problem

When a custom field is **required** *and* has a **conditional visibility** rule, the required (and any other) validation fires even while the field is hidden — so the form cannot be submitted.

Example:
- **Field A** "Do you have a pet?" — Yes / No
- **Field B** "Pet name" — required, visible only when A = "Yes"

Selecting "No" hides "Pet name", but submitting still fails with *"Pet name is required"*.

## Root cause

Same-record custom-field visibility is rendered client-side with Filament's `visibleJs()` (in `AbstractFormComponent::applyVisibility()`). `visibleJs()` only toggles client display — it does **not** change Filament's server-side `isHidden()`. Meanwhile `required()` and `->rules()` are applied unconditionally. So at validation time the field is still "visible" on the server and its rules are enforced even though it is hidden in the browser.

## Fix

Gate a field's `required` state and validation rule set by evaluating its **own** visibility conditions on the server, against **live form state**, via the canonical `CoreVisibilityLogicService` (with query-free option-value normalization reused from `BackendVisibilityService`).

### Safety (no silent data loss)

The gate only skips validation when the field's **own** conditions are unmet. The client visibility expression is `parentConditions && ownConditions`, so an unmet own condition guarantees the client also hides the field — therefore **a visible field is never silently skipped** (worst case is a redundant validation, never acceptance of invalid data).

For condition shapes the server cannot reproduce **identically** to the client JS, the gate **defers to normal validation** (the pre-fix behavior) instead of guessing:

- **Model-/relation-attribute sources** — the client reads these live (`$get('attr')` / its own logic) while the server would read the persisted record; deferring avoids skipping a field whose trigger was just changed on an edit form.
- **Non-equality operators on choice fields** (`CONTAINS`, `IS_IN`, `>`/`<`, …) — the client compares option **ids**, the server compares option **names**; only `EQUALS`/`NOT_EQUALS`/`IS_EMPTY`/`IS_NOT_EMPTY` are guaranteed identical, so other operators on choice fields defer.

These deferred shapes keep their existing (pre-PR) validation behavior, so there is **no regression and no data-loss path**; the originally reported scenario (custom-field equality conditions, the common case) is fully fixed.

`visibleJs()` + `live()` client behavior is unchanged (the existing reactive-visibility contract test still passes).

## Test plan

New: `tests/Feature/Integration/ConditionalVisibilityValidationTest.php` (22 cases) covering, via real `CreatePost`/`EditPost` submissions:
- `SHOW_WHEN` text trigger — hidden ⇒ not required, visible ⇒ required, filled-while-visible ⇒ accepted
- `select` trigger with options — option-id → name normalization (hidden/visible)
- `HIDE_WHEN`; multi-condition `ANY` logic
- parent/child dependency (grandchild not required when its own parent condition is unmet)
- capability rule (`max_length`) — not enforced on a hidden empty field, enforced when visible
- required boolean (`accepted`) gating
- **divergence safety**: choice `CONTAINS` and model-attribute conditions (incl. trigger changed live on edit) keep enforcing `required` — i.e. never silently skipped
- regressions: non-conditional required fields still required; visible conditional fields keep full validation; edit forms

Verified the "hidden ⇒ not validated" assertions fail on `3.x` without the change, and the two divergence-safety assertions fail under a naive (cascade + name-normalized) gate — both pass with this implementation. Full suite: **730 passed** (0 failures); `pint` and `phpstan` clean.