### PR TITLE
feat: add section-level width control (UI_SECTION_WIDTH_CONTROL)

### DIFF
--- a/database/factories/CustomFieldSectionFactory.php
+++ b/database/factories/CustomFieldSectionFactory.php
@@ -7,6 +7,7 @@ namespace Relaticle\CustomFields\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Relaticle\CustomFields\Data\CustomFieldSectionSettingsData;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 class CustomFieldSectionFactory extends Factory
@@ -59,6 +60,13 @@ class CustomFieldSectionFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'type' => CustomFieldSectionType::FIELDSET,
+        ]);
+    }
+
+    public function width(CustomFieldWidth $width): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'width' => $width,
         ]);
     }
 }

--- a/docs/content/2.essentials/1.configuration.md
+++ b/docs/content/2.essentials/1.configuration.md
@@ -183,6 +183,8 @@ If your custom models include tenant-specific scoping logic, you'll need to regi
 
 ::alert{type="info"}
 `UI_SECTION_WIDTH_CONTROL` is disabled by default. Enable it by adding `CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL` to the `->enable(...)` list in your published config. Once enabled, each `SECTION` and `FIELDSET` (not headless sections) can render at a fraction of the row width using the same `CustomFieldWidth` enum used for field-level width. Section widths don't need to sum to 12 — the grid wraps, and sections stack full-width on mobile.
+
+Both section and field widths are fractions of the standard 12-column custom fields grid — `50%` renders as a 6-of-12 column span. If you embed custom fields inside a grid with a different column count, the visual fraction follows that grid instead.
 ::
 
 ## Configuration Examples

--- a/docs/content/2.essentials/1.configuration.md
+++ b/docs/content/2.essentials/1.configuration.md
@@ -172,7 +172,7 @@ The package supports these features that can be enabled/disabled:
 | `UI_TOGGLEABLE_COLUMNS_HIDDEN_DEFAULT` | Hide toggleable columns by default |
 | `UI_TABLE_FILTERS` | Enable filtering by custom field values |
 | `UI_FIELD_WIDTH_CONTROL` | Custom field width per field |
-| `UI_SECTION_WIDTH_CONTROL` | Section-level layout width (25/33/50/66/75/100); off by default |
+| `UI_SECTION_WIDTH_CONTROL` | Section-level layout width (25/33/50/66/75/100) |
 | `SYSTEM_MANAGEMENT_INTERFACE` | Enable the management interface |
 | `SYSTEM_MULTI_TENANCY` | Enable multi-tenant isolation |
 | `SYSTEM_SECTIONS` | Enable field grouping in sections |

--- a/docs/content/2.essentials/1.configuration.md
+++ b/docs/content/2.essentials/1.configuration.md
@@ -172,12 +172,17 @@ The package supports these features that can be enabled/disabled:
 | `UI_TOGGLEABLE_COLUMNS_HIDDEN_DEFAULT` | Hide toggleable columns by default |
 | `UI_TABLE_FILTERS` | Enable filtering by custom field values |
 | `UI_FIELD_WIDTH_CONTROL` | Custom field width per field |
+| `UI_SECTION_WIDTH_CONTROL` | Section-level layout width (25/33/50/66/75/100); off by default |
 | `SYSTEM_MANAGEMENT_INTERFACE` | Enable the management interface |
 | `SYSTEM_MULTI_TENANCY` | Enable multi-tenant isolation |
 | `SYSTEM_SECTIONS` | Enable field grouping in sections |
 
 ::alert{type="info"}
 If your custom models include tenant-specific scoping logic, you'll need to register a [custom tenant resolver](#custom-tenant-resolution) to ensure validation works correctly.
+::
+
+::alert{type="info"}
+`UI_SECTION_WIDTH_CONTROL` is disabled by default. Enable it by adding `CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL` to the `->enable(...)` list in your published config. Once enabled, each `SECTION` and `FIELDSET` (not headless sections) can render at a fraction of the row width using the same `CustomFieldWidth` enum used for field-level width. Section widths don't need to sum to 12 — the grid wraps, and sections stack full-width on mobile.
 ::
 
 ## Configuration Examples

