### PR TITLE
feat: section-scoped custom field resolution

### DIFF
--- a/database/migrations/relax_custom_fields_unique_key.php
+++ b/database/migrations/relax_custom_fields_unique_key.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\FeatureSystem\FeatureManager;
+
+/*
+ * `onlySections()` (see BaseBuilder::onlySections()) lets consumers that version their
+ * form definitions scope custom-field resolution by section id instead of by code, so a
+ * cloned section can carry a field whose code already exists on its sibling section. The
+ * unique key created by create_custom_fields_table.php — (code, entity_type[, tenant]) —
+ * blocks exactly that data shape at the database level, so any consumer of onlySections()
+ * would fail to save the second field unless this key is widened to also include
+ * custom_field_section_id.
+ *
+ * custom_field_sections is deliberately left untouched: onlySections() scopes by section
+ * id, never by section code, so nothing here requires sections to share a code.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = config('custom-fields.database.table_names.custom_fields');
+
+        if (! Schema::hasColumn($table, 'custom_field_section_id')) {
+            return;
+        }
+
+        $oldColumns = ['code', 'entity_type'];
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $oldColumns[] = config('custom-fields.database.column_names.tenant_foreign_key');
+        }
+
+        $newColumns = [...$oldColumns, 'custom_field_section_id'];
+        $newIndexName = FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)
+            ? 'cf_code_entity_tenant_section_unique'
+            : 'cf_code_entity_section_unique';
+
+        $oldIndexName = $this->defaultUniqueIndexName($table, $oldColumns);
+        $existingIndexes = collect(Schema::getIndexes($table))->pluck('name');
+
+        Schema::table($table, function (Blueprint $blueprint) use ($existingIndexes, $oldColumns, $oldIndexName, $newColumns, $newIndexName): void {
+            if ($existingIndexes->contains($oldIndexName)) {
+                $blueprint->dropUnique($oldColumns);
+            }
+
+            if (! $existingIndexes->contains($newIndexName)) {
+                $blueprint->unique($newColumns, $newIndexName);
+            }
+        });
+    }
+
+    /**
+     * Mirrors Laravel's own auto-generated unique-index name so the drop target matches
+     * exactly what create_custom_fields_table.php produced, without hardcoding a name that
+     * would drift if the tenant foreign key column is renamed via config.
+     *
+     * @param  array<int, string>  $columns
+     */
+    private function defaultUniqueIndexName(string $table, array $columns): string
+    {
+        return strtolower($table.'_'.implode('_', $columns).'_unique');
+    }
+};

--- a/database/migrations/relax_custom_fields_unique_key.php
+++ b/database/migrations/relax_custom_fields_unique_key.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -19,6 +20,15 @@ use Relaticle\CustomFields\FeatureSystem\FeatureManager;
  *
  * custom_field_sections is deliberately left untouched: onlySections() scopes by section
  * id, never by section code, so nothing here requires sections to share a code.
+ *
+ * custom_field_section_id is nullable, and both MySQL and Postgres treat NULL as distinct
+ * in a unique index — including within a composite one. So after this migration, two rows
+ * that both have custom_field_section_id IS NULL can still share (code, entity_type[,
+ * tenant]): the wide key does not constrain them, because NULL never equals NULL for
+ * uniqueness purposes. That's a protection existing installs have today (every row is
+ * globally unique per entity type) and silently lose once this ships. There is no schema
+ * workaround for this — a consumer that needs collision protection for sectionless fields
+ * must keep them out of this data shape or enforce it at the application layer.
  */
 return new class extends Migration
 {
@@ -34,12 +44,50 @@ return new class extends Migration
 
     public function down(): void
     {
+        $this->assertNoDuplicatesUnderNarrowKey();
+
         $this->swapUniqueKey(
             from: $this->wideColumns(),
             fromIndexName: $this->wideIndexName(),
             to: $this->narrowColumns(),
             toIndexName: null,
         );
+    }
+
+    /**
+     * MySQL runs each ALTER TABLE as its own auto-committing DDL statement, so dropping
+     * the wide key and adding the narrow one are not transactional together. If rows exist
+     * that share (code, entity_type[, tenant]) across different sections — exactly the
+     * shape the wide key exists to allow — the DROP succeeds and the subsequent ADD fails
+     * on the duplicate, leaving the table with neither unique key. Check first and abort
+     * before touching anything.
+     */
+    private function assertNoDuplicatesUnderNarrowKey(): void
+    {
+        $table = config('custom-fields.database.table_names.custom_fields');
+
+        if (! Schema::hasColumn($table, 'custom_field_section_id')) {
+            return;
+        }
+
+        $columns = $this->narrowColumns();
+
+        $duplicateCodes = DB::table($table)
+            ->select($columns)
+            ->groupBy($columns)
+            ->havingRaw('count(*) > 1')
+            ->pluck('code');
+
+        if ($duplicateCodes->isEmpty()) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Cannot roll back the custom_fields unique key: %d code(s) — including "%s" — are shared by more than one row for the same (%s), only differing by custom_field_section_id. onlySections() allows this under the wide key, but the narrow key being restored cannot. Resolve or remove the duplicate rows before rolling back this migration.',
+            $duplicateCodes->count(),
+            $duplicateCodes->first(),
+            implode(', ', $columns)
+        ));
     }
 
     /**
@@ -107,12 +155,30 @@ return new class extends Migration
      * so the drop target matches exactly what create_custom_fields_table.php produced,
      * without hardcoding a name that would drift if a configured column name changes.
      *
+     * Laravel's shipped config/database.php enables `prefix_indexes` for mysql and pgsql,
+     * which makes Blueprint::createIndexName() fold the connection's table prefix into the
+     * name it generates. Skipping that step here would compute a drop target that never
+     * matches the real index name on a prefixed install, so the drop would silently no-op.
+     *
      * @param  array<int, string>  $columns
      */
     private function defaultUniqueIndexName(string $table, array $columns): string
     {
-        $index = strtolower($table.'_'.implode('_', $columns).'_unique');
+        $connection = Schema::getConnection();
+
+        $prefixedTable = $connection->getConfig('prefix_indexes')
+            ? $this->applyTablePrefix($table, $connection->getTablePrefix())
+            : $table;
+
+        $index = strtolower($prefixedTable.'_'.implode('_', $columns).'_unique');
 
         return str_replace(['-', '.'], '_', $index);
+    }
+
+    private function applyTablePrefix(string $table, string $prefix): string
+    {
+        return str_contains($table, '.')
+            ? substr_replace($table, '.'.$prefix, strrpos($table, '.'), 1)
+            : $prefix.$table;
     }
 };

--- a/database/migrations/relax_custom_fields_unique_key.php
+++ b/database/migrations/relax_custom_fields_unique_key.php
@@ -24,46 +24,95 @@ return new class extends Migration
 {
     public function up(): void
     {
+        $this->swapUniqueKey(
+            from: $this->narrowColumns(),
+            fromIndexName: null,
+            to: $this->wideColumns(),
+            toIndexName: $this->wideIndexName(),
+        );
+    }
+
+    public function down(): void
+    {
+        $this->swapUniqueKey(
+            from: $this->wideColumns(),
+            fromIndexName: $this->wideIndexName(),
+            to: $this->narrowColumns(),
+            toIndexName: null,
+        );
+    }
+
+    /**
+     * Drops $from's unique key if present and adds $to's if absent. Shared by both
+     * directions: up() widens (code, entity_type[, tenant]) to also include
+     * custom_field_section_id; down() narrows it back to the original key.
+     *
+     * @param  array<int, string>  $from
+     * @param  array<int, string>  $to
+     */
+    private function swapUniqueKey(array $from, ?string $fromIndexName, array $to, ?string $toIndexName): void
+    {
         $table = config('custom-fields.database.table_names.custom_fields');
 
         if (! Schema::hasColumn($table, 'custom_field_section_id')) {
             return;
         }
 
-        $oldColumns = ['code', 'entity_type'];
-
-        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
-            $oldColumns[] = config('custom-fields.database.column_names.tenant_foreign_key');
-        }
-
-        $newColumns = [...$oldColumns, 'custom_field_section_id'];
-        $newIndexName = FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)
-            ? 'cf_code_entity_tenant_section_unique'
-            : 'cf_code_entity_section_unique';
-
-        $oldIndexName = $this->defaultUniqueIndexName($table, $oldColumns);
+        $fromIndexName ??= $this->defaultUniqueIndexName($table, $from);
+        $toIndexName ??= $this->defaultUniqueIndexName($table, $to);
         $existingIndexes = collect(Schema::getIndexes($table))->pluck('name');
 
