### PR TITLE
fix: resync docs lockfile so the docs deploy can install again

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,7 +11,7 @@
                 "@nuxt/ui": "^4.10.0",
                 "@unhead/vue": "^2.0.17",
                 "better-sqlite3": "^12.4.1",
-                "docus": "*",
+                "docus": "latest",
                 "nuxt": "^4.4.8",
                 "typescript": "^5.9.2"
             },
@@ -1479,6 +1479,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1501,6 +1502,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1523,6 +1525,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1539,6 +1542,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1555,6 +1559,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1571,6 +1576,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1587,6 +1593,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1603,6 +1610,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1619,6 +1627,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1635,6 +1644,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1651,6 +1661,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1667,6 +1678,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
@@ -1683,6 +1695,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1705,6 +1718,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1727,6 +1741,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1749,6 +1764,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1771,6 +1787,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1793,6 +1810,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1815,6 +1833,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1837,6 +1856,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1856,6 +1876,7 @@
             ],
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/runtime": "^1.7.0"
             },
@@ -1878,6 +1899,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1897,6 +1919,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -1916,6 +1939,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
@@ -3092,6 +3116,40 @@
                 "ufo": "^1.6.4"
             }
         },
+        "node_modules/@nuxt/icon/node_modules/@emnapi/core": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@emnapi/runtime": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@nuxt/icon/node_modules/@nuxt/kit": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
@@ -3124,6 +3182,398 @@
                 "node": ">=18.12.0"
             }
         },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.142.0.tgz",
+            "integrity": "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.142.0.tgz",
+            "integrity": "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.142.0.tgz",
+            "integrity": "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.142.0.tgz",
+            "integrity": "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.142.0.tgz",
+            "integrity": "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.142.0.tgz",
+            "integrity": "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.142.0.tgz",
+            "integrity": "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.142.0.tgz",
+            "integrity": "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.142.0.tgz",
+            "integrity": "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.142.0.tgz",
+            "integrity": "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.142.0.tgz",
+            "integrity": "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.142.0.tgz",
+            "integrity": "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.142.0.tgz",
+            "integrity": "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.142.0.tgz",
+            "integrity": "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.142.0.tgz",
+            "integrity": "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.142.0.tgz",
+            "integrity": "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.142.0.tgz",
+            "integrity": "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.142.0.tgz",
+            "integrity": "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/@oxc-project/types": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/oxc-parser": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.142.0.tgz",
+            "integrity": "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "^0.142.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.142.0",
+                "@oxc-parser/binding-android-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-x64": "0.142.0",
+                "@oxc-parser/binding-freebsd-x64": "0.142.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.142.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.142.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.142.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.142.0"
+            }
+        },
         "node_modules/@nuxt/icon/node_modules/std-env": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
@@ -3152,6 +3602,62 @@
                     "optional": true
                 },
                 "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/icon/node_modules/unplugin": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.4",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -3605,6 +4111,40 @@
                 }
             }
         },
+        "node_modules/@nuxt/ui/node_modules/@emnapi/core": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@emnapi/runtime": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@nuxt/ui/node_modules/@nuxt/kit": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
@@ -3663,6 +4203,359 @@
                 }
             }
         },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.142.0.tgz",
+            "integrity": "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.142.0.tgz",
+            "integrity": "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.142.0.tgz",
+            "integrity": "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.142.0.tgz",
+            "integrity": "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.142.0.tgz",
+            "integrity": "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.142.0.tgz",
+            "integrity": "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.142.0.tgz",
+            "integrity": "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.142.0.tgz",
+            "integrity": "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.142.0.tgz",
+            "integrity": "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.142.0.tgz",
+            "integrity": "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.142.0.tgz",
+            "integrity": "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.142.0.tgz",
+            "integrity": "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.142.0.tgz",
+            "integrity": "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.142.0.tgz",
+            "integrity": "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.142.0.tgz",
+            "integrity": "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.142.0.tgz",
+            "integrity": "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.142.0.tgz",
+            "integrity": "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.142.0.tgz",
+            "integrity": "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxt/ui/node_modules/@oxc-project/types": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@nuxt/ui/node_modules/@vueuse/core": {
             "version": "14.3.0",
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
@@ -3706,6 +4599,45 @@
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
             "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "license": "MIT"