--- a/docs/content/2.essentials/6.data-model.md
+++ b/docs/content/2.essentials/6.data-model.md
@@ -30,7 +30,7 @@ The Custom Fields plugin employs a **Hybrid Entity-Attribute-Value (EAV) with Ty
   | `code` | string | Unique identifier |
   | `name` | string | Display name |
   | `type` | string | Section type |
-  | `width` | string | Layout width |
+  | `width` | string | Section layout width (`CustomFieldWidth` enum: 25/33/50/66/75/100). Requires the `UI_SECTION_WIDTH_CONTROL` feature. |
   | `sort_order` | int | Display order |
   | `active` | bool | Enabled flag |
   | `system_defined` | bool | Protected from user deletion |

--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -17,6 +17,7 @@ return [
             'name' => 'Name',
             'code' => 'Code',
             'type' => 'Type',
+            'width' => 'Width',
             'description' => 'Description',
             'add_section' => 'Add Section',
             'system_defined_cannot_delete' => 'System-defined sections cannot be deleted.',

--- a/src/Data/CustomFieldSectionData.php
+++ b/src/Data/CustomFieldSectionData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields\Data;
 
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Mappers\SnakeCaseMapper;
@@ -25,6 +26,7 @@ final class CustomFieldSectionData extends Data
         public bool $active = true,
         public bool $systemDefined = false,
         public ?string $entityType = null,
-        public ?CustomFieldSectionSettingsData $settings = null
+        public ?CustomFieldSectionSettingsData $settings = null,
+        public CustomFieldWidth $width = CustomFieldWidth::_100,
     ) {}
 }

--- a/src/Enums/CustomFieldsFeature.php
+++ b/src/Enums/CustomFieldsFeature.php
@@ -31,6 +31,7 @@ enum CustomFieldsFeature: string
     case UI_TOGGLEABLE_COLUMNS = 'ui_toggleable_columns';
     case UI_TOGGLEABLE_COLUMNS_HIDDEN_DEFAULT = 'ui_toggleable_columns_hidden_default';
     case UI_FIELD_WIDTH_CONTROL = 'ui_field_width_control';
+    case UI_SECTION_WIDTH_CONTROL = 'ui_section_width_control';
 
     // System-level features
     case SYSTEM_MANAGEMENT_INTERFACE = 'system_management_interface';

--- a/src/Filament/Integration/Factories/Concerns/AppliesSectionWidth.php
+++ b/src/Filament/Integration/Factories/Concerns/AppliesSectionWidth.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Filament\Integration\Factories\Concerns;
+
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Section;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+
+trait AppliesSectionWidth
+{
+    private function applyWidth(Section|Fieldset $component, CustomFieldSection $section): void
+    {
+        if (
+            FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
+            && $section->width instanceof CustomFieldWidth
+            && $section->width !== CustomFieldWidth::_100
+        ) {
+            $component->columnSpan($section->width->getSpanValue());
+
+            return;
+        }
+
+        $component->columnSpanFull();
+    }
+}

--- a/src/Filament/Integration/Factories/SectionComponentFactory.php
+++ b/src/Filament/Integration/Factories/SectionComponentFactory.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -36,21 +37,38 @@ final readonly class SectionComponentFactory
     ): Section|Fieldset|Grid {
         $component = match ($customFieldSection->type) {
             CustomFieldSectionType::SECTION => Section::make($customFieldSection->name)
-                ->columnSpanFull()
                 ->description($customFieldSection->description)
                 ->columns(12),
             CustomFieldSectionType::FIELDSET => Fieldset::make('custom_fields.'.$customFieldSection->code)
-                ->columnSpanFull()
                 ->label($customFieldSection->name)
                 ->columns(12),
             CustomFieldSectionType::HEADLESS => Grid::make(12)->columnSpanFull(),
         };
+
+        if (in_array($customFieldSection->type, [CustomFieldSectionType::SECTION, CustomFieldSectionType::FIELDSET], true)) {
+            $this->applyWidth($component, $customFieldSection);
+        }
 
         if ($this->shouldApplySectionVisibility($customFieldSection)) {
             $this->applySectionVisibility($component, $customFieldSection, $allFields, $record);
         }
 
         return $component;
+    }
+
+    private function applyWidth(Section|Fieldset $component, CustomFieldSection $section): void
+    {
+        if (
+            FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
+            && $section->width instanceof CustomFieldWidth
+            && $section->width !== CustomFieldWidth::_100
+        ) {
+            $component->columnSpan($section->width->getSpanValue());
+
+            return;
+        }
+
+        $component->columnSpanFull();
     }
 
     private function shouldApplySectionVisibility(CustomFieldSection $section): bool

