### PR TITLE
fix: apply presence rule to custom field validation on import [3.x]

### DIFF
--- a/src/Filament/Integration/Base/AbstractFormComponent.php
+++ b/src/Filament/Integration/Base/AbstractFormComponent.php
@@ -331,10 +331,15 @@ abstract readonly class AbstractFormComponent implements FormComponentInterface
         return $field->live()->visibleJs($jsExpression);
     }
 
-    /** @return array<int, mixed> */
+    /**
+     * Presence is applied separately via ->required(), conditionally on field visibility,
+     * so only the value rules belong here.
+     *
+     * @return array<int, mixed>
+     */
     protected function getFieldValidationRules(CustomField $customField, string|int|null $ignoreEntityId = null): array
     {
-        return $this->validationService->getValidationRules($customField, $ignoreEntityId);
+        return $this->validationService->getValueValidationRules($customField, $ignoreEntityId);
     }
 
     /**

--- a/src/Filament/Integration/Concerns/Forms/ConfiguresValidation.php
+++ b/src/Filament/Integration/Concerns/Forms/ConfiguresValidation.php
@@ -21,6 +21,6 @@ trait ConfiguresValidation
     {
         return $field
             ->required($validationService->isRequired($customField))
-            ->rules($validationService->getValidationRules($customField));
+            ->rules($validationService->getValueValidationRules($customField));
     }
 }

--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -19,19 +19,51 @@ use Relaticle\CustomFields\Support\DatabaseFieldConstraints;
 final class ValidationService
 {
     /**
-     * Get all validation rules for a custom field, applying both:
+     * Get the complete validation rule set for a custom field: the presence rule
+     * followed by the value rules.
+     *
+     * This is the rule set to use whenever the value is handed straight to a Laravel
+     * validator — imports, APIs, jobs — because nothing else supplies presence there.
+     * Filament fields supply their own presence rule and should use
+     * {@see self::getValueValidationRules()} instead.
+     *
+     * @param  CustomField  $customField  The custom field to get validation rules for
+     * @param  string|int|null  $ignoreEntityId  Entity ID to ignore for unique checks (when updating)
+     * @return array<int, mixed> Presence rule followed by the value rules
+     */
+    public function getValidationRules(CustomField $customField, string|int|null $ignoreEntityId = null): array
+    {
+        return [
+            $this->getPresenceRule($customField),
+            ...$this->getValueValidationRules($customField, $ignoreEntityId),
+        ];
+    }
+
+    /**
+     * Get the presence rule for a custom field.
+     *
+     * Without it a mapped-but-empty value reaches the validator as null and every
+     * type rule (date, numeric, boolean, file, regex) rejects it, while a required
+     * field is never enforced at all.
+     */
+    public function getPresenceRule(CustomField $customField): string
+    {
+        return $this->isRequired($customField) ? 'required' : 'nullable';
+    }
+
+    /**
+     * Get the value rules for a custom field — how the value must look when present,
+     * with no presence rule. Applies:
      * - User-defined validation rules from the field configuration
      * - Database field constraints based on field type
      * - Type-specific settings (e.g., unique per entity type for email fields)
      * - Special handling for numeric values to prevent database errors
      *
-     * Returns a combined array of validation rules in Laravel validator format.
-     *
      * @param  CustomField  $customField  The custom field to get validation rules for
      * @param  string|int|null  $ignoreEntityId  Entity ID to ignore for unique checks (when updating)
      * @return array<int, mixed> Combined array of validation rules
      */
