### PR TITLE
fix: generate cloned container schemas from the evaluated component

### DIFF
--- a/src/EntitySystem/EntityConfigurator.php
+++ b/src/EntitySystem/EntityConfigurator.php
@@ -16,7 +16,7 @@ final class EntityConfigurator implements EntityConfigurationInterface
 {
     private bool $autoDiscover = true;
 
-    private array $discoveryPaths = [];
+    private array $discoveryPaths;
 
     private array $discoveryNamespaces = ['App\\Models'];
 

--- a/src/Filament/Integration/Builders/FormContainer.php
+++ b/src/Filament/Integration/Builders/FormContainer.php
@@ -21,8 +21,12 @@ final class FormContainer extends Grid
     {
         $container = new self($columns);
 
-        // Defer schema generation until component is in container
-        $container->schema(fn (): array => $container->generateSchema());
+        // Defer schema generation until component is in container. Resolve the
+        // component Filament is evaluating instead of capturing `$container`:
+        // cloning a component copies this closure by reference, so a captured
+        // `$container` would keep generating the clone's schema from the
+        // original — which Filament never assigns a container to.
+        $container->schema(static fn (self $component): array => $component->generateSchema());
 
         return $container;
     }

--- a/src/Filament/Integration/Builders/InfolistContainer.php
+++ b/src/Filament/Integration/Builders/InfolistContainer.php
@@ -26,8 +26,12 @@ final class InfolistContainer extends Grid
     {
         $container = new self($columns);
 
-        // Defer schema generation until component is in container
-        $container->schema(fn (): array => $container->generateSchema());
+        // Defer schema generation until component is in container. Resolve the
+        // component Filament is evaluating instead of capturing `$container`:
+        // cloning a component copies this closure by reference, so a captured
+        // `$container` would keep generating the clone's schema from the
+        // original — which Filament never assigns a container to.
+        $container->schema(static fn (self $component): array => $component->generateSchema());
 
         return $container;
     }

--- a/tests/Feature/Integration/ClonedContainerTest.php
+++ b/tests/Feature/Integration/ClonedContainerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+// FormContainer and InfolistContainer defer schema generation to a closure. That
+// closure must resolve the component Filament is evaluating rather than capturing
+// the instance `make()` built, because `clone` copies the closure by reference:
+// a cloned container would otherwise generate its schema from the original, which
+// Filament never assigns a container to.
+//
+// Filament 5.6 masked this — `HasComponents::cloneComponents()` called
+// `->container($this)->getClone()`, so the original was containerised before being
+// cloned. Filament 5.7 reordered that to `->getClone()->container($this)`, leaving
+// the original uninitialised and turning every cloned container into
+// "Typed property Filament\Schemas\Components\Component::$container must not be
+// accessed before initialization".
+//
+// Repeaters and repeatable entries clone their child schema per item, so this is
+// the user-facing path: custom fields nested in a repeater.
+//
+// The crash is the loud symptom, but the underlying defect predates 5.7: a clone
+// generating its schema from the original also resolves the *original's* model, so
+// on 5.6 it silently rendered the wrong entity's fields. The last test pins that
+// down, and holds regardless of how Filament clones components in future.
+
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TextInput;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\CustomFields\Filament\Integration\Builders\FormContainer;
+use Relaticle\CustomFields\Filament\Integration\Builders\InfolistContainer;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Comment;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $section = CustomFieldSection::factory()->forEntityType(Post::class)->create();
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Cloned field',
+        'code' => 'cloned_field',
+        'type' => 'text',
+        'entity_type' => Post::class,
+    ]);
+
+    $this->livewire = livewire(CreatePost::class)->instance();
+});
+
+it('renders form custom fields inside a repeater, whose item schemas are cloned', function (): void {
+    $schema = Schema::make($this->livewire)
+        ->model(Post::class)
+        ->statePath('data')
+        ->components([
+            Repeater::make('items')
+                ->schema([CustomFields::form()->build()]),
+        ]);
+
+    $repeater = $schema->getComponents()[0];
+    $repeater->rawState([['cloned_field' => null]]);
+
+    $fieldNames = collect($repeater->getChildSchemas())
+        ->flatMap(fn (Schema $itemSchema): array => $itemSchema->getFlatComponents())
+        ->map(fn (object $component): string => $component::class);
+
+    expect($fieldNames)->toContain(FormContainer::class)
+        ->and($fieldNames)->toContain(TextInput::class);
+});
+
+it('regenerates a cloned form container against the clone, not the original', function (): void {
+    $schema = Schema::make($this->livewire)
+        ->model(Post::class)
+        ->components([CustomFields::form()->build()]);
+
+    $componentNames = collect($schema->getClone()->getFlatComponents())
+        ->map(fn (object $component): string => $component::class);
+
+    expect($componentNames)->toContain(FormContainer::class)
+        ->and($componentNames)->toContain(TextInput::class);
+});
+
+it('regenerates a cloned infolist container against the clone, not the original', function (): void {
+    $schema = Schema::make($this->livewire)
+        ->record(Post::factory()->create())
+        ->components([CustomFields::infolist()->build()]);
+
+    $componentNames = collect($schema->getClone()->getFlatComponents())
+        ->map(fn (object $component): string => $component::class);
+
+    expect($componentNames)->toContain(InfolistContainer::class)
+        ->and($componentNames)->toContain(TextEntry::class);
+});
+
+it('generates a cloned container against the model of the schema it now belongs to', function (): void {
+    $commentSection = CustomFieldSection::factory()->forEntityType(Comment::class)->create();
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $commentSection->id,
+        'name' => 'Comment only',
+        'code' => 'comment_only',
+        'type' => 'text',
+        'entity_type' => Comment::class,
+    ]);
+
+    $container = CustomFields::form()->build();
+
+    // Containerise the original under a Post form, then clone it into a Comment
+    // form — the shape Filament's own cloneComponents() produces.
+    Schema::make($this->livewire)->model(Post::class)->components([$container])->getComponents();
+
+    $commentSchema = Schema::make($this->livewire)
+        ->model(Comment::class)
+        ->components([$container->getClone()]);
+
+    $fieldNames = collect($commentSchema->getFlatComponents())
+        ->filter(fn (object $component): bool => $component instanceof Field)
+        ->map(fn (Field $component): string => $component->getName())
+        ->implode(',');
+
+    expect($fieldNames)->toContain('comment_only')
+        ->and($fieldNames)->not->toContain('cloned_field');
+});