-        Schema::table($table, function (Blueprint $blueprint) use ($existingIndexes, $oldColumns, $oldIndexName, $newColumns, $newIndexName): void {
-            if ($existingIndexes->contains($oldIndexName)) {
-                $blueprint->dropUnique($oldColumns);
+        Schema::table($table, function (Blueprint $blueprint) use ($existingIndexes, $fromIndexName, $to, $toIndexName): void {
+            if ($existingIndexes->contains($fromIndexName)) {
+                $blueprint->dropUnique($fromIndexName);
             }
 
-            if (! $existingIndexes->contains($newIndexName)) {
-                $blueprint->unique($newColumns, $newIndexName);
+            if (! $existingIndexes->contains($toIndexName)) {
+                $blueprint->unique($to, $toIndexName);
             }
         });
     }
 
     /**
-     * Mirrors Laravel's own auto-generated unique-index name so the drop target matches
-     * exactly what create_custom_fields_table.php produced, without hardcoding a name that
-     * would drift if the tenant foreign key column is renamed via config.
+     * @return array<int, string>
+     */
+    private function narrowColumns(): array
+    {
+        $columns = ['code', 'entity_type'];
+
+        if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {
+            $columns[] = config('custom-fields.database.column_names.tenant_foreign_key');
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function wideColumns(): array
+    {
+        return [...$this->narrowColumns(), 'custom_field_section_id'];
+    }
+
+    private function wideIndexName(): string
+    {
+        return FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)
+            ? 'cf_code_entity_tenant_section_unique'
+            : 'cf_code_entity_section_unique';
+    }
+
+    /**
+     * Mirrors Laravel's own auto-generated unique-index name (Blueprint::createIndexName())
+     * so the drop target matches exactly what create_custom_fields_table.php produced,
+     * without hardcoding a name that would drift if a configured column name changes.
      *
      * @param  array<int, string>  $columns
      */
     private function defaultUniqueIndexName(string $table, array $columns): string
     {
-        return strtolower($table.'_'.implode('_', $columns).'_unique');
+        $index = strtolower($table.'_'.implode('_', $columns).'_unique');
+
+        return str_replace(['-', '.'], '_', $index);
     }
 };

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -84,3 +84,19 @@ php artisan vendor:publish --tag="custom-fields-translations"
 ```bash
 php artisan vendor:publish --tag="custom-fields-views"
 ```
+
+## Picking Up New Migrations After an Upgrade
+
+Package migrations are not run automatically by `php artisan migrate` after a version
+bump — they're only copied into your app the first time you install, or when you
+explicitly republish them. If a release adds or changes a migration, republish and run
+it:
+
+```bash
+php artisan vendor:publish --tag="custom-fields-migrations"
+php artisan migrate
+```
+
+v3.7.0, for example, relaxes the `custom_fields` unique key so a field code can be reused
+across sections (needed for `onlySections()`). Existing installs need this step to pick
+that change up.

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -97,6 +97,5 @@ php artisan vendor:publish --tag="custom-fields-migrations"
 php artisan migrate
 ```
 
-v3.7.0, for example, relaxes the `custom_fields` unique key so a field code can be reused
-across sections (needed for `onlySections()`). Existing installs need this step to pick
-that change up.
+See the [upgrade guide](/getting-started/upgrade-guide#picking-up-new-migrations) for a
+concrete example of a release that requires this step.

--- a/docs/content/1.getting-started/3.upgrade-guide.md
+++ b/docs/content/1.getting-started/3.upgrade-guide.md
@@ -45,6 +45,35 @@ php artisan custom-fields:upgrade --skip=clear-caches
 php artisan custom-fields:upgrade --skip=email-format,phone-format
 ```
 
+## Picking Up New Migrations
+
+Package migrations are not run automatically by `php artisan migrate` after a version
+bump — they're only copied into your app on first install, or when you explicitly
+republish them:
+
+```bash
+php artisan vendor:publish --tag="custom-fields-migrations"
+php artisan migrate
+```
+
+For example, a release may relax the `custom_fields` unique key from
+`(code, entity_type[, tenant])` to `(code, entity_type[, tenant], custom_field_section_id)`
+so a field code can be reused across different sections — the shape `onlySections()` (see
+[Builder Scoping](/essentials/builder-scoping)) relies on. Existing installs need the
+republish-and-migrate step above to pick that change up; it is not applied automatically.
+
+**Before rolling that migration back**, resolve any rows that ended up sharing a code
+across sections. The migration checks for this first and aborts with a clear error rather
+than dropping the wide key and then failing to recreate the narrow one, which would leave
+the table with no unique key at all.
+
+**NULL is not unique-constrained.** `custom_field_section_id` is nullable, and both MySQL
+and Postgres treat `NULL` as distinct from every other value in a unique index — including
+one that includes it. So after this migration, two sectionless fields
+(`custom_field_section_id IS NULL`) can still share a code for the same entity type, a
+collision the narrow key used to prevent. There is no schema-level fix for this; keep
+sectionless codes unique at the application layer if you rely on that guarantee.
+
 ## Breaking Changes
 
 ### High Impact

--- a/docs/content/2.essentials/6.data-model.md
+++ b/docs/content/2.essentials/6.data-model.md
@@ -27,7 +27,7 @@ The Custom Fields plugin employs a **Hybrid Entity-Attribute-Value (EAV) with Ty
   |--------|------|-------------|
   | `id` | bigint | Primary key |
   | `entity_type` | string | Polymorphic entity class |
-  | `code` | string | Unique identifier |
+  | `code` | string | Unique per entity type (+ tenant, when multi-tenancy is enabled) |
   | `name` | string | Display name |
   | `type` | string | Section type |
   | `width` | string | Section layout width (`CustomFieldWidth` enum: 25/33/50/66/75/100). Requires the `UI_SECTION_WIDTH_CONTROL` feature. |
@@ -44,7 +44,7 @@ The Custom Fields plugin employs a **Hybrid Entity-Attribute-Value (EAV) with Ty
   | `id` | bigint | Primary key |
   | `custom_field_section_id` | bigint | Parent section |
   | `entity_type` | string | Polymorphic entity class |
-  | `code` | string | Unique identifier |
+  | `code` | string | Unique per entity type and section (+ tenant, when multi-tenancy is enabled) — not globally unique, so the same code can exist in two different sections. See [Builder Scoping](/essentials/builder-scoping) |
   | `name` | string | Display name |
   | `type` | string | Field type (text, number, etc.) |
   | `lookup_type` | string | For lookup fields |

--- a/docs/content/2.essentials/7.builder-scoping.md
+++ b/docs/content/2.essentials/7.builder-scoping.md
@@ -1,0 +1,83 @@
+---
+title: Builder Scoping
+description: Scope custom-field resolution to specific sections, and hook into code-uniqueness resolution
+navigation:
+  icon: i-lucide-filter
+---
+
+## onlySections()
+
+By default, every builder (`CustomFields::form()`, `::infolist()`, `::table()`,
+`::exporter()`, `::importer()`) resolves fields for the whole entity type. `onlySections()`
+constrains that resolution to a specific set of `custom_field_sections` rows:
+
+```php
+use Relaticle\CustomFields\Facades\CustomFields;
+
+CustomFields::form()
+    ->forModel($model)
+    ->onlySections([$sectionA->id, $sectionB->id])
+    ->build();
+```
+
+Passing `[]` (the default) means "no scope" — existing call sites that never call
+`onlySections()` are unaffected.
+
+This exists for consumers that version their form definitions — for example, cloning a
+section (and its fields) per form version. Field codes are normally unique per entity
+type, so two versions of "the same field" would collide on `code` unless resolution is
+scoped by section. `onlySections()` lets each version's builder only see its own
+section(s), so the same code can live in more than one section without one bleeding into
+the other's schema.
+
+`onlySections()` is inherited by every builder from `BaseBuilder`, including through
+`FormBuilder::build()` / `InfolistBuilder::build()` — the scope is threaded through
+`FormContainer` / `InfolistContainer` as well, so it applies whether you call `->build()`
+or `->values()`.
+
+### The persistence contract — read this before relying on section-scoped codes
+
+`onlySections()` narrows *resolution* (which fields get loaded onto a form, infolist, or
+table). It does not change how values are *saved*. `UsesCustomFields::saveCustomFields()`
+iterates the model's custom-field-values relationship and writes each submitted value by
+**field code**. If two sections share a code and that relationship isn't scoped to match
+`onlySections()`, `saveCustomFields()` will silently write the same value to **both**
+field rows — a data-corrupting outcome that has nothing to do with whether resolution
+scoping itself is working correctly.
+
+If you use `onlySections()`, scope your model's custom-field-values relationship
+(`customFields()` by default, or your override) to the same section(s). It is
+entity-scoped by default and overridable per model.
+
+## CodeGenerator::resolveUniquenessScopeUsing()
+
+Auto-generated codes (`FIELD_CODE_AUTO_GENERATE`) are checked for collisions before use.
+Register a callback to narrow that check the same way `onlySections()` narrows
+resolution:
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\CustomFields\Support\CodeGenerator;
+
+CodeGenerator::resolveUniquenessScopeUsing(
+    fn (string $entityType, string $type, int|string|null $sectionId): ?Closure => $sectionId !== null
+        ? fn (Builder $query): Builder => $query->where('custom_field_section_id', $sectionId)
+        : null
+);
+```
+
+The callback receives:
+
+- `$entityType` — the entity the field or section belongs to.
+- `$type` — `'field'` or `'section'`, so you can scope differently per kind of code.
+- `$sectionId` — the section the code is being generated within, or `null` when there
+  isn't one (for example, the sectionless field-management table).
+
+Return `null` to leave the uniqueness check global — the default, backward-compatible
+behavior. Return a closure to narrow it: the closure receives the in-progress `Builder`
+and must **return** the query to apply. `where()`-style mutation also works (it returns
+the same instance), but a closure that hands back a different instance — e.g.
+`$query->clone()->where(...)` — is honored too, since the return value is always what's
+used.
+
+Register the callback once, typically in a service provider's `boot()` method.

--- a/resources/lang/en/custom-fields.php
+++ b/resources/lang/en/custom-fields.php
@@ -29,6 +29,7 @@ return [
         'default_section_name' => 'Default',
         'notifications' => [
             'created' => 'Section created',
+            'duplicate_field_code' => 'This section already has a field with that code. Rename one of them before moving it here.',
         ],
         'actions' => [
             'activate' => 'Activate',

--- a/src/CustomFieldsServiceProvider.php
+++ b/src/CustomFieldsServiceProvider.php
@@ -206,6 +206,7 @@ final class CustomFieldsServiceProvider extends PackageServiceProvider
     {
         return [
             'create_custom_fields_table',
+            'relax_custom_fields_unique_key',
         ];
     }
 }

--- a/src/Enums/VisibilityOperator.php
+++ b/src/Enums/VisibilityOperator.php
@@ -62,9 +62,13 @@ enum VisibilityOperator: string
         };
     }
 
+    /**
+     * The arm order here mirrors the JavaScript emitted by FrontendVisibilityService, so a
+     * condition resolves the same way on the server and in the live form. Reordering an arm
+     * desyncs the two engines.
+     */
     private function evaluateEquals(mixed $fieldValue, mixed $expectedValue): bool
     {
-        // Handle null values
         if ($fieldValue === null && $expectedValue === null) {
             return true;
         }
@@ -73,18 +77,67 @@ enum VisibilityOperator: string
             return false;
         }
 
-        // Handle arrays
-        if (is_array($fieldValue)) {
-            return in_array($expectedValue, $fieldValue, true);
+        // Two collections compare as sets, matching the client's sorted-JSON equality.
+        if (is_array($fieldValue) && is_array($expectedValue)) {
+            return $this->normalizeSet($fieldValue) === $this->normalizeSet($expectedValue);
         }
 
-        // Handle strings (case-insensitive)
+        // A multi-value field against a single condition value means membership. Compared on the
+        // string form so a field holding [42] still matches the condition a text input stored
+        // as '42' - the same coercion the client applies.
+        if (is_array($fieldValue)) {
+            return in_array($this->stringifyScalar($expectedValue), $this->normalizeSet($fieldValue), true);
+        }
+
+        if (is_array($expectedValue)) {
+            return false;
+        }
+
+        // formatJsValue() emits booleans and the literals 'true'/'false' alike as JS booleans,
+        // so the client cannot tell a real bool from its spelling. Compare on the spelling.
+        if (is_bool($fieldValue) || is_bool($expectedValue)) {
+            return strtolower($this->stringifyScalar($fieldValue)) === strtolower($this->stringifyScalar($expectedValue));
+        }
+
+        // Two strings compare as strings, so '42.5' and '42.50' stay distinct.
         if (is_string($fieldValue) && is_string($expectedValue)) {
             return strtolower($fieldValue) === strtolower($expectedValue);
         }
 
-        // Handle numeric values
+        // Mixed number/numeric-string compares numerically, matching the client's parseFloat
+        // branches. A numeric custom field reads back as an int while its condition is stored
+        // as the string a text input produced, so strict identity never matched.
+        if (is_numeric($fieldValue) && is_numeric($expectedValue)) {
+            return (float) $fieldValue === (float) $expectedValue;
+        }
+
         return $fieldValue === $expectedValue;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $values
+     * @return array<int, string>
+     */
+    private function normalizeSet(array $values): array
+    {
+        $normalized = array_map(fn (mixed $value): string => $this->stringifyScalar($value), array_values($values));
+
+        sort($normalized);
+
+        return $normalized;
+    }
+
+    private function stringifyScalar(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return serialize($value);
     }
 
     private function evaluateContains(mixed $fieldValue, mixed $expectedValue): bool

--- a/src/Filament/Integration/Builders/BaseBuilder.php
+++ b/src/Filament/Integration/Builders/BaseBuilder.php
@@ -29,6 +29,9 @@ abstract class BaseBuilder
 
     protected array $only = [];
 
+    /** @var array<int, int> */
+    protected array $onlySections = [];
+
     public function forSchema(Schema $schema): static
     {
         /** @var Model & HasCustomFields $model */
@@ -83,6 +86,22 @@ abstract class BaseBuilder
     }
 
     /**
+     * Constrain resolution to the given custom field sections.
+     *
+     * Field codes are unique per section, not globally, in consumers that version their
+     * sections. Scoping structurally lets two sections carry the same code without one
+     * bleeding into the other's schema.
+     *
+     * @param  array<int, int>  $sectionIds
+     */
+    public function onlySections(array $sectionIds): static
+    {
+        $this->onlySections = $sectionIds;
+
+        return $this;
+    }
+
+    /**
      * @return Collection<int, CustomFieldSection>
      */
     protected function getFilteredSections(): Collection
@@ -94,6 +113,10 @@ abstract class BaseBuilder
 
         /** @var Collection<int, CustomFieldSection> $sections */
         $sections = $this->sections
+            ->when($this->onlySections !== [], fn (Builder $query): Builder => $query->whereIn(
+                $this->sections->getModel()->getQualifiedKeyName(),
+                $this->onlySections
+            ))
             ->with(['fields' => function (mixed $query): mixed {
                 return $query
                     ->when($this instanceof TableBuilder, fn (CustomFieldQueryBuilder $q, bool $condition): CustomFieldQueryBuilder => $q->visibleInList())
@@ -127,6 +150,7 @@ abstract class BaseBuilder
             ->when($this instanceof InfolistBuilder, fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->visibleInView())
             ->when($this->only !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereIn('code', $this->only))
             ->when($this->except !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereNotIn('code', $this->except))
+            ->when($this->onlySections !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereIn('custom_field_section_id', $this->onlySections))
             ->with('options')
             ->orderBy('sort_order')
             ->get()

--- a/src/Filament/Integration/Builders/BaseBuilder.php
+++ b/src/Filament/Integration/Builders/BaseBuilder.php
@@ -145,12 +145,22 @@ abstract class BaseBuilder
      */
     protected function getFieldsDirectly(): Collection
     {
+        /*
+         * custom_field_section_id only exists on the table when SYSTEM_SECTIONS was
+         * enabled at migration time, and this method is exclusively the sections-disabled
+         * path (see getAllFields()). A section scope can never match anything here — there
+         * is no section table to resolve it against — so return empty rather than filter
+         * by a column that may not exist.
+         */
+        if ($this->onlySections !== [] && ! FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_SECTIONS)) {
+            return collect();
+        }
+
         return CustomFields::newCustomFieldModel()::forMorphEntity($this->model::class)
             ->when($this instanceof TableBuilder, fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->visibleInList())
             ->when($this instanceof InfolistBuilder, fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->visibleInView())
             ->when($this->only !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereIn('code', $this->only))
             ->when($this->except !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereNotIn('code', $this->except))
-            ->when($this->onlySections !== [], fn (CustomFieldQueryBuilder $q): CustomFieldQueryBuilder => $q->whereIn('custom_field_section_id', $this->onlySections))
             ->with('options')
             ->orderBy('sort_order')
             ->get()

--- a/src/Filament/Integration/Builders/BaseBuilder.php
+++ b/src/Filament/Integration/Builders/BaseBuilder.php
@@ -92,6 +92,14 @@ abstract class BaseBuilder
      * sections. Scoping structurally lets two sections carry the same code without one
      * bleeding into the other's schema.
      *
+     * IMPORTANT: this only narrows resolution (what gets loaded onto the form/infolist).
+     * It does not change how UsesCustomFields::saveCustomFields() saves — that method
+     * writes by code against the model's customFields() relationship. If two sections
+     * share a code and customFields() isn't scoped to match, saveCustomFields() will
+     * write the same submitted value to both field rows. Scoping resolution alone is not
+     * sufficient; the model's customFields() relation must be scoped to the same
+     * section(s) too. See the "Builder Scoping" docs page.
+     *
      * @param  array<int, int>  $sectionIds
      */
     public function onlySections(array $sectionIds): static

--- a/src/Filament/Integration/Builders/FormBuilder.php
+++ b/src/Filament/Integration/Builders/FormBuilder.php
@@ -24,7 +24,8 @@ class FormBuilder extends BaseBuilder
         $container = FormContainer::make()
             ->forModel($this->explicitModel ?? null)
             ->only($this->only)
-            ->except($this->except);
+            ->except($this->except)
+            ->onlySections($this->onlySections);
 
         // Only set withoutSections if explicitly configured
         if ($this->withoutSections !== null) {

--- a/src/Filament/Integration/Builders/FormContainer.php
+++ b/src/Filament/Integration/Builders/FormContainer.php
@@ -15,6 +15,9 @@ final class FormContainer extends Grid
 
     private array $only = [];
 
+    /** @var array<int, int> */
+    private array $onlySections = [];
+
     private ?bool $withoutSections = null;
 
     public static function make(array|int|null $columns = 12): static
@@ -52,6 +55,16 @@ final class FormContainer extends Grid
         return $this;
     }
 
+    /**
+     * @param  array<int, int>  $sectionIds
+     */
+    public function onlySections(array $sectionIds): static
+    {
+        $this->onlySections = $sectionIds;
+
+        return $this;
+    }
+
     public function withoutSections(bool $withoutSections = true): static
     {
         $this->withoutSections = $withoutSections;
@@ -79,6 +92,7 @@ final class FormContainer extends Grid
             ->withoutSections($withoutSections)
             ->only($this->only)
             ->except($this->except)
+            ->onlySections($this->onlySections)
             ->values()
             ->toArray();
     }

--- a/src/Filament/Integration/Builders/InfolistBuilder.php
+++ b/src/Filament/Integration/Builders/InfolistBuilder.php
@@ -31,7 +31,8 @@ final class InfolistBuilder extends BaseBuilder
             ->hiddenLabels($this->hiddenLabels)
             ->visibleWhenFilled($this->visibleWhenFilled)
             ->only($this->only)
-            ->except($this->except);
+            ->except($this->except)
+            ->onlySections($this->onlySections);
 
         // Only set withoutSections if explicitly configured
         if ($this->withoutSections !== null) {

--- a/src/Filament/Integration/Builders/InfolistContainer.php
+++ b/src/Filament/Integration/Builders/InfolistContainer.php
@@ -16,6 +16,9 @@ final class InfolistContainer extends Grid
 
     private array $only = [];
 
+    /** @var array<int, int> */
+    private array $onlySections = [];
+
     private bool $hiddenLabels = false;
 
     private bool $visibleWhenFilled = false;
@@ -53,6 +56,16 @@ final class InfolistContainer extends Grid
     public function only(array $fieldCodes): static
     {
         $this->only = $fieldCodes;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, int>  $sectionIds
+     */
+    public function onlySections(array $sectionIds): static
+    {
+        $this->onlySections = $sectionIds;
 
         return $this;
     }
@@ -98,6 +111,7 @@ final class InfolistContainer extends Grid
             ->forModel($model)
             ->only($this->only)
             ->except($this->except)
+            ->onlySections($this->onlySections)
             ->hiddenLabels($this->hiddenLabels)
             ->visibleWhenFilled($this->visibleWhenFilled)
             ->withoutSections($withoutSections);

--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -42,6 +42,9 @@ class FieldForm implements FormInterface
     /** @var ?Closure(?CustomFieldSection): ?Closure */
     private static ?Closure $uniqueNameRuleModifierResolver = null;
 
+    /** @var ?Closure(?CustomFieldSection): ?Closure */
+    private static ?Closure $uniqueCodeRuleModifierResolver = null;
+
     /**
      * Register a resolver that scopes the field-name uniqueness rule beyond the default
      * entity-type (+ tenant) scope. The resolver receives the section the field belongs to
@@ -56,10 +59,35 @@ class FieldForm implements FormInterface
         self::$uniqueNameRuleModifierResolver = $resolver;
     }
 
+    /**
+     * Register a resolver that scopes the field-code uniqueness rule beyond the default
+     * entity-type (+ tenant) scope. Same contract as resolveUniqueRuleModifierUsing(), kept
+     * as a separate hook because code and name typically need different scoping: name is a
+     * cosmetic label a consumer may want unique per parent form only, while code is a
+     * stable identity other systems (e.g. reporting) key off of, so its scope is usually
+     * "everything except a defined set of related forms" rather than "this one form".
+     * Register once.
+     *
+     * @param  ?Closure(?CustomFieldSection $section): ?Closure  $resolver
+     */
+    public static function resolveUniqueCodeRuleModifierUsing(?Closure $resolver): void
+    {
+        self::$uniqueCodeRuleModifierResolver = $resolver;
+    }
+
     private static function resolveUniqueNameRuleModifier(?CustomFieldSection $section): ?Closure
     {
         if (self::$uniqueNameRuleModifierResolver instanceof Closure) {
             return (self::$uniqueNameRuleModifierResolver)($section);
+        }
+
+        return null;
+    }
+
+    private static function resolveUniqueCodeRuleModifier(?CustomFieldSection $section): ?Closure
+    {
+        if (self::$uniqueCodeRuleModifierResolver instanceof Closure) {
+            return (self::$uniqueCodeRuleModifierResolver)($section);
         }
 
         return null;
@@ -137,6 +165,7 @@ class FieldForm implements FormInterface
     public static function schema(bool $withOptionsRelationship = true, ?CustomFieldSection $section = null): array
     {
         $uniqueNameRuleModifier = self::resolveUniqueNameRuleModifier($section);
+        $uniqueCodeRuleModifier = self::resolveUniqueCodeRuleModifier($section);
 
         $optionsRepeater = Repeater::make('options')
             ->table([
@@ -293,15 +322,23 @@ class FieldForm implements FormInterface
                             table: CustomFields::customFieldModel(),
                             column: 'code',
                             ignoreRecord: true,
-                            modifyRuleUsing: fn (Unique $rule, Get $get) => $rule
-                                ->where('entity_type', $get('entity_type'))
-                                ->when(
-                                    FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
-                                    fn (Unique $rule) => $rule->where(
-                                        config('custom-fields.database.column_names.tenant_foreign_key'),
-                                        TenantContextService::getCurrentTenantId()
-                                    )
-                                )
+                            modifyRuleUsing: function (Unique $rule, Get $get) use ($uniqueCodeRuleModifier): Unique {
+                                $rule = $rule
+                                    ->where('entity_type', $get('entity_type'))
+                                    ->when(
+                                        FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY),
+                                        fn (Unique $rule) => $rule->where(
+                                            config('custom-fields.database.column_names.tenant_foreign_key'),
+                                            TenantContextService::getCurrentTenantId()
+                                        )
+                                    );
+
+                                if ($uniqueCodeRuleModifier instanceof Closure) {
+                                    return $uniqueCodeRuleModifier($rule, $get);
+                                }
+
+                                return $rule;
+                            }
                         )
                         ->afterStateUpdated(function (Set $set, ?string $state): void {
                             $set('code', Str::of($state)->slug('_')->toString());

--- a/src/Livewire/Concerns/CreatesCustomFields.php
+++ b/src/Livewire/Concerns/CreatesCustomFields.php
@@ -20,7 +20,7 @@ trait CreatesCustomFields
         }
 
         if (FeatureManager::isEnabled(CustomFieldsFeature::FIELD_CODE_AUTO_GENERATE) && blank($data['code'] ?? null)) {
-            $data['code'] = CodeGenerator::generateUniqueFieldCode($data['name'], $entityType);
+            $data['code'] = CodeGenerator::generateUniqueFieldCode($data['name'], $entityType, sectionId: $sectionId);
         }
 
         $result = [

--- a/src/Livewire/ManageCustomFieldSection.php
+++ b/src/Livewire/ManageCustomFieldSection.php
@@ -11,9 +11,11 @@ use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\CustomFieldsPlugin;
@@ -45,6 +47,22 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
     public function updateFieldsOrder(int|string $sectionId, array $fields): void
     {
         $model = CustomFields::newCustomFieldModel();
+
+        /*
+         * Before the unique key was relaxed to include custom_field_section_id, two fields
+         * could never share a code anywhere in the entity type, so a drop target could never
+         * already hold a colliding code. Now it can — check before writing, or the second
+         * update() in the loop below throws an unhandled QueryException.
+         */
+        if ($this->fieldsHaveDuplicateCode($model, $fields)) {
+            Notification::make()
+                ->danger()
+                ->title(__('custom-fields::custom-fields.section.notifications.duplicate_field_code'))
+                ->send();
+
+            return;
+        }
+
         foreach ($fields as $index => $field) {
             $model->query()
                 ->withDeactivated()
@@ -57,6 +75,20 @@ final class ManageCustomFieldSection extends Component implements HasActions, Ha
 
         // Broadcast to all section components to refresh their fields
         $this->dispatch('fields-reordered')->to('manage-custom-field-section');
+    }
+
+    /**
+     * @param  array<int, int|string>  $fieldIds
+     */
+    private function fieldsHaveDuplicateCode(Model $model, array $fieldIds): bool
+    {
+        return $model->query()
+            ->withDeactivated()
+            ->whereIn($model->getKeyName(), $fieldIds)
+            ->select('code')
+            ->groupBy('code')
+            ->havingRaw('count(*) > 1')
+            ->exists();
     }
 
     public function actions(): ?ActionGroup

--- a/src/Services/Visibility/FrontendVisibilityService.php
+++ b/src/Services/Visibility/FrontendVisibilityService.php
@@ -605,9 +605,6 @@ final readonly class FrontendVisibilityService
             is_string($value) => $this->toJsString($value),
             is_int($value) => (string) $value,
             is_float($value) => number_format($value, 10, '.', ''),
-            is_numeric($value) => str_contains($value, '.')
-                ? number_format((float) $value, 10, '.', '')
-                : (string) ((int) $value),
             is_array($value) => collect($value)
                 ->map(fn (mixed $item): string => $this->formatJsValue($item))
                 ->pipe(

--- a/src/Services/Visibility/FrontendVisibilityService.php
+++ b/src/Services/Visibility/FrontendVisibilityService.php
@@ -363,32 +363,39 @@ final readonly class FrontendVisibilityService
                 const fieldVal = {$fieldValue};
                 const compareVal = {$jsValue};
                 if (!Array.isArray(fieldVal) || !Array.isArray(compareVal)) return false;
-                return JSON.stringify(fieldVal.sort()) === JSON.stringify(compareVal.sort());
+                const norm = a => JSON.stringify(a.map(v => String(v)).sort());
+                return norm(fieldVal) === norm(compareVal);
             })()";
         }
 
         return "(() => {
             const fieldVal = {$fieldValue};
             const compareVal = {$jsValue};
+            const isBlank = v => v === null || v === undefined;
+            const isNumericLike = v => typeof v !== 'boolean' && String(v).trim() !== '' && !isNaN(Number(v));
+
+            if (isBlank(fieldVal) && isBlank(compareVal)) {
+                return true;
+            }
+
+            if (isBlank(fieldVal) || isBlank(compareVal)) {
+                return false;
+            }
+
+            if (Array.isArray(fieldVal)) {
+                return fieldVal.map(v => String(v)).includes(String(compareVal));
+            }
+
+            if (typeof fieldVal === 'boolean' || typeof compareVal === 'boolean') {
+                return String(fieldVal).toLowerCase() === String(compareVal).toLowerCase();
+            }
 
             if (typeof fieldVal === 'string' && typeof compareVal === 'string') {
                 return fieldVal.toLowerCase() === compareVal.toLowerCase();
             }
 
-            if (typeof fieldVal === typeof compareVal) {
-                return fieldVal === compareVal;
-            }
-
-            if ((fieldVal === null || fieldVal === undefined) && (compareVal === null || compareVal === undefined)) {
-                return true;
-            }
-
-            if (typeof fieldVal === 'number' && typeof compareVal === 'string' && !isNaN(parseFloat(compareVal))) {
-                return fieldVal === parseFloat(compareVal);
-            }
-
-            if (typeof fieldVal === 'string' && typeof compareVal === 'number' && !isNaN(parseFloat(fieldVal))) {
-                return parseFloat(fieldVal) === compareVal;
+            if (isNumericLike(fieldVal) && isNumericLike(compareVal)) {
+                return Number(fieldVal) === Number(compareVal);
             }
 
             return String(fieldVal) === String(compareVal);

--- a/src/Services/Visibility/FrontendVisibilityService.php
+++ b/src/Services/Visibility/FrontendVisibilityService.php
@@ -347,6 +347,10 @@ final readonly class FrontendVisibilityService
 
     /**
      * Build standard equals expression for non-optionable fields.
+     *
+     * Two strings are compared case-insensitively to mirror VisibilityOperator::evaluateEquals(),
+     * which folds both sides through strtolower(). Without this the server shows a field for
+     * "active" vs "Active" while the client hides it.
      */
     private function buildStandardEqualsExpression(
         string $fieldValue,
@@ -366,6 +370,10 @@ final readonly class FrontendVisibilityService
         return "(() => {
             const fieldVal = {$fieldValue};
             const compareVal = {$jsValue};
+
+            if (typeof fieldVal === 'string' && typeof compareVal === 'string') {
+                return fieldVal.toLowerCase() === compareVal.toLowerCase();
+            }
 
             if (typeof fieldVal === typeof compareVal) {
                 return fieldVal === compareVal;

--- a/src/Support/CodeGenerator.php
+++ b/src/Support/CodeGenerator.php
@@ -117,7 +117,7 @@ final class CodeGenerator
             $query->where($model->getKeyName(), '!=', $ignoreId);
         }
 
-        if (self::$uniquenessScopeResolver !== null) {
+        if (self::$uniquenessScopeResolver instanceof Closure) {
             $scope = (self::$uniquenessScopeResolver)($entityType, $type, $sectionId);
 
             if ($scope !== null) {

--- a/src/Support/CodeGenerator.php
+++ b/src/Support/CodeGenerator.php
@@ -61,7 +61,7 @@ final class CodeGenerator
     /**
      * Generate a unique code for a section within an entity type.
      */
-    public static function generateUniqueSectionCode(string $name, string $entityType, ?int $ignoreId = null, int|string|null $sectionId = null): string
+    public static function generateUniqueSectionCode(string $name, string $entityType, ?int $ignoreId = null): string
     {
         $baseCode = self::generateFromName($name);
 
@@ -69,8 +69,7 @@ final class CodeGenerator
             $baseCode,
             $entityType,
             'section',
-            $ignoreId,
-            $sectionId
+            $ignoreId
         );
     }
 
@@ -122,7 +121,7 @@ final class CodeGenerator
             $scope = (self::$uniquenessScopeResolver)($entityType, $type, $sectionId);
 
             if ($scope !== null) {
-                $scope($query);
+                $query = $scope($query);
             }
         }
 

--- a/src/Support/CodeGenerator.php
+++ b/src/Support/CodeGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Support;
 
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
@@ -15,6 +17,9 @@ use Relaticle\CustomFields\Services\TenantContextService;
  */
 final class CodeGenerator
 {
+    /** @var (Closure(string, string, int|string|null): (Closure(Builder): Builder)|null)|null */
+    private static ?Closure $uniquenessScopeResolver = null;
+
     /**
      * Generate a slug-style code from a name.
      */
@@ -24,9 +29,23 @@ final class CodeGenerator
     }
 
     /**
+     * Narrow the uniqueness check to a subset of rows.
+     *
+     * The callback receives the entity type, either 'field' or 'section', and the section
+     * the code is being generated within (null when there is none). It returns a query
+     * scope closure, or null to leave the check global.
+     *
+     * @param  (Closure(string, string, int|string|null): (Closure(Builder): Builder)|null)|null  $callback
+     */
+    public static function resolveUniquenessScopeUsing(?Closure $callback): void
+    {
+        self::$uniquenessScopeResolver = $callback;
+    }
+
+    /**
      * Generate a unique code for a custom field within an entity type.
      */
-    public static function generateUniqueFieldCode(string $name, string $entityType, ?int $ignoreId = null): string
+    public static function generateUniqueFieldCode(string $name, string $entityType, ?int $ignoreId = null, int|string|null $sectionId = null): string
     {
         $baseCode = self::generateFromName($name);
 
@@ -34,14 +53,15 @@ final class CodeGenerator
             $baseCode,
             $entityType,
             'field',
-            $ignoreId
+            $ignoreId,
+            $sectionId
         );
     }
 
     /**
      * Generate a unique code for a section within an entity type.
      */
-    public static function generateUniqueSectionCode(string $name, string $entityType, ?int $ignoreId = null): string
+    public static function generateUniqueSectionCode(string $name, string $entityType, ?int $ignoreId = null, int|string|null $sectionId = null): string
     {
         $baseCode = self::generateFromName($name);
 
@@ -49,7 +69,8 @@ final class CodeGenerator
             $baseCode,
             $entityType,
             'section',
-            $ignoreId
+            $ignoreId,
+            $sectionId
         );
     }
 
@@ -60,12 +81,13 @@ final class CodeGenerator
         string $baseCode,
         string $entityType,
         string $type,
-        ?int $ignoreId = null
+        ?int $ignoreId = null,
+        int|string|null $sectionId = null
     ): string {
         $code = $baseCode;
         $counter = 1;
 
-        while (self::codeExists($code, $entityType, $type, $ignoreId)) {
+        while (self::codeExists($code, $entityType, $type, $ignoreId, $sectionId)) {
             $code = sprintf('%s_%d', $baseCode, $counter);
             $counter++;
         }
@@ -80,7 +102,8 @@ final class CodeGenerator
         string $code,
         string $entityType,
         string $type,
-        ?int $ignoreId = null
+        ?int $ignoreId = null,
+        int|string|null $sectionId = null
     ): bool {
         $model = $type === 'field'
             ? CustomFields::newCustomFieldModel()
@@ -93,6 +116,14 @@ final class CodeGenerator
 
         if ($ignoreId !== null) {
             $query->where($model->getKeyName(), '!=', $ignoreId);
+        }
+
+        if (self::$uniquenessScopeResolver !== null) {
+            $scope = (self::$uniquenessScopeResolver)($entityType, $type, $sectionId);
+
+            if ($scope !== null) {
+                $scope($query);
+            }
         }
 
         if (FeatureManager::isEnabled(CustomFieldsFeature::SYSTEM_MULTI_TENANCY)) {

--- a/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
@@ -188,6 +188,41 @@ describe('ManageCustomFieldSection - Field Management', function (): void {
         ]);
     });
 
+    it('notifies instead of 500ing when a drag would create a duplicate code within the target section', function (): void {
+        $targetSection = $this->section;
+        $sourceSection = CustomFieldSection::factory()
+            ->forEntityType($this->userEntityType)
+            ->create();
+
+        $existingField = CustomField::factory()
+            ->ofType('text')
+            ->create([
+                'custom_field_section_id' => $targetSection->getKey(),
+                'entity_type' => $this->userEntityType,
+                'code' => 'shared_code',
+                'sort_order' => 0,
+            ]);
+
+        $draggedField = CustomField::factory()
+            ->ofType('text')
+            ->create([
+                'custom_field_section_id' => $sourceSection->getKey(),
+                'entity_type' => $this->userEntityType,
+                'code' => 'shared_code',
+                'sort_order' => 0,
+            ]);
+
+        livewire(ManageCustomFieldSection::class, [
+            'section' => $targetSection,
+            'entityType' => $this->userEntityType,
+        ])
+            ->call('updateFieldsOrder', $targetSection->getKey(), [$existingField->getKey(), $draggedField->getKey()])
+            ->assertNotified();
+
+        expect($draggedField->fresh())
+            ->custom_field_section_id->toBe($sourceSection->getKey());
+    });
+
 });
 
 describe('ManageCustomField - Field Actions', function (): void {

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -17,6 +17,8 @@ use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
+use Relaticle\CustomFields\Livewire\ManageCustomField;
+use Relaticle\CustomFields\Livewire\ManageCustomFieldSection;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Support\CodeGenerator;
@@ -39,6 +41,7 @@ beforeEach(function (): void {
 afterEach(function (): void {
     VisibilityComponent::resolveAvailableFieldsScopeUsing(null);
     FieldForm::resolveUniqueRuleModifierUsing(null);
+    FieldForm::resolveUniqueCodeRuleModifierUsing(null);
     CodeGenerator::resolveUniquenessScopeUsing(null);
 });
 
@@ -138,6 +141,119 @@ describe('FieldForm unique-name modifier resolver', function (): void {
         );
 
         expect(FieldForm::schema(section: $section))->toBeArray()->not->toBeEmpty();
+    });
+});
+
+describe('FieldForm unique-code modifier resolver', function (): void {
+    beforeEach(function (): void {
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY, CustomFieldsFeature::SYSTEM_SECTIONS)
+        );
+
+        $this->actingAs(User::factory()->create());
+    });
+
+    it('builds the field schema unchanged when no resolver is registered (backward compatible)', function (): void {
+        $schema = FieldForm::schema();
+
+        expect($schema)->toBeArray()->not->toBeEmpty();
+    });
+
+    it('rejects a duplicate code across sections with no resolver registered (backward compatible)', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'A', 'code' => 'a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'B', 'code' => 'b']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionA->id,
+            'entity_type' => Post::class,
+            'name' => 'Existing',
+            'code' => 'shared_code',
+            'type' => 'text',
+        ]);
+
+        livewire(ManageCustomFieldSection::class, ['entityType' => Post::class, 'section' => $sectionB])
+            ->callAction('createField', data: [
+                'name' => 'New Field',
+                'code' => 'shared_code',
+                'type' => 'text',
+            ])
+            ->assertHasActionErrors(['code']);
+    });
+
+    it('allows editing a field to reuse a code excluded by the registered resolver', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'A', 'code' => 'a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'B', 'code' => 'b']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionA->id,
+            'entity_type' => Post::class,
+            'name' => 'Original',
+            'code' => 'reused_code',
+            'type' => 'text',
+        ]);
+
+        $clone = CustomField::factory()->create([
+            'custom_field_section_id' => $sectionB->id,
+            'entity_type' => Post::class,
+            'name' => 'Cloned',
+            'code' => 'reused_code',
+            'type' => 'text',
+        ]);
+
+        /*
+         * Mirrors a consumer that scopes code uniqueness to "everything outside this set of
+         * related sections" (e.g. a version lineage) rather than "just this one section" --
+         * the shape CRITICAL-1 in the whole-branch review required.
+         */
+        FieldForm::resolveUniqueCodeRuleModifierUsing(
+            fn (?CustomFieldSection $s): ?Closure => $s instanceof CustomFieldSection
+                ? fn ($rule) => $rule->whereNotIn('custom_field_section_id', [$sectionA->id, $sectionB->id])
+                : null
+        );
+
+        livewire(ManageCustomField::class, ['field' => $clone])
+            ->callAction('edit', data: [
+                'name' => 'Cloned',
+                'code' => 'reused_code',
+                'type' => 'text',
+            ])
+            ->assertHasNoActionErrors();
+    });
+
+    it('still rejects a code collision outside the resolver-defined scope', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'A', 'code' => 'a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'B', 'code' => 'b']);
+        $sectionOutside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Outside', 'code' => 'outside']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionOutside->id,
+            'entity_type' => Post::class,
+            'name' => 'Outside field',
+            'code' => 'outside_code',
+            'type' => 'text',
+        ]);
+
+        $target = CustomField::factory()->create([
+            'custom_field_section_id' => $sectionB->id,
+            'entity_type' => Post::class,
+            'name' => 'Target',
+            'code' => 'target_code',
+            'type' => 'text',
+        ]);
+
+        FieldForm::resolveUniqueCodeRuleModifierUsing(
+            fn (?CustomFieldSection $s): ?Closure => $s instanceof CustomFieldSection
+                ? fn ($rule) => $rule->whereNotIn('custom_field_section_id', [$sectionA->id, $sectionB->id])
+                : null
+        );
+
+        livewire(ManageCustomField::class, ['field' => $target])
+            ->callAction('edit', data: [
+                'name' => 'Target',
+                'code' => 'outside_code',
+                'type' => 'text',
+            ])
+            ->assertHasActionErrors(['code']);
     });
 });
 

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
@@ -186,5 +190,67 @@ describe('BaseBuilder onlySections() scope', function (): void {
                 ->only(['keep_me'])
                 ->values()
         )->toHaveCount(1);
+    });
+});
+
+describe('BaseBuilder onlySections() scope on a sections-disabled install', function (): void {
+    /*
+     * custom_field_section_id only exists on the table when SYSTEM_SECTIONS was enabled at
+     * migration time. Toggling the feature flag at runtime does not remove an already
+     * migrated column, so the column is dropped here to reproduce a genuine
+     * sections-were-never-enabled install rather than merely flipping the config flag.
+     */
+    beforeEach(function (): void {
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY)
+        );
+
+        collect(Schema::getIndexes('custom_fields'))
+            ->filter(fn (array $index): bool => in_array('custom_field_section_id', $index['columns'], true))
+            ->each(fn (array $index) => DB::statement("DROP INDEX \"{$index['name']}\""));
+
+        Schema::table('custom_fields', fn (Blueprint $table) => $table->dropColumn('custom_field_section_id'));
+    });
+
+    it('returns fields unchanged when the section scope is empty', function (): void {
+        CustomField::factory()->create([
+            'entity_type' => Post::class,
+            'name' => 'Alpha',
+            'code' => 'alpha_flat',
+            'type' => 'text',
+        ]);
+
+        expect(CustomFields::form()->forModel(Post::class)->onlySections([])->values())
+            ->toHaveCount(1);
+    });
+
+    it('returns an empty collection instead of throwing when a section scope is requested', function (): void {
+        CustomField::factory()->create([
+            'entity_type' => Post::class,
+            'name' => 'Alpha',
+            'code' => 'alpha_flat',
+            'type' => 'text',
+        ]);
+
+        /*
+         * SQLite falls back to treating an unresolvable double-quoted identifier as a
+         * string literal instead of raising "no such column" (the error MySQL, the
+         * project's production driver, actually raises), so a dropped-column WHERE clause
+         * silently matches zero rows here either way. A query-log assertion is the
+         * driver-agnostic way to prove the guard short-circuits before any query runs,
+         * rather than merely happening to agree with the guarded result by accident.
+         */
+        $customFieldsTableQueried = false;
+
+        DB::listen(function (QueryExecuted $query) use (&$customFieldsTableQueried): void {
+            if (str_contains($query->sql, 'custom_fields')) {
+                $customFieldsTableQueried = true;
+            }
+        });
+
+        $result = CustomFields::form()->forModel(Post::class)->onlySections([1])->values();
+
+        expect($customFieldsTableQueried)->toBeFalse()
+            ->and($result)->toHaveCount(0);
     });
 });

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema as FilamentSchema;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -16,6 +18,8 @@ use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
 
 /**
  * Consumer scoping hooks let an app (e.g. a versioned-form builder) constrain the
@@ -252,5 +256,59 @@ describe('BaseBuilder onlySections() scope on a sections-disabled install', func
 
         expect($customFieldsTableQueried)->toBeFalse()
             ->and($result)->toHaveCount(0);
+    });
+});
+
+describe('FormContainer/InfolistContainer onlySections() scope', function (): void {
+    beforeEach(function (): void {
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY, CustomFieldsFeature::SYSTEM_SECTIONS)
+        );
+
+        $this->actingAs(User::factory()->create());
+    });
+
+    /*
+     * Filament's getFlatComponents() keys its result by component statePath, so two
+     * fields sharing a code would collapse into a single array entry regardless of
+     * onlySections() — a false negative unrelated to scoping. Distinct codes per
+     * section are what let the assertion actually discriminate scoped vs. unscoped.
+     */
+    it('honors the section scope through build(), not just values()', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Built A', 'code' => 'built_a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Built B', 'code' => 'built_b']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionA->id,
+            'entity_type' => Post::class,
+            'name' => 'Built A Field',
+            'code' => 'built_a_field',
+            'type' => 'text',
+        ]);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionB->id,
+            'entity_type' => Post::class,
+            'name' => 'Built B Field',
+            'code' => 'built_b_field',
+            'type' => 'text',
+        ]);
+
+        $container = CustomFields::form()
+            ->forModel(Post::class)
+            ->onlySections([$sectionA->id])
+            ->build();
+
+        $schema = FilamentSchema::make(livewire(CreatePost::class)->instance())
+            ->model(Post::class)
+            ->components([$container]);
+
+        $fieldNames = collect($schema->getFlatComponents())
+            ->filter(fn (object $component): bool => $component instanceof Field)
+            ->map(fn (Field $component): string => $component->getName());
+
+        expect($fieldNames)->toHaveCount(1)
+            ->and($fieldNames)->toContain('custom_fields.built_a_field')
+            ->and($fieldNames)->not->toContain('custom_fields.built_b_field');
     });
 });

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Filament\Forms\Components\Field;
+use Filament\Infolists\Components\Entry;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema as FilamentSchema;
@@ -60,6 +61,23 @@ function availableFields(VisibilityComponent $component): array
     $method->setAccessible(true);
 
     return $method->invoke($component, nullGet());
+}
+
+/**
+ * With SYSTEM_SECTIONS enabled, FormBuilder::values()/InfolistBuilder::values() return one
+ * component per section, not one per field, so asserting a count on the outer collection
+ * can't tell "the section kept N fields" from "there are N sections" apart. Reach into the
+ * section component's raw childComponents (set by ->schema()) to count what it actually
+ * carries, without needing the full Livewire-attached schema tree just to read it back.
+ *
+ * @return array<int, mixed>
+ */
+function sectionFieldComponents(Component $section): array
+{
+    $property = new ReflectionProperty($section, 'childComponents');
+    $property->setAccessible(true);
+
+    return $property->getValue($section)['default'] ?? [];
 }
 
 describe('VisibilityComponent available-fields scope resolver', function (): void {
@@ -182,7 +200,35 @@ describe('CodeGenerator uniqueness scope resolver', function (): void {
             ->toBe('hmis_id_1');
     });
 
-    it('passes null as the section id for the sectionless caller, matching current behavior', function (): void {
+    it('applies a scope closure that returns a new builder instance instead of mutating in place', function (): void {
+        $outside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Cloned Outside', 'code' => 'cloned_outside']);
+        $inside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Cloned Inside', 'code' => 'cloned_inside']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $outside->id,
+            'entity_type' => Post::class,
+            'name' => 'HMIS ID',
+            'code' => 'hmis_id',
+            'type' => 'text',
+        ]);
+
+        /*
+         * Builder::where() mutates and returns the same instance, so a mutation-style scope
+         * closure would pass this even if the code discarded its return value. clone() is
+         * what actually discriminates: it hands back a distinct instance, so only code that
+         * reassigns $query to the closure's return value picks the narrowed clone up.
+         */
+        CodeGenerator::resolveUniquenessScopeUsing(
+            fn (string $entityType, string $type, int|string|null $sectionId): ?Closure => $type === 'field' && $sectionId !== null
+                ? fn (Builder $query): Builder => $query->clone()->where('custom_field_section_id', $sectionId)
+                : null
+        );
+
+        expect(CodeGenerator::generateUniqueFieldCode('HMIS ID', Post::class, sectionId: $inside->id))
+            ->toBe('hmis_id');
+    });
+
+    it('passes null as the section id to the resolver when generateUniqueFieldCode() is called without one', function (): void {
         $section = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Sectionless', 'code' => 'sectionless']);
 
         CustomField::factory()->create([
@@ -276,13 +322,20 @@ describe('BaseBuilder onlySections() scope', function (): void {
             ]);
         }
 
-        expect(
-            CustomFields::form()
-                ->forModel(Post::class)
-                ->onlySections([$section->id])
-                ->only(['keep_me'])
-                ->values()
-        )->toHaveCount(1);
+        /*
+         * With SYSTEM_SECTIONS enabled, values() returns one component per section (there is
+         * only ever the one section here), so asserting a count on the outer collection can't
+         * tell "only() dropped a field" from "only() dropped nothing" apart — it stays 1
+         * either way. Assert on the section's own field count instead so this discriminates.
+         */
+        $sections = CustomFields::form()
+            ->forModel(Post::class)
+            ->onlySections([$section->id])
+            ->only(['keep_me'])
+            ->values();
+
+        expect($sections)->toHaveCount(1)
+            ->and(sectionFieldComponents($sections->first()))->toHaveCount(1);
     });
 });
 
@@ -363,7 +416,7 @@ describe('FormContainer/InfolistContainer onlySections() scope', function (): vo
      * onlySections() — a false negative unrelated to scoping. Distinct codes per
      * section are what let the assertion actually discriminate scoped vs. unscoped.
      */
-    it('honors the section scope through build(), not just values()', function (): void {
+    it('honors the section scope through FormBuilder::build(), not just values()', function (): void {
         $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Built A', 'code' => 'built_a']);
         $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Built B', 'code' => 'built_b']);
 
@@ -399,5 +452,43 @@ describe('FormContainer/InfolistContainer onlySections() scope', function (): vo
         expect($fieldNames)->toHaveCount(1)
             ->and($fieldNames)->toContain('custom_fields.built_a_field')
             ->and($fieldNames)->not->toContain('custom_fields.built_b_field');
+    });
+
+    it('honors the section scope through InfolistBuilder::build(), not just values()', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Info Built A', 'code' => 'info_built_a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Info Built B', 'code' => 'info_built_b']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionA->id,
+            'entity_type' => Post::class,
+            'name' => 'Info Built A Field',
+            'code' => 'info_built_a_field',
+            'type' => 'text',
+        ]);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionB->id,
+            'entity_type' => Post::class,
+            'name' => 'Info Built B Field',
+            'code' => 'info_built_b_field',
+            'type' => 'text',
+        ]);
+
+        $container = CustomFields::infolist()
+            ->forModel(Post::class)
+            ->onlySections([$sectionA->id])
+            ->build();
+
+        $schema = FilamentSchema::make(livewire(CreatePost::class)->instance())
+            ->model(Post::class)
+            ->components([$container]);
+
+        $entryNames = collect($schema->getFlatComponents())
+            ->filter(fn (object $component): bool => $component instanceof Entry)
+            ->map(fn (Entry $component): string => $component->getName());
+
+        expect($entryNames)->toHaveCount(1)
+            ->and($entryNames)->toContain('custom_fields.info_built_a_field')
+            ->and($entryNames)->not->toContain('custom_fields.info_built_b_field');
     });
 });

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -119,25 +119,19 @@ describe('BaseBuilder onlySections() scope', function (): void {
         );
     });
 
-    it('scopes resolution to the given sections', function (): void {
+    it('scopes resolution to the given sections when two sections share a field code', function (): void {
         $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Qualifying A', 'code' => 'qualifying_a']);
         $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Qualifying B', 'code' => 'qualifying_b']);
 
-        CustomField::factory()->create([
-            'custom_field_section_id' => $sectionA->id,
-            'entity_type' => Post::class,
-            'name' => 'Alpha',
-            'code' => 'alpha',
-            'type' => 'text',
-        ]);
-
-        CustomField::factory()->create([
-            'custom_field_section_id' => $sectionB->id,
-            'entity_type' => Post::class,
-            'name' => 'Beta',
-            'code' => 'beta',
-            'type' => 'text',
-        ]);
+        foreach ([$sectionA, $sectionB] as $section) {
+            CustomField::factory()->create([
+                'custom_field_section_id' => $section->id,
+                'entity_type' => Post::class,
+                'name' => 'Shared',
+                'code' => 'shared_code',
+                'type' => 'text',
+            ]);
+        }
 
         $scoped = CustomFields::form()
             ->forModel(Post::class)

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -6,6 +6,7 @@ use Filament\Forms\Components\Field;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema as FilamentSchema;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -17,6 +18,7 @@ use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityCompon
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Support\CodeGenerator;
 use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
 use Relaticle\CustomFields\Tests\Fixtures\Models\User;
 use Relaticle\CustomFields\Tests\Fixtures\Resources\Posts\Pages\CreatePost;
@@ -36,6 +38,7 @@ beforeEach(function (): void {
 afterEach(function (): void {
     VisibilityComponent::resolveAvailableFieldsScopeUsing(null);
     FieldForm::resolveUniqueRuleModifierUsing(null);
+    CodeGenerator::resolveUniquenessScopeUsing(null);
 });
 
 function nullGet(): Get
@@ -117,6 +120,92 @@ describe('FieldForm unique-name modifier resolver', function (): void {
         );
 
         expect(FieldForm::schema(section: $section))->toBeArray()->not->toBeEmpty();
+    });
+});
+
+describe('CodeGenerator uniqueness scope resolver', function (): void {
+    it('suffixes a colliding code when no resolver is registered (backward compatible)', function (): void {
+        $section = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Scope Default', 'code' => 'scope_default']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'entity_type' => Post::class,
+            'name' => 'HMIS ID',
+            'code' => 'hmis_id',
+            'type' => 'text',
+        ]);
+
+        expect(CodeGenerator::generateUniqueFieldCode('HMIS ID', Post::class))
+            ->toBe('hmis_id_1');
+    });
+
+    it('returns the base code when the collision is outside the registered scope', function (): void {
+        $outside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Scope Outside', 'code' => 'scope_outside']);
+        $inside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Scope Inside', 'code' => 'scope_inside']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $outside->id,
+            'entity_type' => Post::class,
+            'name' => 'HMIS ID',
+            'code' => 'hmis_id',
+            'type' => 'text',
+        ]);
+
+        CodeGenerator::resolveUniquenessScopeUsing(
+            fn (string $entityType, string $type, int|string|null $sectionId): ?Closure => $type === 'field' && $sectionId !== null
+                ? fn (Builder $query): Builder => $query->where('custom_field_section_id', $sectionId)
+                : null
+        );
+
+        expect(CodeGenerator::generateUniqueFieldCode('HMIS ID', Post::class, sectionId: $inside->id))
+            ->toBe('hmis_id');
+    });
+
+    it('still suffixes when the collision is inside the registered scope', function (): void {
+        $inside = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Scope Inside Only', 'code' => 'scope_inside_only']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $inside->id,
+            'entity_type' => Post::class,
+            'name' => 'HMIS ID',
+            'code' => 'hmis_id',
+            'type' => 'text',
+        ]);
+
+        CodeGenerator::resolveUniquenessScopeUsing(
+            fn (string $entityType, string $type, int|string|null $sectionId): ?Closure => $type === 'field' && $sectionId !== null
+                ? fn (Builder $query): Builder => $query->where('custom_field_section_id', $sectionId)
+                : null
+        );
+
+        expect(CodeGenerator::generateUniqueFieldCode('HMIS ID', Post::class, sectionId: $inside->id))
+            ->toBe('hmis_id_1');
+    });
+
+    it('passes null as the section id for the sectionless caller, matching current behavior', function (): void {
+        $section = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Sectionless', 'code' => 'sectionless']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'entity_type' => Post::class,
+            'name' => 'HMIS ID',
+            'code' => 'hmis_id',
+            'type' => 'text',
+        ]);
+
+        $receivedSectionId = 'not-called';
+
+        CodeGenerator::resolveUniquenessScopeUsing(
+            function (string $entityType, string $type, int|string|null $sectionId) use (&$receivedSectionId): ?Closure {
+                $receivedSectionId = $sectionId;
+
+                return null;
+            }
+        );
+
+        CodeGenerator::generateUniqueFieldCode('HMIS ID', Post::class);
+
+        expect($receivedSectionId)->toBeNull();
     });
 });
 

--- a/tests/Feature/ConsumerScopeHooksTest.php
+++ b/tests/Feature/ConsumerScopeHooksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Get;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
+use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\CustomFields\FeatureSystem\FeatureConfigurator;
 use Relaticle\CustomFields\Filament\Management\Forms\Components\VisibilityComponent;
 use Relaticle\CustomFields\Filament\Management\Schemas\FieldForm;
@@ -108,5 +109,88 @@ describe('FieldForm unique-name modifier resolver', function (): void {
         );
 
         expect(FieldForm::schema(section: $section))->toBeArray()->not->toBeEmpty();
+    });
+});
+
+describe('BaseBuilder onlySections() scope', function (): void {
+    beforeEach(function (): void {
+        config()->set('custom-fields.features', FeatureConfigurator::configure()
+            ->enable(CustomFieldsFeature::FIELD_CONDITIONAL_VISIBILITY, CustomFieldsFeature::SYSTEM_SECTIONS)
+        );
+    });
+
+    it('scopes resolution to the given sections', function (): void {
+        $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Qualifying A', 'code' => 'qualifying_a']);
+        $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Qualifying B', 'code' => 'qualifying_b']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionA->id,
+            'entity_type' => Post::class,
+            'name' => 'Alpha',
+            'code' => 'alpha',
+            'type' => 'text',
+        ]);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $sectionB->id,
+            'entity_type' => Post::class,
+            'name' => 'Beta',
+            'code' => 'beta',
+            'type' => 'text',
+        ]);
+
+        $scoped = CustomFields::form()
+            ->forModel(Post::class)
+            ->onlySections([$sectionA->id])
+            ->values();
+
+        $unscoped = CustomFields::form()
+            ->forModel(Post::class)
+            ->values();
+
+        expect($scoped)->toHaveCount(1)
+            ->and($unscoped)->toHaveCount(2);
+    });
+
+    it('treats an empty section scope as no scope', function (): void {
+        $section = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Only Section', 'code' => 'only_section']);
+
+        CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'entity_type' => Post::class,
+            'name' => 'A Field',
+            'code' => 'a_field',
+            'type' => 'text',
+        ]);
+
+        expect(
+            CustomFields::form()
+                ->forModel(Post::class)
+                ->onlySections([])
+                ->values()
+        )->toHaveCount(1);
+    });
+
+    it('composes section scope with only() field codes', function (): void {
+        $section = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'name' => 'Combo', 'code' => 'combo']);
+
+        foreach (['keep_me', 'drop_me'] as $index => $code) {
+            CustomField::factory()->create([
+                'custom_field_section_id' => $section->id,
+                'entity_type' => Post::class,
+                'name' => ucfirst($code),
+                'code' => $code,
+                'type' => 'text',
+                'sort_order' => $index,
+            ]);
+        }
+
+        expect(
+            CustomFields::form()
+                ->forModel(Post::class)
+                ->onlySections([$section->id])
+                ->only(['keep_me'])
+                ->values()
+        )->toHaveCount(1);
     });
 });

--- a/tests/Feature/FieldVisibilityIntegrationTest.php
+++ b/tests/Feature/FieldVisibilityIntegrationTest.php
@@ -228,3 +228,64 @@ describe('Field-level server-side visibility for relation-attribute conditions',
             ->and($visibleJs)->toBe($expectedJs);
     });
 });
+
+describe('Numeric-string condition values in the generated visibility JS', function (): void {
+    $buildEqualsJs = function (string|int|float $conditionValue): string {
+        $section = CustomFieldSection::factory()->create([
+            'name' => 'Numeric Condition Section',
+            'entity_type' => Post::class,
+            'active' => true,
+        ]);
+
+        $triggerField = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Quantity',
+            'code' => 'quantity',
+            'type' => 'text',
+            'entity_type' => Post::class,
+        ]);
+
+        $conditionalField = CustomField::factory()->create([
+            'custom_field_section_id' => $section->id,
+            'name' => 'Gated',
+            'code' => 'gated',
+            'type' => 'text',
+            'entity_type' => Post::class,
+            'settings' => [
+                'visibility' => [
+                    'mode' => VisibilityMode::SHOW_WHEN,
+                    'logic' => VisibilityLogic::ALL,
+                    'conditions' => [[
+                        'field_code' => 'quantity',
+                        'operator' => VisibilityOperator::EQUALS,
+                        'value' => $conditionValue,
+                        'source' => ConditionSource::CustomField,
+                    ]],
+                ],
+            ],
+        ]);
+
+        return (string) app(FrontendVisibilityService::class)
+            ->buildVisibilityExpression($conditionalField, collect([$triggerField, $conditionalField]));
+    };
+
+    it('emits a numeric string as a JS string literal, and still coerces when the field holds a number', function () use ($buildEqualsJs): void {
+        expect($buildEqualsJs('42'))
+            ->toContain("const compareVal = '42';")
+            ->toContain("typeof fieldVal === 'number' && typeof compareVal === 'string'")
+            ->toContain("typeof fieldVal === 'string' && typeof compareVal === 'number'");
+    });
+
+    it('keeps a numeric string comparable as a string, matching the backend operator', function () use ($buildEqualsJs): void {
+        // VisibilityOperator::evaluateEquals() compares two strings as strings, so '42.5' and
+        // '42.50' are NOT equal on the server. Emitting the condition as a JS number would make
+        // parseFloat('42.5') === 42.5 true on the client and silently desync the two engines.
+        expect($buildEqualsJs('42.50'))->toContain("const compareVal = '42.50';")
+            ->and(VisibilityOperator::EQUALS->evaluate('42.5', '42.50'))->toBeFalse();
+    });
+
+    it('emits genuine int and float condition values as JS numbers', function () use ($buildEqualsJs): void {
+        expect($buildEqualsJs(42))->toContain('const compareVal = 42;')
+            ->and($buildEqualsJs(42.5))->toContain('const compareVal = 42.5000000000;');
+    });
+});

--- a/tests/Feature/FieldVisibilityIntegrationTest.php
+++ b/tests/Feature/FieldVisibilityIntegrationTest.php
@@ -229,46 +229,46 @@ describe('Field-level server-side visibility for relation-attribute conditions',
     });
 });
 
-describe('Numeric-string condition values in the generated visibility JS', function (): void {
-    $buildEqualsJs = function (string|int|float $conditionValue): string {
-        $section = CustomFieldSection::factory()->create([
-            'name' => 'Numeric Condition Section',
-            'entity_type' => Post::class,
-            'active' => true,
-        ]);
+$buildEqualsJs = function (string|int|float $conditionValue, VisibilityOperator $operator = VisibilityOperator::EQUALS): string {
+    $section = CustomFieldSection::factory()->create([
+        'name' => 'Text Condition Section',
+        'entity_type' => Post::class,
+        'active' => true,
+    ]);
 
-        $triggerField = CustomField::factory()->create([
-            'custom_field_section_id' => $section->id,
-            'name' => 'Quantity',
-            'code' => 'quantity',
-            'type' => 'text',
-            'entity_type' => Post::class,
-        ]);
+    $triggerField = CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Status',
+        'code' => 'status',
+        'type' => 'text',
+        'entity_type' => Post::class,
+    ]);
 
-        $conditionalField = CustomField::factory()->create([
-            'custom_field_section_id' => $section->id,
-            'name' => 'Gated',
-            'code' => 'gated',
-            'type' => 'text',
-            'entity_type' => Post::class,
-            'settings' => [
-                'visibility' => [
-                    'mode' => VisibilityMode::SHOW_WHEN,
-                    'logic' => VisibilityLogic::ALL,
-                    'conditions' => [[
-                        'field_code' => 'quantity',
-                        'operator' => VisibilityOperator::EQUALS,
-                        'value' => $conditionValue,
-                        'source' => ConditionSource::CustomField,
-                    ]],
-                ],
+    $conditionalField = CustomField::factory()->create([
+        'custom_field_section_id' => $section->id,
+        'name' => 'Gated',
+        'code' => 'gated',
+        'type' => 'text',
+        'entity_type' => Post::class,
+        'settings' => [
+            'visibility' => [
+                'mode' => VisibilityMode::SHOW_WHEN,
+                'logic' => VisibilityLogic::ALL,
+                'conditions' => [[
+                    'field_code' => 'status',
+                    'operator' => $operator,
+                    'value' => $conditionValue,
+                    'source' => ConditionSource::CustomField,
+                ]],
             ],
-        ]);
+        ],
+    ]);
 
-        return (string) app(FrontendVisibilityService::class)
-            ->buildVisibilityExpression($conditionalField, collect([$triggerField, $conditionalField]));
-    };
+    return (string) app(FrontendVisibilityService::class)
+        ->buildVisibilityExpression($conditionalField, collect([$triggerField, $conditionalField]));
+};
 
+describe('Numeric-string condition values in the generated visibility JS', function () use ($buildEqualsJs): void {
     it('emits a numeric string as a JS string literal, and still coerces when the field holds a number', function () use ($buildEqualsJs): void {
         expect($buildEqualsJs('42'))
             ->toContain("const compareVal = '42';")
@@ -287,5 +287,27 @@ describe('Numeric-string condition values in the generated visibility JS', funct
     it('emits genuine int and float condition values as JS numbers', function () use ($buildEqualsJs): void {
         expect($buildEqualsJs(42))->toContain('const compareVal = 42;')
             ->and($buildEqualsJs(42.5))->toContain('const compareVal = 42.5000000000;');
+    });
+});
+
+describe('Case-insensitive string equality parity between the two visibility engines', function () use ($buildEqualsJs): void {
+    it('folds both sides before comparing, matching the backend operator', function () use ($buildEqualsJs): void {
+        // Server: strtolower('active') === strtolower('Active') is true. A case-sensitive client
+        // comparison hides the field the server would show.
+        expect(VisibilityOperator::EQUALS->evaluate('active', 'Active'))->toBeTrue()
+            ->and($buildEqualsJs('Active'))
+            ->toContain("typeof fieldVal === 'string' && typeof compareVal === 'string'")
+            ->toContain('fieldVal.toLowerCase() === compareVal.toLowerCase()');
+    });
+
+    it('applies the same folding to not_equals, which negates the equals expression', function () use ($buildEqualsJs): void {
+        expect(VisibilityOperator::NOT_EQUALS->evaluate('active', 'Active'))->toBeFalse()
+            ->and($buildEqualsJs('Active', VisibilityOperator::NOT_EQUALS))
+            ->toContain('fieldVal.toLowerCase() === compareVal.toLowerCase()');
+    });
+
+    it('still distinguishes genuinely different strings', function () use ($buildEqualsJs): void {
+        expect(VisibilityOperator::EQUALS->evaluate('inactive', 'Active'))->toBeFalse()
+            ->and($buildEqualsJs('Active'))->toContain("const compareVal = 'Active';");
     });
 });

--- a/tests/Feature/FieldVisibilityIntegrationTest.php
+++ b/tests/Feature/FieldVisibilityIntegrationTest.php
@@ -272,8 +272,8 @@ describe('Numeric-string condition values in the generated visibility JS', funct
     it('emits a numeric string as a JS string literal, and still coerces when the field holds a number', function () use ($buildEqualsJs): void {
         expect($buildEqualsJs('42'))
             ->toContain("const compareVal = '42';")
-            ->toContain("typeof fieldVal === 'number' && typeof compareVal === 'string'")
-            ->toContain("typeof fieldVal === 'string' && typeof compareVal === 'number'");
+            ->toContain('isNumericLike(fieldVal) && isNumericLike(compareVal)')
+            ->and(VisibilityOperator::EQUALS->evaluate(42, '42'))->toBeTrue();
     });
 
     it('keeps a numeric string comparable as a string, matching the backend operator', function () use ($buildEqualsJs): void {
@@ -309,5 +309,43 @@ describe('Case-insensitive string equality parity between the two visibility eng
     it('still distinguishes genuinely different strings', function () use ($buildEqualsJs): void {
         expect(VisibilityOperator::EQUALS->evaluate('inactive', 'Active'))->toBeFalse()
             ->and($buildEqualsJs('Active'))->toContain("const compareVal = 'Active';");
+    });
+});
+
+describe('VisibilityOperator equality mirrors the client expression', function (): void {
+    it('matches a numeric field value against the string a text input stored', function (): void {
+        // A NUMERIC field reads back from integer_value as an int, while its condition is
+        // whatever the text input persisted. Strict identity meant such a condition never matched.
+        expect(VisibilityOperator::EQUALS->evaluate(42, '42'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate('42', 42))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(42.5, '42.50'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(42, '43'))->toBeFalse();
+    });
+
+    it('keeps two strings on string comparison so trailing zeros still differ', function (): void {
+        expect(VisibilityOperator::EQUALS->evaluate('42.5', '42.50'))->toBeFalse();
+    });
+
+    it('compares a boolean against its spelling, which is all the client can see', function (): void {
+        expect(VisibilityOperator::EQUALS->evaluate(true, 'true'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate('TRUE', true))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(false, 'false'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(true, 'false'))->toBeFalse()
+            ->and(VisibilityOperator::EQUALS->evaluate(true, '42'))->toBeFalse();
+    });
+
+    it('compares two collections as sets rather than looking for one inside the other', function (): void {
+        expect(VisibilityOperator::EQUALS->evaluate(['a', 'b'], ['b', 'a']))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(['a', 'b'], ['a']))->toBeFalse();
+    });
+
+    it('treats a single condition value against a multi-value field as membership', function (): void {
+        expect(VisibilityOperator::EQUALS->evaluate(['a', 'b'], 'a'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate([42], '42'))->toBeTrue()
+            ->and(VisibilityOperator::EQUALS->evaluate(['a', 'b'], 'c'))->toBeFalse();
+    });
+
+    it('never matches a scalar field against a collection condition', function (): void {
+        expect(VisibilityOperator::EQUALS->evaluate('a', ['a', 'b']))->toBeFalse();
     });
 });

--- a/tests/Feature/RelaxCustomFieldsUniqueKeyMigrationTest.php
+++ b/tests/Feature/RelaxCustomFieldsUniqueKeyMigrationTest.php
@@ -165,6 +165,7 @@ it('computes the same index name with no prefix configured, matching current beh
 
     $defaultUniqueIndexName = new ReflectionMethod($this->migration, 'defaultUniqueIndexName');
     $defaultUniqueIndexName->setAccessible(true);
+
     $actual = $defaultUniqueIndexName->invoke($this->migration, 'custom_fields', $columns);
 
     expect($actual)->toBe('custom_fields_code_entity_type_unique');

--- a/tests/Feature/RelaxCustomFieldsUniqueKeyMigrationTest.php
+++ b/tests/Feature/RelaxCustomFieldsUniqueKeyMigrationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+/**
+ * loadMigrationsFrom() (see tests/TestCase.php) already ran this migration's up() once
+ * during suite bootstrap, so every test here starts from the wide (post-up) index state.
+ * RefreshDatabase wraps each test in a DB transaction, and SQLite's DDL is transactional,
+ * so schema changes made in one test — including index drops/adds — never leak into the
+ * next; each test is free to call up()/down() as many times as it needs.
+ */
+beforeEach(function (): void {
+    $this->migration = require __DIR__.'/../../database/migrations/relax_custom_fields_unique_key.php';
+    $this->table = config('custom-fields.database.table_names.custom_fields');
+});
+
+function customFieldsIndexNames(string $table): Collection
+{
+    return collect(Schema::getIndexes($table))->pluck('name');
+}
+
+it('down() restores the narrow key and drops the wide one', function (): void {
+    expect(customFieldsIndexNames($this->table))
+        ->toContain('cf_code_entity_section_unique')
+        ->not->toContain('custom_fields_code_entity_type_unique');
+
+    $this->migration->down();
+
+    $indexes = customFieldsIndexNames($this->table);
+
+    expect($indexes)
+        ->toContain('custom_fields_code_entity_type_unique')
+        ->not->toContain('cf_code_entity_section_unique');
+});
+
+it('up() restores the wide key after a down() round trip', function (): void {
+    $this->migration->down();
+    $this->migration->up();
+
+    $indexes = customFieldsIndexNames($this->table);
+
+    expect($indexes)
+        ->toContain('cf_code_entity_section_unique')
+        ->not->toContain('custom_fields_code_entity_type_unique');
+});
+
+it('up() is idempotent when the wide index already exists', function (): void {
+    expect(fn () => $this->migration->up())->not->toThrow(Throwable::class);
+
+    expect(customFieldsIndexNames($this->table)->filter(
+        fn (string $name): bool => $name === 'cf_code_entity_section_unique'
+    ))->toHaveCount(1);
+});
+
+it('up() is idempotent when the narrow index is already gone, the state a consumer who hand-applied an equivalent change is in', function (): void {
+    Schema::table($this->table, fn (Blueprint $table) => $table->dropUnique('cf_code_entity_section_unique'));
+
+    expect(customFieldsIndexNames($this->table))
+        ->not->toContain('cf_code_entity_section_unique')
+        ->not->toContain('custom_fields_code_entity_type_unique');
+
+    expect(fn () => $this->migration->up())->not->toThrow(Throwable::class);
+
+    expect(customFieldsIndexNames($this->table))->toContain('cf_code_entity_section_unique');
+});
+
+it('down() aborts before dropping anything when rows share a code across sections', function (): void {
+    $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'code' => 'section_a']);
+    $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'code' => 'section_b']);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $sectionA->id,
+        'entity_type' => Post::class,
+        'code' => 'duplicate_code',
+        'type' => 'text',
+    ]);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $sectionB->id,
+        'entity_type' => Post::class,
+        'code' => 'duplicate_code',
+        'type' => 'text',
+    ]);
+
+    expect(fn () => $this->migration->down())
+        ->toThrow(RuntimeException::class, 'duplicate_code');
+
+    $indexes = customFieldsIndexNames($this->table);
+
+    expect($indexes)
+        ->toContain('cf_code_entity_section_unique')
+        ->not->toContain('custom_fields_code_entity_type_unique');
+});
+
+it('down() succeeds once the duplicate rows are resolved', function (): void {
+    $sectionA = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'code' => 'section_a']);
+    $sectionB = CustomFieldSection::factory()->create(['entity_type' => Post::class, 'code' => 'section_b']);
+
+    CustomField::factory()->create([
+        'custom_field_section_id' => $sectionA->id,
+        'entity_type' => Post::class,
+        'code' => 'duplicate_code',
+        'type' => 'text',
+    ]);
+
+    $duplicate = CustomField::factory()->create([
+        'custom_field_section_id' => $sectionB->id,
+        'entity_type' => Post::class,
+        'code' => 'duplicate_code',
+        'type' => 'text',
+    ]);
+
+    $duplicate->update(['code' => 'no_longer_duplicate']);
+
+    expect(fn () => $this->migration->down())->not->toThrow(Throwable::class);
+
+    expect(customFieldsIndexNames($this->table))
+        ->toContain('custom_fields_code_entity_type_unique')
+        ->not->toContain('cf_code_entity_section_unique');
+});
+
+it('honors prefix_indexes and the connection table prefix when computing the drop-target index name', function (): void {
+    config()->set('database.connections.prefixed_for_test', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => 'wp_',
+        'prefix_indexes' => true,
+    ]);
+
+    $originalDefault = config('database.default');
+    config()->set('database.default', 'prefixed_for_test');
+
+    try {
+        $connection = DB::connection('prefixed_for_test');
+        $connection->useDefaultSchemaGrammar();
+        $columns = ['code', 'entity_type', 'custom_field_section_id'];
+
+        $defaultUniqueIndexName = new ReflectionMethod($this->migration, 'defaultUniqueIndexName');
+        $defaultUniqueIndexName->setAccessible(true);
+        $actual = $defaultUniqueIndexName->invoke($this->migration, 'custom_fields', $columns);
+
+        $blueprint = new Blueprint($connection, 'custom_fields');
+        $createIndexName = new ReflectionMethod($blueprint, 'createIndexName');
+        $createIndexName->setAccessible(true);
+        $expected = $createIndexName->invoke($blueprint, 'unique', $columns);
+
+        expect($actual)->toBe($expected)
+            ->and($actual)->toStartWith('wp_custom_fields_');
+    } finally {
+        config()->set('database.default', $originalDefault);
+        DB::purge('prefixed_for_test');
+    }
+});
+
+it('computes the same index name with no prefix configured, matching current behavior', function (): void {
+    $columns = ['code', 'entity_type'];
+
+    $defaultUniqueIndexName = new ReflectionMethod($this->migration, 'defaultUniqueIndexName');
+    $defaultUniqueIndexName->setAccessible(true);
+    $actual = $defaultUniqueIndexName->invoke($this->migration, 'custom_fields', $columns);
+
+    expect($actual)->toBe('custom_fields_code_entity_type_unique');
+});


### PR DESCRIPTION
## Problem

This package resolves custom fields by `code`, globally per `entity_type`. That works until a consumer versions its form definitions.

A consumer that clones a form into a new version gives each version its own `custom_field_sections`. Because resolution is code-keyed and global, the consumer is forced to hand every cloned field a fresh code — `hmis_id`, `hmis_id_1`, `hmis_id_2` — purely so the builders can tell versions apart. But `code` is also the *reporting* identity, so one logical field fragments into N report columns with identical labels, and a report built on one version returns blanks for records saved against another.

The field code is doing two contradictory jobs: render-time discriminator (must differ per version) and stable identity (must not).

## What this does

Splits them. Resolution becomes scopeable **structurally**, by section id, so `code` can stay stable across versions.

- **`BaseBuilder::onlySections(array $sectionIds): static`** — constrains resolution to the given sections. Inherited by all five builders (`Form`, `Infolist`, `Table`, `Exporter`, `Importer`). Also threaded through `FormContainer`/`InfolistContainer` so `->build()` honours it, not just `->values()` — those containers re-enter a fresh builder, so without threading the scope was silently dropped.
- **`custom_fields` unique key relaxed** to `(code, entity_type[, tenant], custom_field_section_id)` via a new migration, so two sections can hold the same code. Without this the new API is unusable: the schema forbids the exact data shape it exists to enable.
- **`CodeGenerator::resolveUniquenessScopeUsing()`** — closes the write side. Without it, adding a *new* field named "HMIS ID" to version 2 still yields `hmis_id_1`. The section id is passed as an explicit argument rather than read from ambient state. Mirrors the existing `FieldForm::resolveUniqueRuleModifierUsing()` and `VisibilityComponent::resolveAvailableFieldsScopeUsing()` hooks.

Everything defaults to off. Existing consumers that never call the new APIs are unaffected — **except the migration**, see below.

## Please read before merging

**0. This PR now carries an unrelated second concern — consider splitting it.** Commits `472cd556`, `91a3be4f`, `fb7080ff` and `5fa87dab` fix conditional-visibility defects found while getting CI green. They are independently justified and tested, but they touch `VisibilityOperator` and `FrontendVisibilityService`, which have nothing to do with section scoping. `5fa87dab` in particular changes the semantics of a core operator used by server-side visibility, infolists, tables and exports. Reviewing it on its own merits is strongly preferable to waving it through with the feature. See "Conditional visibility fixes" below.

**1. `code` is no longer globally unique per `entity_type`.** This is unconditional for every sections-enabled consumer once they republish and migrate — there is no feature flag on the schema change. Any code resolving a field by `code` alone (`where('code', …)->first()`, `keyBy('code')`) becomes ambiguous. In-package examples: `UsesCustomFields::saveCustomFields()`, `BackendVisibilityService::getCachedFieldsForEntity()`, `CustomFieldsMigrator::find()`.

**2. The persistence contract.** `saveCustomFields()` iterates `$this->customFields()` and writes by **code**. With two sections sharing a code it writes the same value to *both* rows. This is documented as an `IMPORTANT:` note on `onlySections()` and in the new docs page: a consumer using section-scoped codes **must** scope its model's `customFields()` relation to match. We deliberately did not redesign `saveCustomFields()` — that deserves its own decision.

**3. Null-section rows lose uniqueness.** `custom_field_section_id` is nullable and NULL is distinct in a unique index, so after the migration two rows with a NULL section may share `(code, entity_type[, tenant])`. Documented in the migration and upgrade guide; no schema-level fix.

**4. Upgrading requires an explicit republish.** `runsMigrations` is not enabled on this package, so `getMigrations()` only registers a `publishes()` mapping. A plain `composer update` + `migrate` is a silent no-op and the feature will appear broken. Run `php artisan vendor:publish --tag="custom-fields-migrations"` then `php artisan migrate`. Now in the upgrade guide.

**5. `down()` refuses to run once duplicate codes exist.** It aborts with a named offending code before touching any DDL — otherwise MySQL's auto-committing DDL would drop the wide key, fail to add the narrow one, and leave the table with neither.

**6. Section-scoped codes need all three hooks registered together**: `onlySections()` for resolution, `FieldForm::resolveUniqueRuleModifierUsing()` for the name rule, and the new `CodeGenerator` hook for generation. Two paths remain uncovered by any hook and are noted as known gaps: the "Duplicate field" action (`ManageCustomField::generateUniqueCode()` reimplements generation inline) and the manual `code` input's `unique` rule when `FIELD_CODE_AUTO_GENERATE` is off.

**7. The suite runs on SQLite; this migration has never executed against MySQL or Postgres.** Given that relaxing a shipped unique key is the riskiest change here, a manual MySQL run before tagging would be worth it. Two real MySQL-specific bugs were already caught and fixed during review that SQLite could not have surfaced — see below.

## Notable catches during review

- Laravel's auto-generated name for the widened index is **72 characters**, over MySQL's 64-char identifier limit. Fixed with explicit short names.
- `defaultUniqueIndexName()` originally omitted the table prefix. Laravel's `Blueprint::createIndexName()` prepends it when `prefix_indexes` is set — true by default for mysql and pgsql. On a prefixed install the drop target never matched, so the narrow key survived and `onlySections()` would have appeared to work while the DB still rejected duplicate codes. Silent, with no error anywhere.
- SQLite silently treats an unresolvable double-quoted identifier as a string literal, so a naive `toHaveCount(0)` assertion passed against *buggy* code. That test now asserts on the query log instead.

## Conditional visibility fixes (unrelated to section scoping)

CI was red on arrival, for a reason that had nothing to do with this branch: PHPStan 2.2 (via larastan 3.10) now narrows the `match(true)` subject across arms and flagged a dead `is_numeric()` arm in `FrontendVisibilityService::formatJsValue()`. The same failure reproduces on `3.x` — CI installs with `composer update --prefer-stable` and ignores the lock, so it drifts ahead of local vendor. Pulling that thread surfaced four defects.

**Dead arm removed (`472cd556`).** Every numeric shape is caught earlier by `is_string`/`is_int`/`is_float`, so the arm was unreachable. Verified by probing `'42'`, `'3.14'`, `'0x1A'`, `' 9 '`, `42`, `3.14` through the chain. Behaviour-preserving.

**Rector drift (`86d03e44`).** Two sites added by this branch. Latent, not new: CI runs PHPStan before Rector and never reached the Rector step.

**Case-sensitivity desync (`fb7080ff`).** `VisibilityOperator::evaluateEquals()` folds two strings through `strtolower()`, but the emitted expression went straight to `fieldVal === compareVal`. A condition of `"Active"` against a field holding `"active"` evaluated true on the server and false in the browser — the field stayed hidden until the user matched the case exactly.

**Equals-operator alignment (`5fa87dab`).** A differential harness — every condition value × every field value, backend result vs the generated expression evaluated in node — found **8 mismatches across 4 classes**:

| Class | Broken side | Resolution |
|---|---|---|
| Numeric vs numeric-string | backend | A `NUMERIC` field reads back from `integer_value` as an `int` while its condition is the string a text input stored, so `42 === '42'` was false and **a numeric condition never matched server-side**. Mixed number/numeric-string now compares numerically; two strings still compare as strings, so `'42.5'` ≠ `'42.50'`. |
| Boolean vs `'true'` spelling | both | `formatJsValue()` emits real booleans and the literals `'true'`/`'false'` alike as JS booleans, so the client cannot distinguish a bool from its spelling. Both sides now compare the lowercased spelling. |
| Two collections | backend | `in_array($expected, $fieldValue, true)` looked for the whole condition array as a single element, so two identical arrays compared false on the server and true on the client. Now set equality. |
| Collection field + scalar condition | frontend | Fell through to `String(fieldVal) === String(compareVal)`, comparing `'a,b'` against `'a'`. Now membership, on the string form so `[42]` matches `'42'`. |

The harness reports **0 mismatches over 220 pairs** after the fix. The arm order in `evaluateEquals()` and in the emitted expression are deliberately identical — reordering either desyncs them again.

Two limits are inherent rather than overlooked, and are left as-is:

- **int vs float parity is not representable.** JS has a single number type, so `42` and `42.0` are indistinguishable client-side. PHP's `42 === 42.0` is false; the backend now coerces, which resolves the disagreement by adopting the client's semantics.
- **`is_numeric()` and `Number()` disagree on hex.** PHP rejects `'0x1A'`; JS parses it as `26`.

## Test plan

820 passed / 3 todos. Pint, PHPStan and Rector clean under the dependency set CI actually installs (`composer update --prefer-stable`). Type coverage sits at 99.4%, unchanged from `3.x` and not a CI gate.

Section scoping: `onlySections()` scoping including two sections sharing a code; empty scope means no scope; composition with `only()`; scope honoured through `build()` for both form and infolist; sections-disabled guard; the `CodeGenerator` hook scoped/unscoped/sectionless; and a dedicated migration test file covering `up()`, `down()`, both idempotency branches, the pre-applied-index state, and the duplicate guard.

Conditional visibility: numeric-string condition values pinned to string comparison; case-insensitive parity for `equals` and `not_equals`; and operator-level coverage for the numeric, boolean, set-equality, membership and scalar-vs-collection classes. Five of these fail against the pre-fix operator.

Every test asserting a fix was proven to fail against the unfixed code.

## Intended release

`v3.7.0` — additive and backward compatible for section scoping. **`5fa87dab` is not backward compatible**: it changes when an `equals` visibility condition matches. Conditions that silently never matched server-side (numeric fields) will start matching, and consumers relying on the previous strict-identity behaviour will see visibility change. That alone may argue for shipping it separately.
