### PR TITLE
fix: record filter matches nothing for single-value fields

### DIFF
--- a/src/Filament/Integration/Components/Tables/Filters/RecordFilter.php
+++ b/src/Filament/Integration/Components/Tables/Filters/RecordFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Filament\Integration\Components\Tables\Filters;
 
+use Filament\Forms\Components\Select;
 use Filament\Tables\Filters\SelectFilter as FilamentSelectFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -23,33 +24,28 @@ final class RecordFilter extends AbstractTableFilter
      */
     public function make(CustomField $customField): FilamentSelectFilter
     {
-        $isMultiSelect = $customField->settings->allow_multiple ?? false;
-
         $filter = FilamentSelectFilter::make($customField->getFieldName())
             ->multiple()
             ->label($customField->name)
             ->searchable()
-            ->native(false);
+            ->native(false)
+            ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml());
 
         $filter = $this->configureLookup($filter, $customField->lookup_type);
 
-        $filter->query(function (array $data, Builder $query) use ($customField, $isMultiSelect): Builder {
+        $filter->query(function (array $data, Builder $query) use ($customField): Builder {
             if (empty($data['values'])) {
                 return $query;
             }
 
-            return $query->whereHas('customFieldValues', function (Builder $q) use ($customField, $data, $isMultiSelect): void {
+            return $query->whereHas('customFieldValues', function (Builder $q) use ($customField, $data): void {
                 $q->where('custom_field_id', $customField->id);
 
-                if ($isMultiSelect) {
-                    $q->where(function (Builder $subQuery) use ($data): void {
-                        foreach ($data['values'] as $value) {
-                            $subQuery->orWhereJsonContains('json_value', $value);
-                        }
-                    });
-                } else {
-                    $q->whereIn('string_value', $data['values']);
-                }
+                $q->where(function (Builder $subQuery) use ($data): void {
+                    foreach ($data['values'] as $value) {
+                        $subQuery->orWhereJsonContains('json_value', $value);
+                    }
+                });
             });
         });
 

--- a/tests/Feature/Integration/Resources/Pages/ListRecordsTest.php
+++ b/tests/Feature/Integration/Resources/Pages/ListRecordsTest.php
@@ -411,3 +411,43 @@ describe('Conditional Visibility in Tables', function (): void {
             ->assertTableColumnStateSet('custom_fields.internal_notes', 'Internal review needed', $draftPost);
     });
 });
+
+describe('Record Field Filtering', function (): void {
+    beforeEach(function (): void {
+        $this->section = CustomFieldSection::factory()->create([
+            'name' => 'Post Relations',
+            'entity_type' => Post::class,
+            'active' => true,
+        ]);
+    });
+
+    it('filters by a record field regardless of cardinality', function (bool $allowMultiple, string $code): void {
+        $field = CustomField::factory()->create([
+            'custom_field_section_id' => $this->section->id,
+            'name' => 'Related Post',
+            'code' => $code,
+            'type' => 'record',
+            'entity_type' => Post::class,
+            'lookup_type' => Post::class,
+            'settings' => new CustomFieldSettingsData(
+                visible_in_list: true,
+                list_toggleable_hidden: false,
+                allow_multiple: $allowMultiple,
+            ),
+        ]);
+
+        $target = Post::factory()->create();
+        $linked = Post::factory()->create();
+        $unlinked = Post::factory()->create();
+
+        $linked->saveCustomFieldValue($field, [$target->getKey()]);
+
+        livewire(ListPosts::class)
+            ->set(sprintf('tableFilters.custom_fields.%s.values', $code), [$target->getKey()])
+            ->assertCanSeeTableRecords([$linked])
+            ->assertCanNotSeeTableRecords([$unlinked]);
+    })->with([
+        'single-value' => [false, 'related_post_single'],
+        'multi-value' => [true, 'related_post_multi'],
+    ]);
+});


### PR DESCRIPTION
## Problem

Filtering a table by a single-value **Record** custom field returns no rows, even when matching records exist. Multi-value Record fields filter correctly.

Found while answering https://github.com/orgs/relaticle/discussions/469 (using Record fields to model people-to-people relationships).

## Root cause

`RecordFilter` branched on `allow_multiple` and queried a different column per cardinality:

```php
if ($isMultiSelect) {
    $subQuery->orWhereJsonContains('json_value', $value);
} else {
    $q->whereIn('string_value', $data['values']);   // never populated
}
```

`RecordFieldType::configure()` is `FieldSchema::multiChoice()` regardless of `allow_multiple`, so values always land in `json_value`. The single-value branch queried a column that is always NULL for record fields:

```
reports_to      string_value=NULL  json_value='["01m0aez6vjvbwnq6j46f2x53pn"]'
direct_reports  string_value=NULL  json_value='["01m0aez6v9ax794ngeenxen1mk", ...]'
```

## Also fixed

Filter option labels rendered as escaped HTML (`<div class="flex items-center gap-2"><img src="data:image/svg+xml;base64…`). `formatOptionWithAvatar()` returns avatar markup but the `SelectFilter` did not allow HTML. `SelectFilter` has no `allowHtml()`, so this goes through `modifyFormFieldUsing()` onto the inner `Select`. Both interpolations already pass through `e()`.

## Test

Added a dataset-driven case in `ListRecordsTest` covering both cardinalities. Verified load-bearing: with the source change reverted, `single-value` fails and `multi-value` passes.

## Verification

- `composer test:pest` — 831 passed, 3 todos
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/pint --test` — passed
- Type coverage on `RecordFilter.php` — 100% (repo total is 99.4% before and after this change)
- Walked in a real browser against a Relaticle app: the filter that returned "No people" now returns the expected row, and the dropdown shows the avatar + name