### PR DESCRIPTION
## Problem

On Filament **5.7**, any cloned `FormContainer` / `InfolistContainer` throws:

```
Error: Typed property Filament\Schemas\Components\Component::$container
       must not be accessed before initialization
  #1 Component->getRecord               (FormContainer.php:61)
  #2 FormContainer->generateSchema      (FormContainer.php:25)
```

User-facing symptom: **custom fields nested in a `Repeater` (or `Builder` / `RepeatableEntry`) are broken outright** — those clone their child schema once per item.

## Root cause

`make()` defers schema generation to a closure that captures `$container`, the instance `make()` itself built:

```php
$container = new self($columns);
$container->schema(fn (): array => $container->generateSchema());
```

`clone` is shallow, so a cloned container keeps *the same Closure*, still bound to the original. The clone is what Filament puts in the schema, but `generateSchema()` still runs against the original.

**This is a correctness bug that predates 5.7.** Because the closure resolves the original, a clone also resolves the *original's* model — so on 5.6 a container cloned into a different form silently rendered **the wrong entity's custom fields**, with no error. 5.7 only escalated one symptom to a fatal.

## Why 5.7 turned it fatal

Not a typed-property strictness change — `BelongsToContainer::$container` is `protected Schema $container;` (no default) identically in v5.6.8, v5.7.0 and v5.7.3. The trigger is a statement reorder in `Filament\Schemas\Concerns\HasComponents::cloneComponents()`:

```diff
- $component->container($this)->getClone(),   // 5.6: ORIGINAL containerised, then cloned
+ $component->getClone()->container($this),   // 5.7: only the CLONE is containerised
```

5.6 containerised the original before cloning, so the stale closure resolved *something*. 5.7 leaves it uninitialised.

## Fix

Resolve the component Filament is evaluating instead of capturing one:

```php
$container->schema(static fn (self $component): array => $component->generateSchema());
```

This is Filament's standard closure-injection contract, not an implementation detail — `EvaluatesClosures::resolveClosureDependencyForEvaluation()` returns `$this` when `is_a($this, $typedParameterClassName)`, and `getTypedReflectionParameterClassName()` has explicit handling for the `self` keyword. Resolution for this parameter never calls `getContainer()`, which matters because that is the property that may be uninitialised.

Applied to both `FormContainer` and `InfolistContainer` — the sibling had the identical bug.

## Verification

`tests/Feature/Integration/ClonedContainerTest.php` — 4 tests, each confirmed **load-bearing** (reverting the source fix turns them red):

| | old @ 5.6.1 | old @ 5.7.3 | fixed @ 5.6.1 | fixed @ 5.7.3 |
|---|---|---|---|---|
| custom fields in a `Repeater` | pass | **fatal** | pass | pass |
| cloned form schema | pass | **fatal** | pass | pass |
| cloned infolist schema | pass | **fatal** | pass | pass |
| clone renders the right entity's fields | **silently wrong** | **fatal** | pass | pass |

Full package suite green on **both**, and under CI's exact resolution (Laravel 13.23 + filament 5.7.3): **761 passed / 2867 assertions**. `pint --test` and `phpstan analyse` clean; `rector --dry-run` reports nothing in the files this PR touches.

Also verified end-to-end in a consuming Filament 5.7.3 app (Relaticle): create form renders custom fields, values persist, infolist renders them on the view page, no regression across the panel.

### Alternatives considered

Overriding `getDefaultChildComponents()` to drop the closure entirely looks cleaner but is worse — it breaks the `array_key_exists('default', $this->childComponents)` guard in `getChildSchemas()`, and it silently ignores a consumer's own `->schema()` override. Tried it: it fails a large part of the existing integration suite.

## Note on CI

The `Tests` workflow currently fails at the **Rector** step for every PR on `3.x`, including dependabot's, on `src/EntitySystem/EntityConfigurator.php:16` (`RemoveDefaultValueFromAssignedPropertyRector`, from a newer rector release). Unrelated to this change and reproducible on a pristine `3.x` checkout with `composer update --prefer-stable`. It blocks the Pest step, so the results above are from running the CI gates locally on that same resolution. Happy to send a separate PR to unblock it.

> The committed `composer.lock` pins `filament/schemas` **5.6.1**, where 3 of the 4 tests pass trivially. CI resolves 5.7.3 via `composer update --prefer-stable`, so the guard is real there. To reproduce locally: `composer update "filament/*" --prefer-stable`. Left the lock to dependabot to avoid conflicting with its open PRs.

---

**Update:** the Rector break described above is fixed in this PR (second commit) rather than a separate one, since it blocked the Pest step and made this PR unreviewable. `EntityConfigurator::$discoveryPaths` had a dead `= []` default — the constructor assigns it unconditionally and both construction paths (`configure()` and `__set_state()`) run the constructor, so removing it is safe. Verified the `var_export()` / `__set_state()` round trip that `config:cache` relies on still restores correctly, both for a configured and an untouched instance.

CI is now green on both matrix legs (L12 and L13), with the new tests executing.
