### PR TITLE
perf: reuse eager-loaded relations in forModel via loadMissing

### DIFF
--- a/src/Filament/Integration/Builders/BaseBuilder.php
+++ b/src/Filament/Integration/Builders/BaseBuilder.php
@@ -52,7 +52,7 @@ abstract class BaseBuilder
         }
 
         if (! $this instanceof TableBuilder) {
-            $model->load('customFieldValues.customField.options');
+            $model->loadMissing('customFieldValues.customField.options');
         }
 
         $this->model = $model;

--- a/tests/Feature/Integration/Builders/ForModelLoadMissingTest.php
+++ b/tests/Feature/Integration/Builders/ForModelLoadMissingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $section = CustomFieldSection::factory()
+        ->forEntityType(Post::class)
+        ->create(['active' => true]);
+
+    $this->field = CustomField::factory()->create([
+        'custom_field_section_id' => $section->getKey(),
+        'entity_type' => Post::class,
+        'code' => 'category',
+        'name' => 'Category',
+        'type' => 'text',
+    ]);
+
+    $this->post = Post::factory()->create();
+    $this->post->saveCustomFieldValue($this->field, 'premium');
+});
+
+it('does not re-query custom field values when the record is already eager loaded', function (): void {
+    // The host application (e.g. a Filament resource's getEloquentQuery) eager-loads
+    // the values so the table can render without an N+1. forModel() must reuse that
+    // work rather than refetch it for the infolist/form.
+    $record = Post::query()
+        ->whereKey($this->post->getKey())
+        ->with('customFieldValues.customField.options')
+        ->firstOrFail();
+
+    $valuesTable = config('custom-fields.database.table_names.custom_field_values');
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    try {
+        CustomFields::infolist()->forModel($record)->values();
+
+        $valueQueries = array_filter(DB::getQueryLog(), static fn (array $entry): bool => str_contains($entry['query'], '"'.$valuesTable.'"')
+            || str_contains($entry['query'], '`'.$valuesTable.'`'));
+
+        expect($valueQueries)->toBeEmpty();
+    } finally {
+        DB::disableQueryLog();
+        DB::flushQueryLog();
+    }
+});
+
+it('still loads custom field values when the record is not eager loaded', function (): void {
+    $record = Post::query()->whereKey($this->post->getKey())->firstOrFail();
+
+    expect($record->relationLoaded('customFieldValues'))->toBeFalse();
+
+    CustomFields::infolist()->forModel($record)->values();
+
+    expect($record->relationLoaded('customFieldValues'))->toBeTrue();
+});


### PR DESCRIPTION
## What

`BaseBuilder::forModel()` unconditionally calls `$model->load('customFieldValues.customField.options')` on every Infolist/Form schema generation. When the host application already eager-loads those relations — e.g. a Filament resource's `getEloquentQuery()` loading custom field values so the **table** avoids an N+1 — `load()` refetches them anyway, so a view/edit page runs the three relation queries **twice**: once from the host's eager-load, once from `forModel()`.

This switches `load()` → `loadMissing()`, so `forModel()` reuses relations that are already loaded and only queries when they're absent.

## Why it's safe

- The un-eager path is unchanged: `loadMissing()` still loads the relations when they aren't present (covered by a test).
- It matches the package's own behaviour elsewhere — `BackendVisibilityService::extractFieldValues()` and `LookupPreloader` already guard on `relationLoaded()` rather than force-loading.
- The `TableBuilder` guard is untouched; only Infolist/Form/Exporter/Importer builders are affected, and Exporter/Importer call `forModel(new $model)` on a keyless instance where the load is inert.

## Caveat

`loadMissing()` no longer force-refetches. If code mutates a record's custom field values and re-renders the **same in-memory instance within one request**, it should `$record->unsetRelation('customFieldValues')` before re-rendering. Standard Filament view/edit flows re-resolve the record per request, so they're unaffected.

## Test

`tests/Feature/Integration/Builders/ForModelLoadMissingTest.php`:
- asserts `forModel()` issues **no** `custom_field_values` query when the record is already eager-loaded (fails on `load()`, passes on `loadMissing()`)
- asserts the relations **still load** when the record isn't eager-loaded (regression guard)

Local run of the full CI gate passes: Pint, PHPStan, Rector, and Pest (785 passed).