-    public function getValidationRules(CustomField $customField, string|int|null $ignoreEntityId = null): array
+    public function getValueValidationRules(CustomField $customField, string|int|null $ignoreEntityId = null): array
     {
         // Get capability-based rules from stored values
         $capabilityRules = $this->getCapabilityRules($customField);

--- a/tests/Feature/Imports/ImportColumnPresenceValidationTest.php
+++ b/tests/Feature/Imports/ImportColumnPresenceValidationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Imports\ImportColumn;
+use Illuminate\Support\Facades\Validator;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldTypeConfigurator;
+use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportColumnConfigurator;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Services\ValidationService;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+
+    config()->set('custom-fields.field_type_configuration', FieldTypeConfigurator::configure()
+        ->enabled([])
+        ->disabled([])
+        ->discover(true)
+        ->cache(enabled: false));
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create();
+});
+
+/**
+ * Mirrors what Filament does per row: Importer::castData() casts the raw cell
+ * (blank always becomes null), then Importer::validateData() validates the cast state.
+ */
+function validateImportedCell(CustomField $field, mixed $cell): Illuminate\Contracts\Validation\Validator
+{
+    $column = ImportColumn::make('custom_fields_'.$field->code)->label($field->name);
+
+    app(ImportColumnConfigurator::class)->configure($column, $field);
+
+    return Validator::make(
+        ['value' => $column->castState($cell)],
+        ['value' => $column->getDataValidationRules()],
+    );
+}
+
+function makeImportableField(string $type, bool $required): CustomField
+{
+    return CustomField::factory()->create([
+        'custom_field_section_id' => test()->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'imported_'.str_replace('-', '_', $type),
+        'type' => $type,
+        'validation_rules' => $required ? ['required' => true] : [],
+    ]);
+}
+
+/**
+ * @return array<int, string>
+ */
+function registeredFieldTypeKeys(): array
+{
+    return CustomFieldsType::toCollection()
+        ->map(fn (mixed $fieldType): string => $fieldType->key)
+        ->values()
+        ->all();
+}
+
+it('accepts an empty mapped cell for every optional field type', function (): void {
+    $rejected = [];
+
+    foreach (registeredFieldTypeKeys() as $type) {
+        $validator = validateImportedCell(makeImportableField($type, required: false), '');
+
+        if ($validator->fails()) {
+            $rejected[$type] = $validator->errors()->first();
+        }
+    }
+
+    expect($rejected)->toBe([]);
+});
+
+it('rejects an empty mapped cell for every required field type', function (): void {
+    $accepted = [];
+
+    foreach (registeredFieldTypeKeys() as $type) {
+        if (! validateImportedCell(makeImportableField($type, required: true), '')->fails()) {
+            $accepted[] = $type;
+        }
+    }
+
+    expect($accepted)->toBe([]);
+});
+
+it('accepts a filled cell for an optional field', function (string $type, string $cell): void {
+    $validator = validateImportedCell(makeImportableField($type, required: false), $cell);
+
+    expect($validator->fails())->toBeFalse(
+        sprintf('[%s] optional field rejected "%s": %s', $type, $cell, $validator->errors()->first())
+    );
+})->with([
+    'text' => ['text', 'Sample text'],
+    'textarea' => ['textarea', 'Sample longer text'],
+    'rich-editor' => ['rich-editor', '<p>Sample</p>'],
+    'markdown-editor' => ['markdown-editor', '# Sample'],
+    'number' => ['number', '42'],
+    'currency' => ['currency', '10.50'],
+    'date' => ['date', '2026-01-15'],
+    'date-time' => ['date-time', '2026-01-15 10:00'],
+    'checkbox' => ['checkbox', 'true'],
+    'toggle' => ['toggle', 'yes'],
+    'color-picker' => ['color-picker', '#ff0000'],
+    'link' => ['link', 'https://example.com'],
+    'tags-input' => ['tags-input', 'alpha, beta'],
+]);
+
+it('exposes the presence rule as the single source of truth', function (): void {
+    $service = app(ValidationService::class);
+
+    expect($service->getPresenceRule(makeImportableField('text', required: false)))->toBe('nullable')
+        ->and($service->getPresenceRule(makeImportableField('textarea', required: true)))->toBe('required');
+});
+
+it('keeps value validation rules free of presence rules for callers that supply their own', function (): void {
+    $service = app(ValidationService::class);
+
+    expect($service->getValueValidationRules(makeImportableField('number', required: false)))
+        ->not->toContain('nullable')
+        ->not->toContain('required')
+        ->and($service->getValueValidationRules(makeImportableField('date', required: true)))
+        ->not->toContain('nullable')
+        ->not->toContain('required');
+});