+        },
+        "node_modules/@nuxt/ui/node_modules/oxc-parser": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.142.0.tgz",
+            "integrity": "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "^0.142.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.142.0",
+                "@oxc-parser/binding-android-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-x64": "0.142.0",
+                "@oxc-parser/binding-freebsd-x64": "0.142.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.142.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.142.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.142.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.142.0"
+            }
         },
         "node_modules/@nuxt/ui/node_modules/unplugin": {
             "version": "3.3.0",
@@ -3931,6 +4863,40 @@
                 "semver": "^7.8.1"
             }
         },
+        "node_modules/@nuxtjs/color-mode/node_modules/@emnapi/core": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@emnapi/runtime": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.0.tgz",
@@ -3963,6 +4929,398 @@
                 "node": ">=18.12.0"
             }
         },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.142.0.tgz",
+            "integrity": "sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.142.0.tgz",
+            "integrity": "sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.142.0.tgz",
+            "integrity": "sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.142.0.tgz",
+            "integrity": "sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.142.0.tgz",
+            "integrity": "sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.142.0.tgz",
+            "integrity": "sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.142.0.tgz",
+            "integrity": "sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.142.0.tgz",
+            "integrity": "sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.142.0.tgz",
+            "integrity": "sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.142.0.tgz",
+            "integrity": "sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.142.0.tgz",
+            "integrity": "sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.142.0.tgz",
+            "integrity": "sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.142.0.tgz",
+            "integrity": "sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.142.0.tgz",
+            "integrity": "sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.142.0.tgz",
+            "integrity": "sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.142.0.tgz",
+            "integrity": "sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-wasm32-wasi": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.142.0.tgz",
+            "integrity": "sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
+                "@napi-rs/wasm-runtime": "^1.1.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.142.0.tgz",
+            "integrity": "sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.142.0.tgz",
+            "integrity": "sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/@oxc-project/types": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+            "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/oxc-parser": {
+            "version": "0.142.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.142.0.tgz",
+            "integrity": "sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@oxc-project/types": "^0.142.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.142.0",
+                "@oxc-parser/binding-android-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-arm64": "0.142.0",
+                "@oxc-parser/binding-darwin-x64": "0.142.0",
+                "@oxc-parser/binding-freebsd-x64": "0.142.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.142.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.142.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.142.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.142.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.142.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.142.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.142.0"
+            }
+        },
         "node_modules/@nuxtjs/color-mode/node_modules/unctx": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
