### PR TITLE
fix: only save custom fields the imported row carried [3.x]

### DIFF
--- a/src/Filament/Integration/Builders/ImporterBuilder.php
+++ b/src/Filament/Integration/Builders/ImporterBuilder.php
@@ -123,11 +123,9 @@ final class ImporterBuilder extends BaseBuilder
 
         $this->getAllFields()
             ->filter(fn (CustomField $field): bool => array_key_exists($field->code, $customFieldsData))
-            ->each(fn (CustomField $field) => $this->model->saveCustomFieldValue(
-                $field,
-                $customFieldsData[$field->code],
-                $tenant,
-            ));
+            ->each(function (CustomField $field) use ($customFieldsData, $tenant): void {
+                $this->model->saveCustomFieldValue($field, $customFieldsData[$field->code], $tenant);
+            });
     }
 
     public function filterCustomFieldsFromData(array $data): array

--- a/src/Filament/Integration/Builders/ImporterBuilder.php
+++ b/src/Filament/Integration/Builders/ImporterBuilder.php
@@ -106,16 +106,28 @@ final class ImporterBuilder extends BaseBuilder
         return array_unique(array_merge($typeAliases, $codeAliases));
     }
 
+    /**
+     * Persist only the fields the imported row actually carried.
+     *
+     * saveCustomFields() nulls every field missing from its payload, which is right for a form
+     * (it renders all fields, so absent means cleared) and destructive for an import, where a CSV
+     * legitimately maps a subset of columns and absent means "not in this file".
+     */
     public function saveValues(?Model $tenant = null): void
     {
-        // Get custom field data from storage or extract from provided data
         $customFieldsData = ImportDataStorage::pull($this->model);
 
         if ($customFieldsData === []) {
             return;
         }
 
-        $this->model->saveCustomFields($customFieldsData, $tenant);
+        $this->getAllFields()
+            ->filter(fn (CustomField $field): bool => array_key_exists($field->code, $customFieldsData))
+            ->each(fn (CustomField $field) => $this->model->saveCustomFieldValue(
+                $field,
+                $customFieldsData[$field->code],
+                $tenant,
+            ));
     }
 
     public function filterCustomFieldsFromData(array $data): array

--- a/src/Models/Contracts/HasCustomFields.php
+++ b/src/Models/Contracts/HasCustomFields.php
@@ -29,7 +29,7 @@ interface HasCustomFields
 
     public function getCustomFieldValue(CustomField $customField): mixed;
 
