### PR TITLE
chore: apply rector 2.5.7 auto-fixes

### DIFF
--- a/src/Filament/Integration/Components/Tables/Columns/DateTimeColumn.php
+++ b/src/Filament/Integration/Components/Tables/Columns/DateTimeColumn.php
@@ -55,9 +55,6 @@ class DateTimeColumn extends AbstractTableColumn
         return $column;
     }
 
-    /**
-     * @return $this
-     */
     public function localize(Closure $locale): static
     {
         $this->locale = $locale;

--- a/src/Filament/Management/Forms/Components/VisibilityComponent.php
+++ b/src/Filament/Management/Forms/Components/VisibilityComponent.php
@@ -297,8 +297,11 @@ final class VisibilityComponent extends Component
         }
 
         $operator = $get('operator');
+        if (! $fieldData->dataType->isMultiChoiceField()) {
+            return true;
+        }
 
-        return ! ($fieldData->dataType->isMultiChoiceField() && $this->isContainsOperator($operator));
+        return ! $this->isContainsOperator($operator);
     }
 
     private function shouldShowMultipleSelect(Get $get): bool

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -165,7 +165,7 @@ class FieldForm implements FormInterface
                             $hasDuplicate = collect($get('../../options') ?? [])
                                 ->pluck('name')
                                 ->filter()
-                                ->map(fn ($name) => mb_strtolower($name))
+                                ->map(fn ($name): string => mb_strtolower($name))
                                 ->duplicates()
                                 ->contains(mb_strtolower($value));
 


### PR DESCRIPTION
CI runs `composer update`, which now pulls **rector 2.5.7**. Its new rules flag three pre-existing files, turning every open PR's test job red at the rector step (pest never runs). This applies the mechanical, behavior-preserving auto-fixes:

- `DateTimeColumn` — drop redundant `@return $this` docblock (return type already `static`)
- `VisibilityComponent` — `!(A && B)` → early returns (`ReturnBinaryOrToEarlyReturnRector`)
- `FieldForm` — add arrow-function `: string` return type

After this, `rector --dry-run` is clean. Verified locally: pint ✓, phpstan ✓, full suite **737 passed**. Unblocks #179 and other open PRs.