--- a/src/Filament/Integration/Factories/SectionComponentFactory.php
+++ b/src/Filament/Integration/Factories/SectionComponentFactory.php
@@ -11,8 +11,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Filament\Integration\Factories\Concerns\AppliesSectionWidth;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Services\Visibility\BackendVisibilityService;
@@ -21,6 +21,8 @@ use Relaticle\CustomFields\Services\Visibility\FrontendVisibilityService;
 
 final readonly class SectionComponentFactory
 {
+    use AppliesSectionWidth;
+
     public function __construct(
         private FrontendVisibilityService $frontendVisibilityService,
         private BackendVisibilityService $backendVisibilityService,
@@ -54,21 +56,6 @@ final readonly class SectionComponentFactory
         }
 
         return $component;
-    }
-
-    private function applyWidth(Section|Fieldset $component, CustomFieldSection $section): void
-    {
-        if (
-            FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
-            && $section->width instanceof CustomFieldWidth
-            && $section->width !== CustomFieldWidth::_100
-        ) {
-            $component->columnSpan($section->width->getSpanValue());
-
-            return;
-        }
-
-        $component->columnSpanFull();
     }
 
     private function shouldApplySectionVisibility(CustomFieldSection $section): bool

--- a/src/Filament/Integration/Factories/SectionInfolistsFactory.php
+++ b/src/Filament/Integration/Factories/SectionInfolistsFactory.php
@@ -8,23 +8,45 @@ use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 final class SectionInfolistsFactory
 {
     public function create(CustomFieldSection $customFieldSection): Section|Fieldset|Grid
     {
-        return match ($customFieldSection->type) {
+        $component = match ($customFieldSection->type) {
             CustomFieldSectionType::SECTION => Section::make($customFieldSection->name)
-                ->columnSpanFull()
                 ->columns(12)
                 ->description($customFieldSection->description),
 
             CustomFieldSectionType::FIELDSET => Fieldset::make($customFieldSection->name)
-                ->columnSpanFull()
                 ->columns(12),
 
-            CustomFieldSectionType::HEADLESS => Grid::make($customFieldSection->column_span ?? 12),
+            CustomFieldSectionType::HEADLESS => Grid::make(12),
         };
+
+        if (in_array($customFieldSection->type, [CustomFieldSectionType::SECTION, CustomFieldSectionType::FIELDSET], true)) {
+            $this->applyWidth($component, $customFieldSection);
+        }
+
+        return $component;
+    }
+
+    private function applyWidth(Section|Fieldset $component, CustomFieldSection $section): void
+    {
+        if (
+            FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
+            && $section->width instanceof CustomFieldWidth
+            && $section->width !== CustomFieldWidth::_100
+        ) {
+            $component->columnSpan($section->width->getSpanValue());
+
+            return;
+        }
+
+        $component->columnSpanFull();
     }
 }

--- a/src/Filament/Integration/Factories/SectionInfolistsFactory.php
+++ b/src/Filament/Integration/Factories/SectionInfolistsFactory.php
@@ -8,13 +8,13 @@ use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
-use Relaticle\CustomFields\Enums\CustomFieldsFeature;
-use Relaticle\CustomFields\Enums\CustomFieldWidth;
-use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Filament\Integration\Factories\Concerns\AppliesSectionWidth;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 
 final class SectionInfolistsFactory
 {
+    use AppliesSectionWidth;
+
     public function create(CustomFieldSection $customFieldSection): Section|Fieldset|Grid
     {
         $component = match ($customFieldSection->type) {
@@ -33,20 +33,5 @@ final class SectionInfolistsFactory
         }
 
         return $component;
-    }
-
-    private function applyWidth(Section|Fieldset $component, CustomFieldSection $section): void
-    {
-        if (
-            FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
-            && $section->width instanceof CustomFieldWidth
-            && $section->width !== CustomFieldWidth::_100
-        ) {
-            $component->columnSpan($section->width->getSpanValue());
-
-            return;
-        }
-
-        $component->columnSpanFull();
     }
 }

--- a/src/Filament/Management/Schemas/SectionForm.php
+++ b/src/Filament/Management/Schemas/SectionForm.php
@@ -17,6 +17,7 @@ use Illuminate\Validation\Rules\Unique;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -174,6 +175,22 @@ class SectionForm implements FormInterface, SectionFormInterface
                     ->options(CustomFieldSectionType::class)
                     ->required()
                     ->columnSpan(12),
+                Select::make('width')
+                    ->label(__('custom-fields::custom-fields.section.form.width'))
+                    ->options(CustomFieldWidth::class)
+                    ->default(CustomFieldWidth::_100->value)
+                    ->selectablePlaceholder(false)
+                    ->formatStateUsing(fn (mixed $state): string => match (true) {
+                        $state instanceof CustomFieldWidth => $state->value,
+                        is_string($state) && $state !== '' => $state,
+                        default => CustomFieldWidth::_100->value,
+                    })
+                    ->visible(fn (Get $get): bool => FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)
+                        && in_array($get('type'), [
+                            CustomFieldSectionType::SECTION,
+                            CustomFieldSectionType::FIELDSET,
+                        ], true))
+                    ->columnSpan(6),
                 Textarea::make('description')
                     ->label(
                         __(

--- a/src/Models/CustomFieldSection.php
+++ b/src/Models/CustomFieldSection.php
@@ -14,6 +14,7 @@ use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Data\CustomFieldSectionSettingsData;
 use Relaticle\CustomFields\Database\Factories\CustomFieldSectionFactory;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\Facades\Entities;
 use Relaticle\CustomFields\Models\Concerns\Activable;
 use Relaticle\CustomFields\Models\Scopes\SortOrderScope;
@@ -25,6 +26,7 @@ use Relaticle\CustomFields\Observers\CustomFieldSectionObserver;
  * @property string $code
  * @property string $description
  * @property CustomFieldSectionType $type
+ * @property CustomFieldWidth $width
  * @property string $entity_type
  * @property ?string $lookup_type
  * @property CustomFieldSectionSettingsData $settings
@@ -51,6 +53,10 @@ class CustomFieldSection extends Model
      */
     protected $guarded = [];
 
+    protected $attributes = [
+        'width' => CustomFieldWidth::_100,
+    ];
+
     /**
      * @param  array<string, mixed>  $attributes
      */
@@ -67,6 +73,7 @@ class CustomFieldSection extends Model
     {
         return [
             'type' => CustomFieldSectionType::class,
+            'width' => CustomFieldWidth::class,
             'settings' => CustomFieldSectionSettingsData::class.':default',
             'system_defined' => 'boolean',
         ];

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -2,7 +2,12 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\CustomFieldWidth;
+use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+use Relaticle\CustomFields\Filament\Integration\Factories\SectionComponentFactory;
+use Relaticle\CustomFields\Filament\Integration\Factories\SectionInfolistsFactory;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 
@@ -23,4 +28,75 @@ it('casts the stored section width to the CustomFieldWidth enum', function (): v
         'id' => $section->id,
         'width' => '50',
     ]);
+});
+
+it('has UI_SECTION_WIDTH_CONTROL disabled by default', function (): void {
+    expect(FeatureManager::isEnabled(CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL))->toBeFalse();
+});
+
+it('renders a fractional column span when the flag is on and width is non-100', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS, CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)]);
+
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_50)
+        ->create(['entity_type' => Post::class]);
+
+    $component = app(SectionComponentFactory::class)->create($section);
+
+    expect($component->getColumnSpan('lg'))->toBe(6);
+});
+
+it('renders full width when the flag is on but width is 100', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS, CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)]);
+
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_100)
+        ->create(['entity_type' => Post::class]);
+
+    $component = app(SectionComponentFactory::class)->create($section);
+
+    expect($component->getColumnSpan('default'))->toBe('full');
+});
+
+it('ignores section width when the flag is off', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS)]);
+
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_50)
+        ->create(['entity_type' => Post::class]);
+
+    $component = app(SectionComponentFactory::class)->create($section);
+
+    expect($component->getColumnSpan('default'))->toBe('full');
+});
+
+it('renders a legacy NULL-width section at full width without error', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS, CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)]);
+
+    $section = CustomFieldSection::factory()->create(['entity_type' => Post::class]);
+    CustomFieldSection::query()->whereKey($section->id)->update(['width' => null]);
+    $section = CustomFieldSection::query()->findOrFail($section->id);
+
+    expect($section->width)->toBeNull();
+
+    $component = app(SectionComponentFactory::class)->create($section);
+
+    expect($component->getColumnSpan('default'))->toBe('full');
+});
+
+it('applies the same width rules on the infolist path', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS, CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL)]);
+
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_50)
+        ->create(['entity_type' => Post::class]);
+
+    $component = app(SectionInfolistsFactory::class)->create($section);
+
+    expect($component->getColumnSpan('lg'))->toBe(6);
 });

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Contracts\CustomsFieldsMigrators;
+use Relaticle\CustomFields\Data\CustomFieldData;
 use Relaticle\CustomFields\Data\CustomFieldSectionData;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