@@ -3985,6 +5343,62 @@
                     "optional": true
                 },
                 "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxtjs/color-mode/node_modules/unplugin": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.4",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -4416,9 +5830,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4434,9 +5845,6 @@
             "integrity": "sha512-yqskeIapQvx7Tu/OLsepLPcGsHGzfYy9PX6gIbhaOHfF+LA2zHBKnKb587FGx+lQjHLQR0llfmoSuXQ6q2EN+A==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4454,9 +5862,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4472,9 +5877,6 @@
             "integrity": "sha512-omXWC8I9lAMMjQIeadfItP5H4VDAiuU2BiVCtHMH3ktTbFq04sxscZhK4NFUUuw3fApDdXmfd7LW18q0JBHarg==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4492,9 +5894,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4510,9 +5909,6 @@
             "integrity": "sha512-rFsPDsT1j3beSInbrFukAAlTg101PcqdVMXDioR9AgJ1180tZ8s8D+pNDpQTRmPd3956mnpAE+Cs77Xoo/QZAQ==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4530,9 +5926,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4548,9 +5941,6 @@
             "integrity": "sha512-kd36CDkTkZDMNfVceNTSfpWnitE1+GjZmzJCeq8yaxsgvs/MXg8aauI2RgFjElYZIHSMyZku4pQ7Jtl3ZEYI6w==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6498,9 +7888,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6516,9 +7903,6 @@
             "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6536,9 +7920,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6554,9 +7935,6 @@
             "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17480,9 +18858,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17498,9 +18873,6 @@
             "integrity": "sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17518,9 +18890,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17536,9 +18905,6 @@
             "integrity": "sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -17556,9 +18922,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17574,9 +18937,6 @@
             "integrity": "sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -17594,9 +18954,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17612,9 +18969,6 @@
             "integrity": "sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17835,9 +19189,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17853,9 +19204,6 @@
             "integrity": "sha512-Ec7xJdDrnukgiz20E3iDNzAIgx1XXn8cVVsNNUpgEIAvNlXZaocqlQT8Zalk0Lv3fbkxcJ+9BuWB0ndBRHQtzg==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17873,9 +19221,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17891,9 +19236,6 @@
             "integrity": "sha512-WxMIzItRJR66lgaAyyqj0FFwLMpcuCV9mTFcUMQpIz8+Hey1Enk8xuv+7QpSsqCR5zRlwNr092dsFkz5cbvtrw==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -17911,9 +19253,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17929,9 +19268,6 @@
             "integrity": "sha512-oEyQudXIwWM/+v0vZzPbAi25YMWyvjtQYYjuSrhMEQwe7ZEMDXscX7U1j6alrVdZq2DtCMeror3X/Dv7p/JUwg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -17949,9 +19285,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17967,9 +19300,6 @@
             "integrity": "sha512-Oi/fyOzZ+aytmmsRND5pGgvux4n++v9cG4qNFiXj7qFwSqBKWZHBq7cJLXqbH1I81pyI3kvU1Za+1qk3afXuwg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,


### PR DESCRIPTION
## Problem

**Deploy Docs has been failing on every docs push since 2026-07-21** — the public docs site has not been updated since. Merging #187 just now triggered another failure (29s, [run](https://github.com/relaticle/custom-fields/actions/runs/30356091017)).

The failing step is `npm ci` in `docs/`:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: oxc-parser@0.142.0 from lock file
npm error Missing: unplugin@3.3.0 from lock file
```

Reproduces on a pristine `3.x` checkout, so it is not caused by #187 — that PR only carried `@modelcontextprotocol/sdk` 1.29.0→1.30.0 and `valibot` 1.2.0→1.4.2.

Dependabot edits individual entries in the lockfile surgically; it never regenerates it, so it cannot repair a desync and every dependabot docs PR inherits the red check.

## Fix

Regenerated `docs/package-lock.json` with `npm install`. Lockfile only — `docs/package.json` is untouched, and #187's bumps are preserved (`@modelcontextprotocol/sdk` 1.30.0, `valibot` 1.4.2).

## Verification

```
npm ci          → added 1337 packages, clean
npm run generate → Prerendered 50 routes; Build complete!
```

Checked the generated output rather than trusting the exit code: 16 HTML files in `.output/public`, `index.html` 54 KB with the correct `<title>`.

Ran with the same env the workflow uses (`NUXT_APP_BASE_URL=/custom-fields/`, `NUXT_SITE_URL`, `DOCS_VERSION=3.x`) on Node 22. The workflow pins Node 20 — the lockfile is engine-independent, but CI will confirm.

## Follow-up worth considering

`docs/package.json` declares `"docus": "latest"`. A floating dist-tag means the resolved tree drifts from the committed lock whenever docus publishes, so this desync will recur. Pinning it to a caret range (currently resolves to 5.9.0) would stop that. Not doing it here — separate decision.

The build emits `[400] Invalid island request hash` warnings from `nuxt-og-image` while prerendering OG images. Non-fatal (the build completes and pages generate), but flagging since there is no green baseline to compare against.