-    public function saveCustomFieldValue(CustomField $customField, mixed $value): void;
+    public function saveCustomFieldValue(CustomField $customField, mixed $value, ?Model $tenant = null): void;
 
     /**
      * @param  array<string, mixed>  $customFields

--- a/tests/Feature/Imports/ImporterBuilderSaveValuesTest.php
+++ b/tests/Feature/Imports/ImporterBuilderSaveValuesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportDataStorage;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $this->section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create();
+
+    $this->referralSource = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'referral_source',
+        'type' => 'text',
+    ]);
+
+    $this->caseworker = CustomField::factory()->create([
+        'custom_field_section_id' => $this->section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'caseworker',
+        'type' => 'text',
+    ]);
+});
+
+it('saves the custom field values the imported row carried', function (): void {
+    $post = Post::factory()->create();
+
+    ImportDataStorage::setMultiple($post, [
+        'referral_source' => 'Continuum of Care',
+        'caseworker' => 'Alex Rivera',
+    ]);
+
+    CustomFields::importer()->forModel($post)->saveValues();
+
+    $post->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($this->referralSource))->toBe('Continuum of Care')
+        ->and($post->getCustomFieldValue($this->caseworker))->toBe('Alex Rivera');
+});
+
+it('leaves custom fields the row did not carry untouched', function (): void {
+    $post = Post::factory()->create();
+
+    $post->saveCustomFieldValue($this->caseworker, 'Alex Rivera');
+
+    ImportDataStorage::set($post, 'referral_source', 'Street Outreach');
+
+    CustomFields::importer()->forModel($post)->saveValues();
+
+    $post->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($this->referralSource))->toBe('Street Outreach')
+        ->and($post->getCustomFieldValue($this->caseworker))->toBe('Alex Rivera');
+});
+
+it('does nothing when the row carried no custom field columns', function (): void {
+    $post = Post::factory()->create();
+
+    $post->saveCustomFieldValue($this->caseworker, 'Alex Rivera');
+
+    CustomFields::importer()->forModel($post)->saveValues();
+
+    $post->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($this->caseworker))->toBe('Alex Rivera');
+});

--- a/tests/Feature/Imports/ImporterBuilderSaveValuesTest.php
+++ b/tests/Feature/Imports/ImporterBuilderSaveValuesTest.php
@@ -73,3 +73,34 @@ it('does nothing when the row carried no custom field columns', function (): voi
 
     expect($post->getCustomFieldValue($this->caseworker))->toBe('Alex Rivera');
 });
+
+it('clears a value when the row carried the column but left it blank', function (): void {
+    $post = Post::factory()->create();
+
+    $post->saveCustomFieldValue($this->referralSource, 'Continuum of Care');
+
+    // A mapped-but-blank CSV cell reaches storage as null, not as an absent key.
+    ImportDataStorage::set($post, 'referral_source', null);
+
+    CustomFields::importer()->forModel($post)->saveValues();
+
+    $post->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($this->referralSource))->toBeEmpty();
+});
+
+it('distinguishes a blank mapped column from an unmapped one in the same row', function (): void {
+    $post = Post::factory()->create();
+
+    $post->saveCustomFieldValue($this->referralSource, 'Continuum of Care');
+    $post->saveCustomFieldValue($this->caseworker, 'Alex Rivera');
+
+    ImportDataStorage::set($post, 'referral_source', null);
+
+    CustomFields::importer()->forModel($post)->saveValues();
+
+    $post->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($this->referralSource))->toBeEmpty()
+        ->and($post->getCustomFieldValue($this->caseworker))->toBe('Alex Rivera');
+});


### PR DESCRIPTION
Found while business-reviewing #192 end-to-end against a real consumer app.

## The bug

`ImporterBuilder::saveValues()` delegated to `saveCustomFields()`:

```php
$this->customFields()->each(function (CustomField $customField) use ($customFields, $tenant): void {
    $value = $customFields[$customField->code] ?? null;   // ← absent becomes null
    $this->saveCustomFieldValue($customField, $value, $tenant);
});
```

That semantic is correct for a **form** — it renders every field, so a field absent from the submitted state means the user cleared it. It is destructive for an **import**, where a CSV legitimately maps a subset of columns and absent means "not in this file".

Result: an update import that mapped one custom field silently wiped every other custom field on the record.

```
after create:                   referral_source => 'Continuum of Care'   caseworker => 'Alex Rivera'
after update mapping only one:  referral_source => 'Street Outreach'     caseworker => null   ← wiped
```

## Why it hasn't bitten yet

`saveValues()` returns early when `ImportDataStorage::pull()` is empty. Consumers that strip `custom_fields_*` keys from `$this->data` before Filament's `Importer::fillRecord()` runs never populate the storage at all, so `saveValues()` no-ops and nothing is written — or wiped. In the app I reviewed, that describes all 11 importers: custom field values were never persisted, which also hid this.

Fix that consumer-side ordering and the wipe becomes live immediately. So this is latent today and load-bearing the moment anyone gets the ordering right.

## Fix

`saveValues()` now writes only the codes the row actually carried:

```php
$this->getAllFields()
    ->filter(fn (CustomField $field): bool => array_key_exists($field->code, $customFieldsData))
    ->each(fn (CustomField $field) => $this->model->saveCustomFieldValue(
        $field, $customFieldsData[$field->code], $tenant,
    ));
```

Also fixes `HasCustomFields::saveCustomFieldValue()`, which was missing the `?Model $tenant = null` parameter its `UsesCustomFields` implementation has accepted since multi-tenancy landed. PHPStan caught it as soon as the interface was called with three arguments. Any implementer following the contract would silently drop tenant scoping.

## Verification

- New `tests/Feature/Imports/ImporterBuilderSaveValuesTest.php` — three cases: carried fields are saved, uncarried fields are untouched, empty payload is a no-op. Confirmed the "untouched" case **fails without the fix** (`null` instead of `'Alex Rivera'`), so it isn't vacuous.
- `pest --parallel` — 764 passed, 0 failed
- `phpstan analyse` — no errors
- `pint --dirty`, `rector --dry-run` — clean
- Verified end-to-end in a consumer app: with this plus the consumer's fill-ordering fix, a subset-column update import preserves the unmapped values.

## Relationship to #192

Independent, both in the import path, both should land in the same release. #192 stops optional custom fields from failing validation on a mapped-but-empty column; this stops a subset-column import from wiping data once values actually reach the save path.