@@ -257,4 +259,37 @@ it('carries an explicit width through the section DTO array', function (): void 
     );
 
     expect($data->toArray()['width'])->toBe(CustomFieldWidth::_33->value);
+});
+
+it('persists a preset section width end-to-end through the migrator', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS)]);
+
+    app(CustomsFieldsMigrators::class)->new(
+        model: Post::class,
+        fieldData: new CustomFieldData(
+            name: 'Function Info',
+            code: 'function_info',
+            type: 'text',
+            section: new CustomFieldSectionData(
+                name: 'Function',
+                code: 'function_section',
+                width: CustomFieldWidth::_33,
+            ),
+            systemDefined: true,
+        ),
+    )->create();
+
+    $section = CustomFieldSection::query()
+        ->where('entity_type', Post::class)
+        ->where('code', 'function_section')
+        ->firstOrFail();
+
+    expect($section->width)->toBe(CustomFieldWidth::_33);
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'code' => 'function_section',
+        'entity_type' => Post::class,
+        'width' => '33',
+    ]);
 });

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -8,8 +8,10 @@ use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Integration\Factories\SectionComponentFactory;
 use Relaticle\CustomFields\Filament\Integration\Factories\SectionInfolistsFactory;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 
 it('defaults a new section width to 100', function (): void {
     $section = CustomFieldSection::factory()->create(['entity_type' => Post::class]);
@@ -99,4 +101,53 @@ it('applies the same width rules on the infolist path', function (): void {
     $component = app(SectionInfolistsFactory::class)->create($section);
 
     expect($component->getColumnSpan('lg'))->toBe(6);
+});
+
+it('persists a chosen section width from the management form when the flag is on', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
+        CustomFieldsFeature::SYSTEM_SECTIONS,
+        CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+        CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL,
+    )]);
+
+    $this->actingAs(User::factory()->create());
+
+    livewire(CustomFieldsManagementPage::class)
+        ->call('setCurrentEntityType', Post::class)
+        ->callAction('createSection', [
+            'name' => 'Function Info',
+            'code' => 'function_info',
+            'width' => CustomFieldWidth::_50->value,
+        ])
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'code' => 'function_info',
+        'entity_type' => Post::class,
+        'width' => '50',
+    ]);
+});
+
+it('does not persist section width from the form when the flag is off', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
+        CustomFieldsFeature::SYSTEM_SECTIONS,
+        CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+    )]);
+
+    $this->actingAs(User::factory()->create());
+
+    livewire(CustomFieldsManagementPage::class)
+        ->call('setCurrentEntityType', Post::class)
+        ->callAction('createSection', [
+            'name' => 'Responsibility Info',
+            'code' => 'responsibility_info',
+            'width' => CustomFieldWidth::_50->value,
+        ])
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'code' => 'responsibility_info',
+        'entity_type' => Post::class,
+        'width' => '100',
+    ]);
 });

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Data\CustomFieldSectionData;
 use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\CustomFieldWidth;
