### PR TITLE
feat: allow the host app to register its own management page

### DIFF
--- a/docs/content/2.essentials/1.configuration.md
+++ b/docs/content/2.essentials/1.configuration.md
@@ -135,6 +135,46 @@ Configure the custom fields management page:
 ],
 ```
 
+#### Replacing the Management Page
+
+The config above covers the common cases. Filament reads some things off the page
+class itself rather than from config — sub-navigation, breadcrumbs, header actions —
+so when you need one of those, register your own page instead:
+
+```php
+use App\Filament\Pages\Settings\CustomFields;
+
+CustomFieldsPlugin::make()
+    ->managementPage(CustomFields::class)
+```
+
+```php
+namespace App\Filament\Pages\Settings;
+
+use Filament\Panel;
+use Filament\Pages\Enums\SubNavigationPosition;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+
+class CustomFields extends CustomFieldsManagementPage
+{
+    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Start;
+
+    public static function getSlug(?Panel $panel = null): string
+    {
+        return 'settings/custom-fields';
+    }
+
+    public function getSubNavigation(): array
+    {
+        // Render this page inside your own settings navigation.
+    }
+}
+```
+
+The page must extend `CustomFieldsManagementPage`, and it replaces the packaged page
+rather than sitting alongside it — only one management page is registered on the panel,
+so there is no second route to the same screen.
+
 ### Database Configuration
 
 Customize table names and paths:

--- a/src/CustomFieldsPlugin.php
+++ b/src/CustomFieldsPlugin.php
@@ -10,6 +10,7 @@ use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Enums\Width;
+use InvalidArgumentException;
 use Relaticle\CustomFields\Enums\CustomFieldsFeature;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\FeatureSystem\FeatureManager;
@@ -29,6 +30,9 @@ class CustomFieldsPlugin implements Plugin
 
     protected Width|Closure|null $sectionModalWidth = null;
 
+    /** @var class-string<CustomFieldsManagementPage>|null */
+    protected ?string $managementPage = null;
+
     public function getId(): string
     {
         return 'custom-fields';
@@ -38,7 +42,7 @@ class CustomFieldsPlugin implements Plugin
     {
         $panel
             ->pages([
-                CustomFieldsManagementPage::class,
+                $this->getManagementPage(),
             ])
             ->tenantMiddleware([SetTenantContextMiddleware::class], true);
     }
@@ -117,6 +121,37 @@ class CustomFieldsPlugin implements Plugin
         $this->sectionModalWidth = $width;
 
         return $this;
+    }
+
+    /**
+     * Register your own management page in place of the packaged one, so the host
+     * application controls the things Filament reads off the page class itself —
+     * slug, sub-navigation, cluster, heading. The subclass keeps all packaged
+     * behaviour; only the page registered on the panel changes.
+     *
+     * @param  class-string<CustomFieldsManagementPage>  $page
+     */
+    public function managementPage(string $page): static
+    {
+        if (! is_subclass_of($page, CustomFieldsManagementPage::class)) {
+            throw new InvalidArgumentException(sprintf(
+                '[%s] must extend [%s] to be used as the management page.',
+                $page,
+                CustomFieldsManagementPage::class,
+            ));
+        }
+
+        $this->managementPage = $page;
+
+        return $this;
+    }
+
+    /**
+     * @return class-string<CustomFieldsManagementPage>
+     */
+    public function getManagementPage(): string
+    {
+        return $this->managementPage ?? CustomFieldsManagementPage::class;
     }
 
     public function getSectionModalWidth(): Width

--- a/src/CustomFieldsPlugin.php
+++ b/src/CustomFieldsPlugin.php
@@ -133,7 +133,9 @@ class CustomFieldsPlugin implements Plugin
      */
     public function managementPage(string $page): static
     {
-        if (! is_subclass_of($page, CustomFieldsManagementPage::class)) {
+        // is_a() rather than is_subclass_of(), so passing the packaged page
+        // itself is an explicit no-op rather than an error.
+        if (! is_a($page, CustomFieldsManagementPage::class, allow_string: true)) {
             throw new InvalidArgumentException(sprintf(
                 '[%s] must extend [%s] to be used as the management page.',
                 $page,

--- a/tests/Feature/ManagementPageOverrideTest.php
+++ b/tests/Feature/ManagementPageOverrideTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Panel;
+use Relaticle\CustomFields\CustomFieldsPlugin;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+use Relaticle\CustomFields\Tests\Fixtures\Pages\CustomManagementPage;
+
+it('registers the packaged management page by default', function (): void {
+    expect(CustomFieldsPlugin::make()->getManagementPage())
+        ->toBe(CustomFieldsManagementPage::class);
+});
+
+it('registers an overridden management page', function (): void {
+    expect(CustomFieldsPlugin::make()->managementPage(CustomManagementPage::class)->getManagementPage())
+        ->toBe(CustomManagementPage::class);
+});
+
+it('rejects a management page that does not extend the packaged one', function (): void {
+    CustomFieldsPlugin::make()->managementPage(Panel::class);
+})->throws(InvalidArgumentException::class, 'must extend');
+
+it('puts only the overridden page on the panel', function (): void {
+    $panel = Panel::make();
+
+    CustomFieldsPlugin::make()->managementPage(CustomManagementPage::class)->register($panel);
+
+    expect($panel->getPages())
+        ->toContain(CustomManagementPage::class)
+        ->not->toContain(CustomFieldsManagementPage::class);
+});
+
+it('puts the packaged page on the panel when not overridden', function (): void {
+    $panel = Panel::make();
+
+    CustomFieldsPlugin::make()->register($panel);
+
+    expect($panel->getPages())->toContain(CustomFieldsManagementPage::class);
+});

--- a/tests/Feature/ManagementPageOverrideTest.php
+++ b/tests/Feature/ManagementPageOverrideTest.php
@@ -17,6 +17,11 @@ it('registers an overridden management page', function (): void {
         ->toBe(CustomManagementPage::class);
 });
 
+it('accepts the packaged page itself as an explicit no-op', function (): void {
+    expect(CustomFieldsPlugin::make()->managementPage(CustomFieldsManagementPage::class)->getManagementPage())
+        ->toBe(CustomFieldsManagementPage::class);
+});
+
 it('rejects a management page that does not extend the packaged one', function (): void {
     CustomFieldsPlugin::make()->managementPage(Panel::class);
 })->throws(InvalidArgumentException::class, 'must extend');

--- a/tests/Fixtures/Pages/CustomManagementPage.php
+++ b/tests/Fixtures/Pages/CustomManagementPage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Tests\Fixtures\Pages;
+
+use Filament\Panel;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+
+class CustomManagementPage extends CustomFieldsManagementPage
+{
+    public static function getSlug(?Panel $panel = null): string
+    {
+        return 'settings/custom-fields';
+    }
+}


### PR DESCRIPTION
## Problem

The `management` config block covers slug, navigation sort/group and cluster. But Filament reads several things off the **page class itself** — `getSubNavigation()`, breadcrumbs, header actions — and config cannot reach any of them.

A consumer that wants the custom fields screen inside its own settings navigation therefore has to subclass `CustomFieldsManagementPage` and register the subclass on the panel. `CustomFieldsPlugin::register()` still adds the packaged page unconditionally, and `Panel::getPages()` de-duplicates by class string only — so the app ends up with **two routes to the same screen**, one of them unlinked.

The `cluster` option is not a way out: `Page::getRoutePath()` applies the cluster slug as a route prefix, so it moves the URL as a side effect of wanting navigation.

## Solution

`CustomFieldsPlugin::managementPage()` — swaps the registered page rather than adding to it, so there is exactly one route either way.

```php
CustomFieldsPlugin::make()
    ->managementPage(\App\Filament\Pages\Settings\CustomFields::class)
```

```php
class CustomFields extends CustomFieldsManagementPage
{
    public static function getSlug(?Panel $panel = null): string
    {
        return 'settings/custom-fields';
    }

    public function getSubNavigation(): array { /* ... */ }
}
```

The class must extend `CustomFieldsManagementPage` (guarded with an `InvalidArgumentException`), so every packaged behaviour is inherited by default and a consumer overrides only what it needs. Default behaviour is unchanged when the option is not used.

## Testing

`tests/Feature/ManagementPageOverrideTest.php` covers the default, the override, the subclass guard, and that `register()` puts **only** the override on the panel. I verified that last one is load-bearing by reverting `register()` to the hardcoded class — it fails.

- Package suite: 827 passed, 3 todos
- Pint and PHPStan clean

**Pre-existing on `3.x`, not touched here:** `composer test:type-coverage` reports 99.4% (below the 100% gate) and Rector flags `tests/Feature/ConsumerScopeHooksTest.php:469`. Both reproduce with my changes stashed.