### PR TITLE
fix: route dependent-field detection through visibility service (#149)

### DIFF
--- a/src/Filament/Integration/Builders/FormBuilder.php
+++ b/src/Filament/Integration/Builders/FormBuilder.php
@@ -13,6 +13,7 @@ use Relaticle\CustomFields\Filament\Integration\Factories\FieldComponentFactory;
 use Relaticle\CustomFields\Filament\Integration\Factories\SectionComponentFactory;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\Visibility\CoreVisibilityLogicService;
 
 class FormBuilder extends BaseBuilder
 {
@@ -42,16 +43,14 @@ class FormBuilder extends BaseBuilder
 
     private function getDependentFieldCodes(Collection $fields): array
     {
+        $visibilityLogic = app(CoreVisibilityLogicService::class);
         $dependentCodes = [];
 
         foreach ($fields as $field) {
-            if ($field->visibility_conditions && is_array($field->visibility_conditions)) {
-                foreach ($field->visibility_conditions as $condition) {
-                    if (isset($condition['field'])) {
-                        $dependentCodes[] = $condition['field'];
-                    }
-                }
-            }
+            $dependentCodes = array_merge(
+                $dependentCodes,
+                $visibilityLogic->getDependentFields($field),
+            );
 
             $validationRules = $field->validation_rules;
             if ($validationRules) {

--- a/tests/Feature/Integration/FormBuilderStrictModeTest.php
+++ b/tests/Feature/Integration/FormBuilderStrictModeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Forms\Components\Field;
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Enums\ConditionSource;
+use Relaticle\CustomFields\Enums\VisibilityLogic;
+use Relaticle\CustomFields\Enums\VisibilityMode;
+use Relaticle\CustomFields\Enums\VisibilityOperator;
+use Relaticle\CustomFields\Filament\Integration\Builders\FormBuilder;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
+
+afterEach(function (): void {
+    Model::preventAccessingMissingAttributes(false);
+});
+
+function seedDependentFieldPair(): void
+{
+    $section = CustomFieldSection::factory()->create([
+        'entity_type' => Post::class,
+        'active' => true,
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'code' => 'trigger_field',
+        'name' => 'Trigger Field',
+        'type' => 'text',
+        'entity_type' => Post::class,
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'code' => 'dependent_field',
+        'name' => 'Dependent Field',
+        'type' => 'text',
+        'entity_type' => Post::class,
+        'settings' => [
+            'visibility' => [
+                'mode' => VisibilityMode::SHOW_WHEN,
+                'logic' => VisibilityLogic::ALL,
+                'conditions' => [[
+                    'field_code' => 'trigger_field',
+                    'operator' => VisibilityOperator::IS_NOT_EMPTY,
+                    'value' => null,
+                    'source' => ConditionSource::CustomField,
+                ]],
+            ],
+        ],
+    ]);
+}
+
+it('builds a custom field form under Eloquent strict mode without reading a phantom visibility_conditions attribute', function (): void {
+    seedDependentFieldPair();
+
+    Model::preventAccessingMissingAttributes();
+
+    $components = app(FormBuilder::class)->forModel(Post::class)->values();
+
+    expect($components)->not->toBeEmpty();
+});
+
+it('marks a field live when another field depends on it via custom-field visibility', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    seedDependentFieldPair();
+
+    livewire(CreatePost::class)
+        ->assertSuccessful()
+        ->assertFormFieldExists(
+            'custom_fields.trigger_field',
+            fn (Field $field): bool => $field->isLive(),
+        );
+});


### PR DESCRIPTION
## Summary

`FormBuilder::getDependentFieldCodes()` read `$field->visibility_conditions` directly, but that attribute has **no column, cast, or accessor** on the `CustomField` model (visibility lives in `settings->visibility`). This caused two bugs:

1. **Crash under strict mode** — with `Model::preventAccessingMissingAttributes()` enabled, rendering *any* custom-field form threw `MissingAttributeException` (the reported issue).
2. **Silent malfunction otherwise** — without strict mode the access returned `null`, and the expected `['field' => …]` shape no longer matched the current `VisibilityConditionData` (`field_code`), so dependent fields were **never** detected and their trigger fields were never marked `->live()`.

The fix routes through the canonical `CoreVisibilityLogicService::getDependentFields()`, which reads `settings->visibility` and the current condition shape — resolving both bugs.

Fixes #149.

## Root-cause trace

```
MissingAttributeException: attribute [visibility_conditions] … [CustomField]
  vendor/.../HasAttributes.php:527  throwMissingAttributeExceptionIfApplicable()
  src/Filament/Integration/Builders/FormBuilder.php:48  $field->visibility_conditions
  src/Filament/Integration/Builders/FormBuilder.php:77  getDependentFieldCodes()
  src/Filament/Integration/Builders/FormContainer.php:78
```

## Test plan

New `tests/Feature/Integration/FormBuilderStrictModeTest.php` (both fail on the old code, pass on the fix):

- **builds a custom field form under Eloquent strict mode** — enables `preventAccessingMissingAttributes()` and builds the form; previously threw `MissingAttributeException`.
- **marks a field live when another field depends on it via custom-field visibility** — renders `CreatePost` and asserts the trigger field is `->live()`; previously the dependency was never detected, so it was not live.

Verified:
- `vendor/bin/pest` — full suite **739 passed** (0 failures)
- `pint --test` ✓ · `rector --dry-run` ✓ (no changes) · `phpstan analyse` ✓ (no errors) · changed file at 100% type-coverage
- **Browser end-to-end** in a consuming app (Filament v5): opening the *New Company* create form threw a 500 (`MissingAttributeException` at `FormBuilder.php:48`) before the fix, and rendered the full form (including custom fields) after.