@@ -227,4 +228,20 @@ it('formats a legacy NULL width as 100 when opening the edit form', function ():
     ])->mountAction('edit');
 
     expect($component->get('mountedActions.0.data.width'))->toBe(CustomFieldWidth::_100->value);
+});
+
+it('defaults the section DTO width to 100', function (): void {
+    $data = new CustomFieldSectionData(name: 'Info', code: 'info');
+
+    expect($data->width)->toBe(CustomFieldWidth::_100);
+});
+
+it('carries an explicit width through the section DTO array', function (): void {
+    $data = new CustomFieldSectionData(
+        name: 'Info',
+        code: 'info',
+        width: CustomFieldWidth::_33,
+    );
+
+    expect($data->toArray()['width'])->toBe(CustomFieldWidth::_33->value);
 });

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\CustomFieldWidth;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+it('defaults a new section width to 100', function (): void {
+    $section = CustomFieldSection::factory()->create(['entity_type' => Post::class]);
+
+    expect($section->width)->toBe(CustomFieldWidth::_100);
+});
+
+it('casts the stored section width to the CustomFieldWidth enum', function (): void {
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_50)
+        ->create(['entity_type' => Post::class]);
+
+    expect($section->refresh()->width)->toBe(CustomFieldWidth::_50);
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'id' => $section->id,
+        'width' => '50',
+    ]);
+});

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Relaticle\CustomFields\Enums\CustomFieldSectionType;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Enums\CustomFieldWidth;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
@@ -9,6 +10,7 @@ use Relaticle\CustomFields\FeatureSystem\FeatureManager;
 use Relaticle\CustomFields\Filament\Integration\Factories\SectionComponentFactory;
 use Relaticle\CustomFields\Filament\Integration\Factories\SectionInfolistsFactory;
 use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
