### PR TITLE
fix: keep a persisted field's code stable when its name is renamed [3.x]

### DIFF
--- a/src/Filament/Management/Schemas/FieldForm.php
+++ b/src/Filament/Management/Schemas/FieldForm.php
@@ -271,7 +271,16 @@ class FieldForm implements FormInterface
                                 return $rule;
                             }
                         )
-                        ->afterStateUpdated(function (Get $get, Set $set, ?string $old, ?string $state): void {
+                        ->afterStateUpdated(function (Get $get, Set $set, ?CustomField $record, ?string $old, ?string $state): void {
+                            // On a persisted field the code is an identity, not a label:
+                            // stored values, report columns and visibility conditions all
+                            // key on it, and a field cloned onto a new form version shares
+                            // it with the original. Renaming must therefore never rewrite
+                            // it — only derive the code while the field is being created.
+                            if ($record instanceof CustomField) {
+                                return;
+                            }
+
                             $old ??= '';
                             $state ??= '';
 

--- a/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
+++ b/tests/Feature/Admin/Pages/CustomFieldsFieldManagementTest.php
@@ -916,3 +916,37 @@ describe('Custom Fields Management Workflow - Phase 2.1', function (): void {
             ->active->toBeTrue();
     });
 });
+
+describe('ManageCustomField - Code Stability On Rename', function (): void {
+    beforeEach(function (): void {
+        $this->section = CustomFieldSection::factory()
+            ->forEntityType($this->userEntityType)
+            ->create();
+    });
+
+    it('keeps a persisted fields code stable when the name is renamed', function (): void {
+        $field = CustomField::factory()
+            ->ofType('text')
+            ->create([
+                'custom_field_section_id' => $this->section->getKey(),
+                'entity_type' => $this->userEntityType,
+                'name' => 'HMIS ID',
+                'code' => 'hmis_id',
+            ]);
+
+        // The code is an identity: stored values, report columns and visibility
+        // conditions key on it, and a field cloned onto a new form version shares
+        // it with the original. Renaming must not rewrite it, even though the code
+        // still matches the slug of the previous name.
+        livewire(ManageCustomField::class, ['field' => $field])
+            ->mountAction('edit')
+            ->set('mountedActions.0.data.name', 'HMIS ID (Q/A testing added)')
+            ->assertSet('mountedActions.0.data.code', 'hmis_id')
+            ->callMountedAction()
+            ->assertHasNoActionErrors();
+
+        expect($field->refresh())
+            ->code->toBe('hmis_id')
+            ->name->toBe('HMIS ID (Q/A testing added)');
+    });
+});


### PR DESCRIPTION
## Problem

The `name` input on `FieldForm` derives `code` from `name` whenever the current code still matches the slug of the *previous* name:

```php
if (($get('code') ?? '') !== Str::of($old)->slug('_')->toString()) {
    return;
}

$set('code', Str::of($state)->slug('_')->toString());
```

That heuristic is correct while a field is being **created** — it stops overwriting a code the user typed by hand. On a **persisted** field it is wrong: the code is an identity, not a label. Stored values, report columns and visibility conditions all key on it, and a field cloned onto a new form version deliberately shares its code with the original.

So renaming a field silently rewrote its code and severed it from its own data: the existing values kept the old code, and reporting then offered two unrelated columns where the user expected one renamed column.

## Fix

Only derive the code while the field is being created, detected by the absence of a bound record.

This is correctly scoped across all four `FieldForm::schema()` consumers:

| Consumer | Binds a record? | Behaviour |
| --- | --- | --- |
| `ManageCustomFieldSection::createField` | no | derivation still runs |
| `ManageFieldsTable` create action | no | derivation still runs |
| `ManageCustomField::editAction` | yes | derivation suppressed |
| `ManageFieldsTable::editField` | yes | derivation suppressed |

`duplicateAction` does not use this form — it is confirmation-only and already generates its own unique code via `generateUniqueCode()`, so it is unaffected.

## Verification

New regression test in `CustomFieldsFieldManagementTest`, verified **red** against the previous implementation (it failed on the `code` assertion) and green with the fix.

- Full package suite: **786 passed**, 3 todos, 0 failures
- PHPStan: no errors
- Rector + Pint: clean

## Downstream

This is the blocker for Padmission/journey#3427, where renaming a field on a new Flex Fund form version broke code continuity with v1 and hid the field from Custom Reports. Journey will need a version bump once this is released.