### PR DESCRIPTION
Fixes optional custom fields failing import validation when the column is mapped but the cell is empty (Journey: [868kkcw4h](https://app.clickup.com/t/868kkcw4h)).

## Root cause

`ValidationService::getValidationRules()` returns **value-shape rules only** — no `required`, no `nullable`. Filament form fields hide that gap because `Field::getRequiredValidationRule()` always prepends one. The importer calls Laravel's validator directly, so it shipped a rule set that was wrong in both directions.

Per row, Filament runs `Importer::castData()` **before** `Importer::validateData()`, and `ImportColumn::castStateItem()` turns every blank cell into `null`. So a mapped-but-empty column reaches the validator as a *present* `null`, which Laravel considers validatable. Without `nullable`, `date` / `numeric` / `boolean` / `file` / `regex` all reject it.

## Reproduced

Against all 24 registered field types, optional field + mapped column + empty cell — 11 types rejected the row:

| types | error |
| --- | --- |
| `number` `radio` `select` `toggle-buttons` | must be a number / must be an integer |
| `currency` | must be a number / 0-15 decimal places |
| `date` `date-time` | must be a valid date |
| `checkbox` `toggle` | must be true or false |
| `color-picker` | format is invalid |
| `file-upload` | must be a file |

The same run with `validation_rules = ['required' => true]` exposed the inverse bug: **required custom fields were never enforced on import**. `text`, `textarea`, `rich-editor`, `markdown-editor`, `email`, `phone`, `link`, `multi-select`, `checkbox-list`, `tags-input`, `record` all *accepted* an empty mapped cell. The remaining types only rejected it by accident, via the type rule, with a misleading message.

## Fix

Make presence a first-class part of the `ValidationService` contract, with the **safe default**:

- `getValidationRules()` — presence rule + value rules. The correct set for any caller handing a value straight to a Laravel validator (imports, APIs, jobs).
- `getValueValidationRules()` — value rules only, for callers that supply presence themselves.
- `getPresenceRule()` — single source of truth for `required` vs `nullable`.

`ImportColumnConfigurator` needs no change: it already calls `getValidationRules()`, which is now complete. The two Filament form adapters move to `getValueValidationRules()` because they apply `->required()` separately and **conditionally on field visibility** — that conditionality is exactly why presence must not be baked into the form path.

Patching the importer call site alone would have fixed this ticket in three lines and left the same trap for the next consumer. This makes the obvious call correct and requires the special case to opt out.

## Future-proofing

The one-line fix isn't what stops this recurring. `tests/Feature/Imports/ImportColumnPresenceValidationTest.php` iterates `CustomFieldsType::toCollection()` and asserts, per registered type:

- optional + empty mapped cell → accepted
- required + empty mapped cell → rejected
- optional + representative value → accepted

Because it enumerates the registry rather than a hardcoded list, any newly added field type — including app-registered ones — is covered in both directions automatically.

## Behaviour change

Required custom fields are now actually enforced on import. Rows that previously imported with a required custom field left blank will now fail with a clear "field is required" message instead of silently landing incomplete.

## Verification

- `pest --parallel` — 778 passed, 0 failed (3 todos)
- `phpstan analyse` — no errors
- `pint --dirty` — passed
- `rector --dry-run` — clean
- Type coverage sits at 99.4% both before and after this change (pre-existing, in `DateConstraintField.php` and `FieldForm.php`; not gated in CI)

## Known gaps, deliberately out of scope

1. **Required + unmapped column is still silent.** `Importer::getValidationRules()` skips unmapped columns entirely, so a required custom field the user never mapped is never validated. Filament's answer is `ImportColumn::requiredMapping()`. Left out because it would block existing import workflows at the mapping step — worth a separate, deliberate PR.
2. **`file-upload` fields are unimportable with a filled cell.** `FileUploadFieldType` declares `defaultValidationRules(['file'])`, and a CSV cell is always a string, so a filled cell fails with "must be a file" regardless of this change. `nullable` only rescues the empty case. `getDatabaseValidationRules()` already special-cases `FieldDataType::FILE` for the same reason; the import path should too.