@@ -150,4 +152,79 @@ it('does not persist section width from the form when the flag is off', function
         'entity_type' => Post::class,
         'width' => '100',
     ]);
+});
+
+it('drops a submitted width for a headless section because the field is hidden for that type', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
+        CustomFieldsFeature::SYSTEM_SECTIONS,
+        CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+        CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL,
+    )]);
+
+    $this->actingAs(User::factory()->create());
+
+    livewire(CustomFieldsManagementPage::class)
+        ->call('setCurrentEntityType', Post::class)
+        ->callAction('createSection', [
+            'name' => 'Headless Info',
+            'code' => 'headless_info',
+            'type' => CustomFieldSectionType::HEADLESS->value,
+            'width' => CustomFieldWidth::_50->value,
+        ])
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'code' => 'headless_info',
+        'entity_type' => Post::class,
+        'type' => CustomFieldSectionType::HEADLESS->value,
+        'width' => '100',
+    ]);
+});
+
+it('persists a submitted width for a fieldset section because the field is shown for that type', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
+        CustomFieldsFeature::SYSTEM_SECTIONS,
+        CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+        CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL,
+    )]);
+
+    $this->actingAs(User::factory()->create());
+
+    livewire(CustomFieldsManagementPage::class)
+        ->call('setCurrentEntityType', Post::class)
+        ->callAction('createSection', [
+            'name' => 'Fieldset Info',
+            'code' => 'fieldset_info',
+            'type' => CustomFieldSectionType::FIELDSET->value,
+            'width' => CustomFieldWidth::_50->value,
+        ])
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas(CustomFieldSection::class, [
+        'code' => 'fieldset_info',
+        'entity_type' => Post::class,
+        'type' => CustomFieldSectionType::FIELDSET->value,
+        'width' => '50',
+    ]);
+});
+
+it('formats a legacy NULL width as 100 when opening the edit form', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
+        CustomFieldsFeature::SYSTEM_SECTIONS,
+        CustomFieldsFeature::SYSTEM_MANAGEMENT_INTERFACE,
+        CustomFieldsFeature::UI_SECTION_WIDTH_CONTROL,
+    )]);
+
+    $this->actingAs(User::factory()->create());
+
+    $section = CustomFieldSection::factory()->create(['entity_type' => Post::class]);
+    CustomFieldSection::query()->whereKey($section->id)->update(['width' => null]);
+    $section = CustomFieldSection::query()->findOrFail($section->id);
+
+    $component = livewire(ManageCustomFieldSection::class, [
+        'section' => $section,
+        'entityType' => Post::class,
+    ])->mountAction('edit');
+
+    expect($component->get('mountedActions.0.data.width'))->toBe(CustomFieldWidth::_100->value);
 });

--- a/tests/Feature/SectionWidthTest.php
+++ b/tests/Feature/SectionWidthTest.php
@@ -106,6 +106,19 @@ it('applies the same width rules on the infolist path', function (): void {
     expect($component->getColumnSpan('lg'))->toBe(6);
 });
 
+it('ignores section width on the infolist path when the flag is off', function (): void {
+    config(['custom-fields.features' => FeatureConfigurator::configure()
+        ->enable(CustomFieldsFeature::SYSTEM_SECTIONS)]);
+
+    $section = CustomFieldSection::factory()
+        ->width(CustomFieldWidth::_50)
+        ->create(['entity_type' => Post::class]);
+
+    $component = app(SectionInfolistsFactory::class)->create($section);
+
+    expect($component->getColumnSpan('default'))->toBe('full');
+});
+
 it('persists a chosen section width from the management form when the flag is on', function (): void {
     config(['custom-fields.features' => FeatureConfigurator::configure()->enable(
         CustomFieldsFeature::SYSTEM_SECTIONS,


### PR DESCRIPTION
Closes #154.

## What & why

`custom_field_sections.width` has existed as a nullable column since Aug 2025 but
nothing read it — sections always rendered `columnSpanFull()`, forcing multiple
section groups on one entity to stack vertically. This wires the column up so
sections can render side-by-side (25/33/50/66/75/100), reusing the existing
`CustomFieldWidth` enum shared with field-level width.

Gated behind a new `UI_SECTION_WIDTH_CONTROL` feature, **disabled by default** —
no consumer sees a layout change on upgrade.

## Design

Mirrors the existing field-level `UI_FIELD_WIDTH_CONTROL` pattern:

- **Model** — `CustomFieldSection` casts `width` → `CustomFieldWidth`, default `_100`.
- **Rendering** — a shared `AppliesSectionWidth` trait (used by both
  `SectionComponentFactory` and `SectionInfolistsFactory`) applies a fractional
  `columnSpan` only when the flag is on and an explicit non-100 width is set; every
  other case (flag off, `_100`, legacy `NULL`) keeps emitting `columnSpanFull()` —
  byte-identical to today. Applies to `SECTION`/`FIELDSET`; headless is unchanged.
- **Management UI** — a `Select` in the section modal, visible only when the flag is
  on and the type is `SECTION`/`FIELDSET`.
- **DTO** — `CustomFieldSectionData->width` flows through the migrator automatically,
  so presets can set section width.
- Removed a phantom `$section->column_span` read in the infolist factory (no such
  column ever existed; it always fell back to `12`).

## Backward compatibility

- Off by default; full-width path renders exactly as before.
- No DB migration (column already exists); legacy `NULL`-width rows render full width
  and show `100` in the edit form.
- Responsive: a fractional section collapses to full-width-of-its-container on mobile
  (`span 1/1`), so sections stack rather than sit side-by-side.

## Note on the grid

Widths are fractions of the standard **12-column** custom-fields grid
(`FormContainer`/`InfolistContainer` are `Grid::make(12)`): `50%` = a 6-of-12 span.
If an app embeds custom fields inside a grid with a different column count, the visual
fraction follows that grid instead. Documented in `2.essentials/1.configuration.md`.

## Test plan

- [x] Model cast/default, factory state
- [x] Flag off by default; render on/off (form + infolist); legacy `NULL` → full width
- [x] Management form: width persists with flag on; dropped (defaults to `100`) with
      flag off; hidden for headless; `formatStateUsing` shows `100` for legacy rows
- [x] DTO default + serialization; migrator persists a preset section width end-to-end
- [x] Full suite green (757 passing); all touched files 100% type coverage
- [x] Verified in a real Filament app: two `_50` sections render side-by-side at 50/50
      (light + dark) on a 12-column view page

Follow-up: forward-port to `4.x` / `5.x` after merge.
