### PR TITLE
fix(imports): report every invalid cell instead of aborting the row or silently guessing

### DIFF
--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -159,6 +159,24 @@ return [
         'currencies' => null,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Imports
+    |--------------------------------------------------------------------------
+    |
+    | How CSV cells are read during import. Dates and numbers are parsed against a
+    | declared convention rather than guessed, so an ambiguous cell like 3/4/2024 has
+    | exactly one meaning. The defaults match how this package has always behaved.
+    |
+    */
+    'imports' => [
+        // 'european' (day first), 'american' (month first), or 'iso' (Y-m-d only).
+        'date_format' => env('CUSTOM_FIELDS_IMPORT_DATE_FORMAT', 'european'),
+
+        // 'point' (1,234.56) or 'comma' (1.234,56).
+        'number_format' => env('CUSTOM_FIELDS_IMPORT_NUMBER_FORMAT', 'point'),
+    ],
+
     'database' => [
         'migrations_path' => database_path('custom-fields'),
         'table_names' => [

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -170,8 +170,9 @@ return [
     |
     */
     'imports' => [
-        // 'european' (day first), 'american' (month first), or 'iso' (Y-m-d only).
-        'date_format' => env('CUSTOM_FIELDS_IMPORT_DATE_FORMAT', 'european'),
+        // 'iso' (Y-m-d only), 'european' (day first), or 'american' (month first).
+        // Every convention also accepts ISO, so picking one only widens what is read.
+        'date_format' => env('CUSTOM_FIELDS_IMPORT_DATE_FORMAT', 'iso'),
 
         // 'point' (1,234.56) or 'comma' (1.234,56).
         'number_format' => env('CUSTOM_FIELDS_IMPORT_NUMBER_FORMAT', 'point'),

--- a/src/CustomFields.php
+++ b/src/CustomFields.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Relaticle\CustomFields;
 
 use Closure;
+use Relaticle\CustomFields\Enums\ImportDateFormat;
+use Relaticle\CustomFields\Enums\ImportNumberFormat;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldOption;
 use Relaticle\CustomFields\Models\CustomFieldSection;
@@ -224,6 +226,26 @@ final class CustomFields
     public static function dateTimeDisplayFormat(): ?string
     {
         return self::$dateTimeDisplayFormat;
+    }
+
+    /**
+     * Date convention used when reading CSV cells during import.
+     */
+    public static function importDateFormat(): ImportDateFormat
+    {
+        return ImportDateFormat::tryFrom(
+            (string) config('custom-fields.imports.date_format', 'european')
+        ) ?? ImportDateFormat::EUROPEAN;
+    }
+
+    /**
+     * Decimal separator convention used when reading CSV cells during import.
+     */
+    public static function importNumberFormat(): ImportNumberFormat
+    {
+        return ImportNumberFormat::tryFrom(
+            (string) config('custom-fields.imports.number_format', 'point')
+        ) ?? ImportNumberFormat::POINT;
     }
 
     /**

--- a/src/CustomFields.php
+++ b/src/CustomFields.php
@@ -234,8 +234,8 @@ final class CustomFields
     public static function importDateFormat(): ImportDateFormat
     {
         return ImportDateFormat::tryFrom(
-            (string) config('custom-fields.imports.date_format', 'european')
-        ) ?? ImportDateFormat::EUROPEAN;
+            (string) config('custom-fields.imports.date_format', 'iso')
+        ) ?? ImportDateFormat::ISO;
     }
 
     /**

--- a/src/Enums/ImportDateFormat.php
+++ b/src/Enums/ImportDateFormat.php
@@ -26,6 +26,15 @@ enum ImportDateFormat: string implements HasLabel
      */
     private const int MINIMUM_YEAR = 1000;
 
+    /**
+     * A written-out month is unambiguous in either word order, so both named
+     * conventions accept all of these. Only `ISO` excludes them, because a column
+     * declared ISO should mean the `Y-m-d` family and nothing else.
+     *
+     * @var list<string>
+     */
+    private const array TEXTUAL_FORMATS = ['j F Y', 'j M Y', 'F j, Y', 'F jS Y', 'M j, Y', 'M jS Y'];
+
     public function getLabel(): string
     {
         return match ($this) {
@@ -117,14 +126,12 @@ enum ImportDateFormat: string implements HasLabel
             self::ISO => [],
             self::EUROPEAN => $withTime
                 ? ['d/m/Y H:i:s', 'd-m-Y H:i:s', 'd.m.Y H:i:s', 'j/n/Y H:i:s', 'd/m/Y H:i', 'j/n/Y H:i']
-                : ['d/m/Y', 'd-m-Y', 'd.m.Y', 'j/n/Y', 'j-n-Y', 'j.n.Y'],
+                : ['d/m/Y', 'd-m-Y', 'd.m.Y', 'j/n/Y', 'j-n-Y', 'j.n.Y', ...self::TEXTUAL_FORMATS],
             self::AMERICAN => $withTime
                 ? ['m/d/Y H:i:s', 'm-d-Y H:i:s', 'n/j/Y H:i:s', 'm/d/Y H:i', 'n/j/Y H:i']
-                : ['m/d/Y', 'm-d-Y', 'n/j/Y', 'n-j-Y'],
+                : ['m/d/Y', 'm-d-Y', 'n/j/Y', 'n-j-Y', ...self::TEXTUAL_FORMATS],
         };
 
-        $textual = $withTime ? [] : ['F j, Y', 'j F Y', 'M j, Y', 'j M Y'];
-
-        return [...$iso, ...$localised, ...$textual];
+        return [...$iso, ...$localised];
     }
 }

--- a/src/Enums/ImportDateFormat.php
+++ b/src/Enums/ImportDateFormat.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Enums;
+
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Declared date convention for CSV import parsing.
+ *
+ * `3/4/2024` is 3 April in Europe and 4 March in the US. Guessing it, as
+ * `Carbon::parse` does, silently transposes day and month whenever both are 12 or under.
+ * Declaring the convention gives the cell exactly one meaning.
+ */
+enum ImportDateFormat: string implements HasLabel
+{
+    case ISO = 'iso';
+    case EUROPEAN = 'european';
+    case AMERICAN = 'american';
+
+    /**
+     * `Y` matches a two-digit year, so without a floor `1/1/24` parses to 1 January 24 AD.
+     */
+    private const int MINIMUM_YEAR = 1000;
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::ISO => 'ISO standard',
+            self::EUROPEAN => 'European (day first)',
+            self::AMERICAN => 'American (month first)',
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getExamples(bool $withTime = false): array
+    {
+        if ($withTime) {
+            return match ($this) {
+                self::ISO => ['2024-05-15 16:00:00'],
+                self::EUROPEAN => ['2024-05-15 16:00:00', '15/05/2024 16:00:00'],
+                self::AMERICAN => ['2024-05-15 16:00:00', '05/15/2024 16:00:00'],
+            };
+        }
+
+        return match ($this) {
+            self::ISO => ['2024-05-15'],
+            self::EUROPEAN => ['2024-05-15', '15/05/2024', '15 May 2024'],
+            self::AMERICAN => ['2024-05-15', '05/15/2024', 'May 15, 2024'],
+        };
+    }
+
+    public function parse(string $value, bool $withTime = false): ?CarbonImmutable
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        foreach ($this->getParseFormats($withTime) as $format) {
+            $parsed = $this->parseStrictly($format, $value);
+
+            if ($parsed instanceof CarbonImmutable) {
+                return $parsed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * `createFromFormat` overflows silently: `d/m/Y` turns 31/02/2024 into 2 March and
+     * `Y-m-d` turns 2024-02-31 into the same. The `!` prefix does not prevent it and
+     * `Carbon::hasFormat()` does not detect it. `getLastErrors()` reports a warning for
+     * every overflow, so that is the gate.
+     */
+    private function parseStrictly(string $format, string $value): ?CarbonImmutable
+    {
+        $parsed = DateTimeImmutable::createFromFormat('!'.$format, $value);
+        $errors = DateTimeImmutable::getLastErrors();
+
+        if ($parsed === false) {
+            return null;
+        }
+
+        if ($errors !== false && (($errors['warning_count'] ?? 0) > 0 || ($errors['error_count'] ?? 0) > 0)) {
+            return null;
+        }
+
+        if ((int) $parsed->format('Y') < self::MINIMUM_YEAR) {
+            return null;
+        }
+
+        return CarbonImmutable::instance($parsed);
+    }
+
+    /**
+     * ISO forms come first in every list so a `Y-m-d` cell is never re-read as something
+     * else, and every list carries the textual and datetime forms the previous
+     * `Carbon::parse` fallback accepted, so nothing that imports today stops importing.
+     *
+     * @return array<int, string>
+     */
+    private function getParseFormats(bool $withTime): array
+    {
+        $iso = $withTime
+            ? ['Y-m-d H:i:s', 'Y-m-d\TH:i:s', 'Y-m-d\TH:i', 'Y-m-d H:i']
+            : ['Y-m-d', 'Y-m-d H:i:s', 'Y-m-d\TH:i:s', 'Y-m-d H:i'];
+
+        $localised = match ($this) {
+            self::ISO => [],
+            self::EUROPEAN => $withTime
+                ? ['d/m/Y H:i:s', 'd-m-Y H:i:s', 'd.m.Y H:i:s', 'j/n/Y H:i:s', 'd/m/Y H:i', 'j/n/Y H:i']
+                : ['d/m/Y', 'd-m-Y', 'd.m.Y', 'j/n/Y', 'j-n-Y', 'j.n.Y'],
+            self::AMERICAN => $withTime
+                ? ['m/d/Y H:i:s', 'm-d-Y H:i:s', 'n/j/Y H:i:s', 'm/d/Y H:i', 'n/j/Y H:i']
+                : ['m/d/Y', 'm-d-Y', 'n/j/Y', 'n-j-Y'],
+        };
+
+        $textual = $withTime ? [] : ['F j, Y', 'j F Y', 'M j, Y', 'j M Y'];
+
+        return [...$iso, ...$localised, ...$textual];
+    }
+}

--- a/src/Enums/ImportNumberFormat.php
+++ b/src/Enums/ImportNumberFormat.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Decimal separator convention for CSV import parsing.
+ *
+ * Only the decimal separator is configurable; thousands separators are stripped.
+ * Declaring it means `1.234,56` has one meaning instead of two.
+ */
+enum ImportNumberFormat: string implements HasLabel
+{
+    case POINT = 'point';
+    case COMMA = 'comma';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::POINT => 'Point',
+            self::COMMA => 'Comma',
+        };
+    }
+
+    public function getExample(): string
+    {
+        return match ($this) {
+            self::POINT => '1,234.56',
+            self::COMMA => '1.234,56',
+        };
+    }
+
+    /**
+     * `$stripCurrencySymbol` keeps currency columns accepting `$1,234.56` and
+     * `1234.56 EUR`, which they accept today. It is not applied to plain number
+     * columns, which reject anything with non-numeric characters.
+     */
+    public function parse(string $value, bool $stripCurrencySymbol = false): ?float
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        if ($stripCurrencySymbol) {
+            // Keep the sign, drop a symbol or code on either side: -$5.50, $1,234.56, 1234.56 EUR.
+            $value = preg_replace('/^([+-]?)[^\d]*/u', '$1', $value) ?? '';
+            $value = preg_replace('/[^\d]*$/u', '', $value) ?? '';
+        }
+
+        $decimalSeparator = match ($this) {
+            self::POINT => '.',
+            self::COMMA => ',',
+        };
+
+        $otherSeparator = match ($this) {
+            self::POINT => ',',
+            self::COMMA => '.',
+        };
+
+        $value = str_replace([' ', "\u{00A0}", $otherSeparator], '', $value);
+
+        if ($decimalSeparator === ',') {
+            $value = str_replace(',', '.', $value);
+        }
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return (float) $value;
+    }
+}

--- a/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
+++ b/src/FieldTypeSystem/Definitions/CurrencyFieldType.php
@@ -9,12 +9,14 @@ use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Utilities\Get;
 use NumberFormatter;
+use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Data\Settings\CurrencyFieldSettingsData;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Filament\Integration\Components\Forms\CurrencyComponent;
 use Relaticle\CustomFields\Filament\Integration\Components\Infolists\CurrencyEntry;
 use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\CurrencyColumn;
+use Relaticle\CustomFields\Imports\UnresolvedValue;
 use Relaticle\CustomFields\Support\CurrencyProvider;
 use Relaticle\CustomFields\Validation\Capabilities\MaxValueCapability;
 use Relaticle\CustomFields\Validation\Capabilities\MinValueCapability;
@@ -40,16 +42,23 @@ class CurrencyFieldType extends BaseFieldType
                 fn (): array => $this->settingsSchema(),
             )
             ->importExample('99.99')
-            ->importTransformer(function (mixed $state): ?float {
+            ->importTransformer(function (mixed $state): float|UnresolvedValue|null {
                 if (blank($state)) {
                     return null;
                 }
 
-                if (is_string($state)) {
-                    $state = preg_replace('/[^0-9.-]/', '', $state);
+                $format = CustomFields::importNumberFormat();
+                $parsed = $format->parse((string) $state, stripCurrencySymbol: true);
+
+                if ($parsed === null) {
+                    return UnresolvedValue::make($state, sprintf(
+                        "'%s' is not a valid amount. Expected format: %s.",
+                        $state,
+                        $format->getExample(),
+                    ));
                 }
 
-                return (float) $state;
+                return $parsed;
             })
             ->exportTransformer(function (mixed $value): ?string {
                 if ($value === null) {

--- a/src/Filament/Integration/Support/Imports/ImportColumnConfigurator.php
+++ b/src/Filament/Integration/Support/Imports/ImportColumnConfigurator.php
@@ -7,16 +7,17 @@ declare(strict_types=1);
 
 namespace Relaticle\CustomFields\Filament\Integration\Support\Imports;
 
-use Carbon\Carbon;
-use Exception;
-use Filament\Actions\Imports\Exceptions\RowImportFailedException;
+use Carbon\CarbonImmutable;
+use Closure;
 use Filament\Actions\Imports\ImportColumn;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Facades\Entities;
+use Relaticle\CustomFields\Imports\UnresolvedValue;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldOption;
+use Relaticle\CustomFields\Rules\RejectsUnresolvedValue;
 use Relaticle\CustomFields\Services\ValidationService;
 use Throwable;
 
@@ -42,10 +43,10 @@ final class ImportColumnConfigurator
         match ($customField->typeData->dataType) {
             FieldDataType::SINGLE_CHOICE => $this->configureSingleChoice($column, $customField),
             FieldDataType::MULTI_CHOICE => $this->configureMultiChoice($column, $customField),
-            FieldDataType::DATE => $this->configureDate($column),
-            FieldDataType::DATE_TIME => $this->configureDateTime($column),
-            FieldDataType::NUMERIC, FieldDataType::FLOAT => $column->numeric(),
-            FieldDataType::BOOLEAN => $this->configureBoolean($column),
+            FieldDataType::DATE => $this->configureDate($column, $customField),
+            FieldDataType::DATE_TIME => $this->configureDateTime($column, $customField),
+            FieldDataType::NUMERIC, FieldDataType::FLOAT => $this->configureNumeric($column, $customField),
+            FieldDataType::BOOLEAN => $this->configureBoolean($column, $customField),
             default => $this->configureText($column, $customField),
         };
 
@@ -70,7 +71,7 @@ final class ImportColumnConfigurator
             return false;
         }
 
-        $column->castStateUsing($transformer);
+        $column->castStateUsing($this->wrapTransformer($transformer, $customField));
 
         $example = $schema->getImportExample();
         if ($example !== null) {
@@ -130,7 +131,7 @@ final class ImportColumnConfigurator
      */
     private function configureLookup(ImportColumn $column, CustomField $customField, bool $multiple): void
     {
-        $column->castStateUsing(function (mixed $state) use ($customField, $multiple): array|null|int {
+        $column->castStateUsing(function (mixed $state) use ($customField, $multiple): array|int|UnresolvedValue|null {
             if (blank($state)) {
                 return $multiple ? [] : null;
             }
@@ -150,14 +151,13 @@ final class ImportColumnConfigurator
     /**
      * Resolve a single lookup value.
      */
-    private function resolveLookupValue(CustomField $customField, mixed $value): int
+    private function resolveLookupValue(CustomField $customField, mixed $value): int|UnresolvedValue
     {
         try {
             $entity = Entities::getEntity($customField->lookup_type);
             $modelInstance = $entity->createModelInstance();
             $primaryAttribute = $entity->getPrimaryAttribute();
 
-            // Try to find by primary attribute
             $record = $modelInstance->newQuery()
                 ->where($primaryAttribute, $value)
                 ->first();
@@ -166,7 +166,6 @@ final class ImportColumnConfigurator
                 return (int) $record->getKey();
             }
 
-            // Try to find by ID if numeric
             if (is_numeric($value)) {
                 $record = $modelInstance->newQuery()
                     ->where($modelInstance->getKeyName(), $value)
@@ -177,43 +176,54 @@ final class ImportColumnConfigurator
                 }
             }
 
-            throw new RowImportFailedException(
-                sprintf("No %s record found matching '%s'", $customField->lookup_type, $value)
-            );
+            return UnresolvedValue::make($value, sprintf(
+                "No %s found matching '%s' for %s.",
+                $this->lookupRecordLabel($customField),
+                is_scalar($value) ? (string) $value : gettype($value),
+                $customField->name,
+            ));
         } catch (Throwable $throwable) {
-            if ($throwable instanceof RowImportFailedException) {
-                throw $throwable;
-            }
-
-            throw new RowImportFailedException('Error resolving lookup value: '.$throwable->getMessage(), $throwable->getCode(), $throwable);
+            return UnresolvedValue::make($value, 'Error resolving lookup value: '.$throwable->getMessage());
         }
     }
 
     /**
      * Resolve multiple lookup values.
      */
-    private function resolveLookupValues(CustomField $customField, array $values): array
+    private function resolveLookupValues(CustomField $customField, array $values): array|UnresolvedValue
     {
         $foundIds = [];
         $missingValues = [];
 
         foreach ($values as $value) {
-            try {
-                $id = $this->resolveLookupValue($customField, $value);
-                $foundIds[] = $id;
-            } catch (RowImportFailedException) {
+            $id = $this->resolveLookupValue($customField, $value);
+
+            if ($id instanceof UnresolvedValue) {
                 $missingValues[] = $value;
+
+                continue;
             }
+
+            $foundIds[] = $id;
         }
 
         if ($missingValues !== []) {
-            throw new RowImportFailedException(
-                sprintf('Could not find %s records: ', $customField->lookup_type).
-                implode(', ', $missingValues)
-            );
+            return UnresolvedValue::make($values, sprintf(
+                'Could not find a %s for %s: %s',
+                $this->lookupRecordLabel($customField),
+                $customField->name,
+                implode(', ', $missingValues),
+            ));
         }
 
         return $foundIds;
+    }
+
+    private function lookupRecordLabel(CustomField $customField): string
+    {
+        return filled($customField->lookup_type)
+            ? $customField->lookup_type.' record'
+            : 'record';
     }
 
     /**
@@ -221,7 +231,7 @@ final class ImportColumnConfigurator
      */
     private function configureChoices(ImportColumn $column, CustomField $customField, bool $multiple): void
     {
-        $column->castStateUsing(function (mixed $state) use ($customField, $multiple): array|null|int|string {
+        $column->castStateUsing(function (mixed $state) use ($customField, $multiple): array|int|string|UnresolvedValue|null {
             if (blank($state)) {
                 return $multiple ? [] : null;
             }
@@ -241,7 +251,7 @@ final class ImportColumnConfigurator
     /**
      * Resolve a single choice value.
      */
-    private function resolveChoiceValue(CustomField $customField, mixed $value): int|string|null
+    private function resolveChoiceValue(CustomField $customField, mixed $value): int|string|UnresolvedValue|null
     {
         // If already numeric, assume it's a choice ID
         if (is_numeric($value)) {
@@ -254,15 +264,17 @@ final class ImportColumnConfigurator
         // Try case-insensitive match
         if (! $choice) {
             $choice = $customField->options->first(
-                fn (CustomFieldOption $opt): bool => strtolower((string) $opt->name) === strtolower($value)
+                fn (CustomFieldOption $opt): bool => strtolower((string) $opt->name) === strtolower((string) $value)
             );
         }
 
         if (! $choice) {
-            throw new RowImportFailedException(
-                sprintf("Invalid choice '%s' for %s. Valid choices: ", $value, $customField->name).
-                $customField->options->pluck('name')->implode(', ')
-            );
+            return UnresolvedValue::make($value, sprintf(
+                "Invalid choice '%s' for %s. Valid choices: %s",
+                is_scalar($value) ? (string) $value : gettype($value),
+                $customField->name,
+                $customField->options->pluck('name')->implode(', '),
+            ));
         }
 
         $key = $choice->getKey();
@@ -270,34 +282,32 @@ final class ImportColumnConfigurator
         return CustomFields::optionModelUsesStringKeys() ? (string) $key : $key;
     }
 
-    /**
-     * Resolve multiple choice values.
-     *
-     * @throws RowImportFailedException
-     */
-    private function resolveChoiceValues(CustomField $customField, array $values): array
+    private function resolveChoiceValues(CustomField $customField, array $values): array|UnresolvedValue
     {
         $foundIds = [];
         $missingValues = [];
 
         foreach ($values as $value) {
-            try {
-                $id = $this->resolveChoiceValue($customField, $value);
-                if ($id !== null) {
-                    $foundIds[] = $id;
-                }
-            } catch (RowImportFailedException) {
+            $id = $this->resolveChoiceValue($customField, $value);
+
+            if ($id instanceof UnresolvedValue) {
                 $missingValues[] = $value;
+
+                continue;
+            }
+
+            if ($id !== null) {
+                $foundIds[] = $id;
             }
         }
 
         if ($missingValues !== []) {
-            throw new RowImportFailedException(
-                sprintf('Invalid choices for %s: ', $customField->name).
-                implode(', ', $missingValues).
-                '. Valid choices: '.
-                $customField->options->pluck('name')->implode(', ')
-            );
+            return UnresolvedValue::make($values, sprintf(
+                'Invalid choices for %s: %s. Valid choices: %s',
+                $customField->name,
+                implode(', ', $missingValues),
+                $customField->options->pluck('name')->implode(', '),
+            ));
         }
 
         return $foundIds;
@@ -306,9 +316,9 @@ final class ImportColumnConfigurator
     /**
      * Configure boolean fields with string coercion for CSV values.
      */
-    private function configureBoolean(ImportColumn $column): void
+    private function configureBoolean(ImportColumn $column, CustomField $customField): void
     {
-        $column->castStateUsing(function (mixed $state): ?bool {
+        $column->castStateUsing(function (mixed $state) use ($customField): bool|UnresolvedValue|null {
             if (blank($state)) {
                 return null;
             }
@@ -317,58 +327,108 @@ final class ImportColumnConfigurator
                 return $state;
             }
 
-            $normalized = strtolower(trim((string) $state));
-
-            return match ($normalized) {
+            return match (strtolower(trim((string) $state))) {
                 '1', 'true', 'yes', 'on' => true,
                 '0', 'false', 'no', 'off' => false,
-                default => null,
+                default => UnresolvedValue::make($state, sprintf(
+                    "'%s' is not a valid value for %s. Use true or false (accepted: true, false, 1, 0, yes, no, on, off).",
+                    $state,
+                    $customField->name,
+                )),
             };
         });
 
         $column->example('true or false');
     }
 
-    /**
-     * Configure date fields.
-     */
-    private function configureDate(ImportColumn $column): void
+    private function configureDate(ImportColumn $column, CustomField $customField): void
     {
-        $column->castStateUsing(function (mixed $state): ?string {
+        $column->castStateUsing(fn (mixed $state): string|UnresolvedValue|null => $this->parseDate($state, false, $customField));
+
+        $column->example(CustomFields::importDateFormat()->getExamples()[0]);
+    }
+
+    private function configureDateTime(ImportColumn $column, CustomField $customField): void
+    {
+        $column->castStateUsing(fn (mixed $state): string|UnresolvedValue|null => $this->parseDate($state, true, $customField));
+
+        $column->example(CustomFields::importDateFormat()->getExamples(withTime: true)[0]);
+    }
+
+    private function parseDate(mixed $state, bool $withTime, CustomField $customField): string|UnresolvedValue|null
+    {
+        if (blank($state)) {
+            return null;
+        }
+
+        $format = CustomFields::importDateFormat();
+        $parsed = $format->parse((string) $state, $withTime);
+
+        if (! $parsed instanceof CarbonImmutable) {
+            return UnresolvedValue::make($state, sprintf(
+                "'%s' is not a valid date for %s. Expected format: %s.",
+                $state,
+                $customField->name,
+                implode(' or ', $format->getExamples($withTime)),
+            ));
+        }
+
+        return $parsed->format($withTime ? 'Y-m-d H:i:s' : 'Y-m-d');
+    }
+
+    private function configureNumeric(ImportColumn $column, CustomField $customField): void
+    {
+        $column->castStateUsing(function (mixed $state) use ($customField): float|UnresolvedValue|null {
             if (blank($state)) {
                 return null;
             }
 
-            try {
-                // Try to parse DD/MM/YYYY format first
-                if (preg_match('#^(\d{1,2})/(\d{1,2})/(\d{4})$#', $state, $matches)) {
-                    return Carbon::createFromFormat('d/m/Y', $state)->format('Y-m-d');
-                }
+            $format = CustomFields::importNumberFormat();
+            $parsed = $format->parse((string) $state);
 
-                // Fall back to Carbon's default parsing
-                return Carbon::parse($state)->format('Y-m-d');
-            } catch (Exception) {
-                return null;
+            if ($parsed === null) {
+                return UnresolvedValue::make($state, sprintf(
+                    "'%s' is not a valid number for %s. Expected format: %s.",
+                    $state,
+                    $customField->name,
+                    $format->getExample(),
+                ));
             }
+
+            return $parsed;
         });
+
+        $column->example('99.99');
     }
 
     /**
-     * Configure datetime fields.
+     * Field types registered by the host application supply their own import
+     * transformers. A throw from one would abort the whole row inside Filament's cast
+     * loop, taking every other column's error with it, so it is converted into a value
+     * the validator can report alongside them.
      */
-    private function configureDateTime(ImportColumn $column): void
+    public function wrapTransformer(Closure $transformer, CustomField $customField): Closure
     {
-        $column->castStateUsing(function (mixed $state): ?string {
-            if (blank($state)) {
-                return null;
+        return function (mixed $state) use ($transformer, $customField): mixed {
+            try {
+                $result = $transformer($state);
+            } catch (Throwable $throwable) {
+                $result = UnresolvedValue::make($state, $throwable->getMessage());
             }
 
-            try {
-                return Carbon::parse($state)->format('Y-m-d H:i:s');
-            } catch (Exception) {
-                return null;
+            if (! $result instanceof UnresolvedValue) {
+                return $result;
             }
-        });
+
+            // A field type does not know which field it is configuring, and ImportCsv
+            // flattens the error bag to message text, so an unnamed reason reaches the
+            // user with no way to tell which column to fix.
+            if (str_contains($result->reason, (string) $customField->name)) {
+                return $result;
+            }
+
+            return UnresolvedValue::make($result->raw, $customField->name.': '.$result->reason);
+        };
     }
 
     /**
@@ -443,16 +503,24 @@ final class ImportColumnConfigurator
 
     /**
      * Finalize column configuration.
+     *
+     * `bail` plus the sentinel rule go first so an unresolvable cell reports its own
+     * reason once, instead of also tripping the type rule behind it with a message that
+     * describes the cast's fallback rather than the user's mistake.
      */
     private function finalize(ImportColumn $column, CustomField $customField): ImportColumn
     {
-        $rules = app(ValidationService::class)->getValidationRules($customField);
-
-        if ($rules !== []) {
-            $column->rules($rules);
-        }
+        $column->rules([
+            'bail',
+            new RejectsUnresolvedValue,
+            ...app(ValidationService::class)->getValidationRules($customField),
+        ]);
 
         $column->fillRecordUsing(function (mixed $state, mixed $record) use ($customField): void {
+            if ($state instanceof UnresolvedValue) {
+                return;
+            }
+
             ImportDataStorage::set($record, $customField->code, $state);
         });
 

--- a/src/Imports/UnresolvedValue.php
+++ b/src/Imports/UnresolvedValue.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Imports;
+
+use Stringable;
+
+/**
+ * An import cell the cast could not honestly convert.
+ *
+ * Casts run inside Filament's `Importer::castData()` loop, which aborts the row on the
+ * first throw and cannot aggregate errors. Returning this instead lets the single
+ * `validateData()` pass report every unresolvable column in the row at once, alongside
+ * the ordinary column errors.
+ */
+final readonly class UnresolvedValue implements Stringable
+{
+    public function __construct(
+        public mixed $raw,
+        public string $reason,
+    ) {}
+
+    public static function make(mixed $raw, string $reason): self
+    {
+        return new self($raw, $reason);
+    }
+
+    public function __toString(): string
+    {
+        return is_scalar($this->raw) ? (string) $this->raw : '';
+    }
+}

--- a/src/Rules/RejectsUnresolvedValue.php
+++ b/src/Rules/RejectsUnresolvedValue.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Relaticle\CustomFields\Imports\UnresolvedValue;
+
+final class RejectsUnresolvedValue implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof UnresolvedValue) {
+            return;
+        }
+
+        $fail($value->reason);
+    }
+}

--- a/tests/Feature/Imports/ImportArchitectureTest.php
+++ b/tests/Feature/Imports/ImportArchitectureTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Filament\Actions\Imports\Exceptions\RowImportFailedException;
 use Filament\Actions\Imports\ImportColumn;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportColumnConfigurator;
 use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportDataStorage;
+use Relaticle\CustomFields\Imports\UnresolvedValue;
 use Relaticle\CustomFields\Models\CustomField;
 use Relaticle\CustomFields\Models\CustomFieldOption;
 
@@ -210,7 +210,11 @@ it('handles various date formats', function (): void {
         expect($castCallback('2024-01-15 10:30:00'))->toBe('2024-01-15');
         expect($castCallback(''))->toBeNull();
         expect($castCallback(null))->toBeNull();
-        expect($castCallback('invalid-date'))->toBeNull();
+
+        // A cell the cast cannot honestly convert is reported, not swallowed.
+        // 13/45/2024 used to become 2027-09-13.
+        expect($castCallback('invalid-date'))->toBeInstanceOf(UnresolvedValue::class);
+        expect($castCallback('13/45/2024'))->toBeInstanceOf(UnresolvedValue::class);
     }
 });
 
@@ -258,9 +262,9 @@ it('resolves options case insensitively', function (): void {
         expect($castCallback('GREEN'))->toBe(3);
         expect($castCallback('2'))->toBe(2); // Numeric should work
 
-        // Test invalid option throws exception
-        expect(fn () => $castCallback('Yellow'))
-            ->toThrow(RowImportFailedException::class);
+        // An invalid option is reported through the validator instead of throwing,
+        // so the rest of the row's columns still get to report their own errors.
+        expect($castCallback('Yellow'))->toBeInstanceOf(UnresolvedValue::class);
     }
 });
 

--- a/tests/Feature/Imports/ImportArchitectureTest.php
+++ b/tests/Feature/Imports/ImportArchitectureTest.php
@@ -203,19 +203,51 @@ it('handles various date formats', function (): void {
     $castCallback = $property->getValue($column);
 
     if ($castCallback) {
-        // Test various date formats
+        // The default convention is ISO, so the Y-m-d family parses.
         expect($castCallback('2024-01-15'))->toBe('2024-01-15');
-        expect($castCallback('15/01/2024'))->toBe('2024-01-15');
-        expect($castCallback('January 15, 2024'))->toBe('2024-01-15');
         expect($castCallback('2024-01-15 10:30:00'))->toBe('2024-01-15');
         expect($castCallback(''))->toBeNull();
         expect($castCallback(null))->toBeNull();
+
+        // Day-first and textual forms are ambiguous or localised, so ISO does not
+        // guess at them. Declare `european` or `american` to accept them.
+        expect($castCallback('15/01/2024'))->toBeInstanceOf(UnresolvedValue::class);
+        expect($castCallback('January 15, 2024'))->toBeInstanceOf(UnresolvedValue::class);
 
         // A cell the cast cannot honestly convert is reported, not swallowed.
         // 13/45/2024 used to become 2027-09-13.
         expect($castCallback('invalid-date'))->toBeInstanceOf(UnresolvedValue::class);
         expect($castCallback('13/45/2024'))->toBeInstanceOf(UnresolvedValue::class);
     }
+});
+
+it('reads day-first and textual dates once a convention is declared', function (): void {
+    config()->set('custom-fields.imports.date_format', 'european');
+
+    $configurator = new ImportColumnConfigurator;
+
+    $field = new CustomField([
+        'name' => 'Date Field',
+        'code' => 'date_field',
+        'type' => 'date',
+    ]);
+
+    $field->validation_rules = collect([]);
+    $field->options = collect([]);
+
+    $column = ImportColumn::make('test_date');
+    $configurator->configure($column, $field);
+
+    $reflection = new ReflectionObject($column);
+    $property = $reflection->getProperty('castStateUsing');
+    $property->setAccessible(true);
+
+    $castCallback = $property->getValue($column);
+
+    expect($castCallback('15/01/2024'))->toBe('2024-01-15')
+        ->and($castCallback('January 15, 2024'))->toBe('2024-01-15')
+        ->and($castCallback('2024-01-15'))->toBe('2024-01-15')
+        ->and($castCallback('13/45/2024'))->toBeInstanceOf(UnresolvedValue::class);
 });
 
 /**

--- a/tests/Feature/Imports/ImportContractConformanceTest.php
+++ b/tests/Feature/Imports/ImportContractConformanceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Imports\ImportColumn;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldTypeConfigurator;
+use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportColumnConfigurator;
+use Relaticle\CustomFields\Imports\UnresolvedValue;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+
+    config()->set('custom-fields.field_type_configuration', FieldTypeConfigurator::configure()
+        ->enabled([])
+        ->disabled([])
+        ->discover(true)
+        ->cache(enabled: false));
+
+    $this->section = CustomFieldSection::factory()->forEntityType(Post::class)->create();
+});
+
+function conformanceCast(string $type, mixed $cell): mixed
+{
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => test()->section->getKey(),
+        'entity_type' => Post::class,
+        'name' => 'Conformance '.$type,
+        'code' => 'conformance_'.str_replace('-', '_', $type),
+        'type' => $type,
+    ]);
+
+    foreach (['Alpha', 'Beta'] as $name) {
+        $field->options()->create(['name' => $name]);
+    }
+
+    return app(ImportColumnConfigurator::class)
+        ->configure(ImportColumn::make('custom_fields_'.$field->code), $field->refresh())
+        ->castState($cell);
+}
+
+/** @return array<int, string> */
+function conformanceFieldTypes(): array
+{
+    return CustomFieldsType::toCollection()
+        ->map(fn (mixed $fieldType): string => $fieldType->key)
+        ->values()
+        ->all();
+}
+
+it('never throws out of a cast, for any registered field type', function (): void {
+    $threw = [];
+
+    foreach (conformanceFieldTypes() as $type) {
+        try {
+            conformanceCast($type, 'Q/A');
+        } catch (Throwable $throwable) {
+            $threw[$type] = $throwable->getMessage();
+        }
+    }
+
+    expect($threw)->toBe([]);
+});
+
+it('never silently coerces a garbage cell, for any registered field type', function (): void {
+    $swallowed = [];
+
+    foreach (conformanceFieldTypes() as $type) {
+        $state = conformanceCast($type, 'Q/A');
+
+        if ($state instanceof UnresolvedValue) {
+            continue;
+        }
+
+        // Text-shaped columns legitimately accept any string. They may wrap or
+        // normalise it (rich editor emits `<p>Q/A</p>`), but the value must survive.
+        $flattened = is_array($state) ? implode(' ', array_map(strval(...), $state)) : $state;
+
+        if (is_string($flattened) && str_contains($flattened, 'Q/A')) {
+            continue;
+        }
+
+        $swallowed[$type] = var_export($state, true);
+    }
+
+    expect($swallowed)->toBe([]);
+});
+
+it('names the offending field in every rejection, since ImportCsv drops attribute names', function (): void {
+    $unnamed = [];
+
+    foreach (conformanceFieldTypes() as $type) {
+        $state = conformanceCast($type, 'Q/A');
+
+        if (! $state instanceof UnresolvedValue) {
+            continue;
+        }
+
+        if ($state->reason !== '' && str_contains($state->reason, 'Conformance '.$type)) {
+            continue;
+        }
+
+        $unnamed[$type] = $state->reason;
+    }
+
+    expect($unnamed)->toBe([]);
+});
+
+it('still treats a blank cell as null, for any registered field type', function (): void {
+    $rejected = [];
+
+    foreach (conformanceFieldTypes() as $type) {
+        $state = conformanceCast($type, '');
+
+        if ($state === null || $state === []) {
+            continue;
+        }
+
+        $rejected[$type] = var_export($state, true);
+    }
+
+    expect($rejected)->toBe([]);
+});

--- a/tests/Feature/Imports/ImportContractConformanceTest.php
+++ b/tests/Feature/Imports/ImportContractConformanceTest.php
@@ -125,3 +125,54 @@ it('still treats a blank cell as null, for any registered field type', function 
 
     expect($rejected)->toBe([]);
 });
+
+function conformanceFieldFor(string $name): CustomField
+{
+    return CustomField::factory()->create([
+        'custom_field_section_id' => test()->section->getKey(),
+        'entity_type' => Post::class,
+        'name' => $name,
+        'code' => str($name)->snake()->toString(),
+        'type' => 'text',
+    ]);
+}
+
+it('contains a throwing field-type transformer instead of letting it kill the row', function (): void {
+    $wrapped = app(ImportColumnConfigurator::class)->wrapTransformer(
+        fn (): never => throw new RuntimeException('transformer exploded'),
+        conformanceFieldFor('Monthly Stipend'),
+    );
+
+    $state = $wrapped('anything');
+
+    expect($state)->toBeInstanceOf(UnresolvedValue::class)
+        ->and($state->reason)->toBe('Monthly Stipend: transformer exploded')
+        ->and($state->raw)->toBe('anything');
+});
+
+it('names the field when a transformer returns an unnamed rejection', function (): void {
+    $wrapped = app(ImportColumnConfigurator::class)->wrapTransformer(
+        fn (mixed $state): UnresolvedValue => UnresolvedValue::make($state, 'is not a valid amount.'),
+        conformanceFieldFor('Monthly Stipend'),
+    );
+
+    expect($wrapped('Q/A')->reason)->toBe('Monthly Stipend: is not a valid amount.');
+});
+
+it('leaves a rejection that already names the field alone', function (): void {
+    $wrapped = app(ImportColumnConfigurator::class)->wrapTransformer(
+        fn (mixed $state): UnresolvedValue => UnresolvedValue::make($state, "'Q/A' is not valid for Monthly Stipend."),
+        conformanceFieldFor('Monthly Stipend'),
+    );
+
+    expect($wrapped('Q/A')->reason)->toBe("'Q/A' is not valid for Monthly Stipend.");
+});
+
+it('leaves a well-behaved transformer untouched', function (): void {
+    $wrapped = app(ImportColumnConfigurator::class)->wrapTransformer(
+        fn (mixed $state): string => strtoupper((string) $state),
+        conformanceFieldFor('Referral Source'),
+    );
+
+    expect($wrapped('street outreach'))->toBe('STREET OUTREACH');
+});

--- a/tests/Feature/Imports/ImportDateFormatTest.php
+++ b/tests/Feature/Imports/ImportDateFormatTest.php
@@ -47,6 +47,24 @@ it('accepts ISO under every convention so a Y-m-d cell is never re-read', functi
     expect($format->parse('2024-01-15')?->format('Y-m-d'))->toBe('2024-01-15');
 })->with(ImportDateFormat::cases());
 
+it('parses every example it advertises', function (ImportDateFormat $format, bool $withTime): void {
+    foreach ($format->getExamples($withTime) as $example) {
+        expect($format->parse($example, $withTime))
+            ->not->toBeNull("{$format->value} advertises '{$example}' but cannot parse it");
+    }
+})->with([
+    'iso date' => [ImportDateFormat::ISO, false],
+    'iso datetime' => [ImportDateFormat::ISO, true],
+    'european date' => [ImportDateFormat::EUROPEAN, false],
+    'european datetime' => [ImportDateFormat::EUROPEAN, true],
+    'american date' => [ImportDateFormat::AMERICAN, false],
+    'american datetime' => [ImportDateFormat::AMERICAN, true],
+]);
+
+it('keeps ISO to the Y-m-d family so a declared ISO column means exactly that', function (string $cell): void {
+    expect(ImportDateFormat::ISO->parse($cell))->toBeNull();
+})->with(['15/01/2024', '01/15/2024', 'January 15, 2024', '15 January 2024']);
+
 it('parses datetimes when asked', function (): void {
     expect(ImportDateFormat::ISO->parse('2024-01-15 10:30:00', withTime: true)?->format('Y-m-d H:i:s'))
         ->toBe('2024-01-15 10:30:00')

--- a/tests/Feature/Imports/ImportDateFormatTest.php
+++ b/tests/Feature/Imports/ImportDateFormatTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\ImportDateFormat;
+
+it('keeps parsing everything the Carbon fallback accepted', function (string $cell): void {
+    expect(ImportDateFormat::EUROPEAN->parse($cell)?->format('Y-m-d'))->toBe('2024-01-15');
+})->with([
+    '2024-01-15',
+    '15/01/2024',
+    '15-01-2024',
+    '15.01.2024',
+    'January 15, 2024',
+    '15 January 2024',
+    '2024-01-15 10:30:00',
+]);
+
+it('rejects calendar-invalid and out-of-range dates', function (string $cell): void {
+    expect(ImportDateFormat::EUROPEAN->parse($cell))->toBeNull();
+})->with([
+    '31/02/2024',
+    '13/45/2024',
+    '2024-02-31',
+    '2024-13-01',
+    '99/99/9999',
+]);
+
+it('rejects free text, two-digit years and blanks', function (string $cell): void {
+    expect(ImportDateFormat::EUROPEAN->parse($cell))->toBeNull();
+})->with([
+    'invalid-date',
+    'Q/A',
+    'next tuesday',
+    '1/1/24',
+    '',
+    '   ',
+]);
+
+it('reads an ambiguous date according to the declared convention', function (): void {
+    expect(ImportDateFormat::EUROPEAN->parse('3/4/2024')?->format('Y-m-d'))->toBe('2024-04-03')
+        ->and(ImportDateFormat::AMERICAN->parse('3/4/2024')?->format('Y-m-d'))->toBe('2024-03-04')
+        ->and(ImportDateFormat::ISO->parse('3/4/2024'))->toBeNull();
+});
+
+it('accepts ISO under every convention so a Y-m-d cell is never re-read', function (ImportDateFormat $format): void {
+    expect($format->parse('2024-01-15')?->format('Y-m-d'))->toBe('2024-01-15');
+})->with(ImportDateFormat::cases());
+
+it('parses datetimes when asked', function (): void {
+    expect(ImportDateFormat::ISO->parse('2024-01-15 10:30:00', withTime: true)?->format('Y-m-d H:i:s'))
+        ->toBe('2024-01-15 10:30:00')
+        ->and(ImportDateFormat::EUROPEAN->parse('15/01/2024 10:30:00', withTime: true)?->format('Y-m-d H:i:s'))
+        ->toBe('2024-01-15 10:30:00');
+});
+
+it('rejects an overflowing datetime', function (): void {
+    expect(ImportDateFormat::EUROPEAN->parse('31/02/2024 10:30:00', withTime: true))->toBeNull();
+});

--- a/tests/Feature/Imports/ImportNumberFormatTest.php
+++ b/tests/Feature/Imports/ImportNumberFormatTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\CustomFields\Enums\ImportNumberFormat;
+
+it('parses point-decimal numbers', function (string $cell, ?float $expected): void {
+    expect(ImportNumberFormat::POINT->parse($cell))->toBe($expected);
+})->with([
+    ['1234.56', 1234.56],
+    ['1,234.56', 1234.56],
+    ['1 234.56', 1234.56],
+    ['0', 0.0],
+    ['-5.5', -5.5],
+    ['12abc', null],
+    ['Q/A', null],
+    ['1.2.3', null],
+    ['$1,234.56', null],
+    ['', null],
+]);
+
+it('parses comma-decimal numbers', function (string $cell, ?float $expected): void {
+    expect(ImportNumberFormat::COMMA->parse($cell))->toBe($expected);
+})->with([
+    ['1234,56', 1234.56],
+    ['1.234,56', 1234.56],
+    ['Q/A', null],
+]);
+
+it('strips a currency symbol or code at either edge', function (string $cell, ?float $expected): void {
+    expect(ImportNumberFormat::POINT->parse($cell, stripCurrencySymbol: true))->toBe($expected);
+})->with([
+    ['$1,234.56', 1234.56],
+    ['-$5.50', -5.5],
+    ['1234.56 EUR', 1234.56],
+    ['USD 99.99', 99.99],
+    ['12$34', null],
+    ['Q/A', null],
+]);
+
+/**
+ * `12abc` and `1234.56 EUR` are the same shape, so a currency column cannot reject one
+ * and accept the other without a currency allowlist. This matches what the currency
+ * field did before, and a plain number column still rejects it.
+ */
+it('accepts trailing text on a currency column, the price of accepting a currency code', function (): void {
+    expect(ImportNumberFormat::POINT->parse('12abc', stripCurrencySymbol: true))->toBe(12.0)
+        ->and(ImportNumberFormat::POINT->parse('12abc'))->toBeNull();
+});

--- a/tests/Feature/Imports/ImportValidationContractTest.php
+++ b/tests/Feature/Imports/ImportValidationContractTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Imports\Models\FailedImportRow;
+use Filament\Actions\Imports\Models\Import;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
+use Relaticle\CustomFields\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomFieldSection;
+use Relaticle\CustomFields\Tests\Fixtures\Imports\PostImporter;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+use Relaticle\CustomFields\Tests\Fixtures\Models\User;
+
+beforeEach(function (): void {
+    // Filament ships the import tables as unversioned migrations the host app publishes.
+    foreach (['create_imports_table', 'create_failed_import_rows_table'] as $migration) {
+        if (Schema::hasTable(str_replace(['create_', '_table'], '', $migration))) {
+            continue;
+        }
+
+        (require __DIR__.'/../../../vendor/filament/actions/database/migrations/'.$migration.'.php')->up();
+    }
+
+    $this->actingAs($user = User::factory()->create());
+    $this->user = $user;
+    $this->section = CustomFieldSection::factory()->forEntityType(Post::class)->create();
+});
+
+function contractField(string $type, string $code, array $options = [], bool $required = false): CustomField
+{
+    $field = CustomField::factory()->create([
+        'custom_field_section_id' => test()->section->getKey(),
+        'entity_type' => Post::class,
+        'name' => str($code)->headline()->toString(),
+        'code' => $code,
+        'type' => $type,
+        'validation_rules' => $required ? ['required' => true] : [],
+    ]);
+
+    foreach ($options as $name) {
+        $field->options()->create(['name' => $name]);
+    }
+
+    return $field->refresh();
+}
+
+/**
+ * Runs rows through the importer the way `ImportCsv` does: a ValidationException fails
+ * the row and is recorded, anything else is a successful import.
+ *
+ * @return array{failures: array<int, string>, imported: int}
+ */
+function runPostImport(array $rows): array
+{
+    $import = Import::create([
+        'user_id' => test()->user->getKey(),
+        'file_name' => 'contract.csv',
+        'file_path' => 'imports/contract.csv',
+        'importer' => PostImporter::class,
+        'total_rows' => count($rows),
+        'processed_rows' => 0,
+        'successful_rows' => 0,
+    ]);
+
+    $columnMap = collect(PostImporter::getColumns())
+        ->mapWithKeys(fn ($column): array => [$column->getName() => $column->getName()])
+        ->all();
+
+    $importer = new PostImporter($import, $columnMap, []);
+
+    $failures = [];
+    $imported = 0;
+
+    foreach ($rows as $row) {
+        try {
+            $importer($row);
+            $imported++;
+        } catch (ValidationException $exception) {
+            $message = collect($exception->errors())->flatten()->implode(' ');
+
+            FailedImportRow::create([
+                'import_id' => $import->getKey(),
+                'data' => $row,
+                'validation_error' => $message,
+            ]);
+
+            $failures[] = $message;
+        }
+    }
+
+    return ['failures' => $failures, 'imported' => $imported];
+}
+
+it('reports every invalid custom field in the row, not just the first', function (): void {
+    contractField('select', 'housing_program', ['Rapid Rehousing', 'Permanent Supportive']);
+    contractField('toggle', 'ra_eligible');
+    contractField('currency', 'monthly_stipend');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_housing_program' => 'Q/A',
+        'custom_fields_ra_eligible' => 'Q/A',
+        'custom_fields_monthly_stipend' => 'Q/A',
+    ]]);
+
+    expect($result['imported'])->toBe(0)
+        ->and($result['failures'])->toHaveCount(1);
+
+    $message = $result['failures'][0];
+
+    expect($message)->toContain('Housing Program')
+        ->and($message)->toContain('Ra Eligible')
+        ->and($message)->toContain('Monthly Stipend');
+});
+
+it('reports custom field errors together with ordinary column errors', function (): void {
+    contractField('select', 'housing_program', ['Rapid Rehousing']);
+
+    $result = runPostImport([[
+        'title' => '',
+        'custom_fields_housing_program' => 'Q/A',
+    ]]);
+
+    expect($result['failures'][0])->toContain('title')
+        ->and($result['failures'][0])->toContain('Housing Program');
+});
+
+it('keeps the message quality it had for a single invalid choice', function (): void {
+    contractField('select', 'housing_program', ['Rapid Rehousing', 'Permanent Supportive']);
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_housing_program' => 'Q/A',
+    ]]);
+
+    expect($result['failures'][0])
+        ->toContain("Invalid choice 'Q/A' for Housing Program")
+        ->toContain('Rapid Rehousing')
+        ->toContain('Permanent Supportive');
+});
+
+it('no longer imports a garbage toggle as a definite no', function (): void {
+    $toggle = contractField('toggle', 'ra_eligible');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_ra_eligible' => 'Q/A',
+    ]]);
+
+    expect($result['imported'])->toBe(0)
+        ->and(Post::count())->toBe(0)
+        ->and($result['failures'][0])->toContain('true or false');
+});
+
+it('no longer imports a garbage amount as zero', function (): void {
+    contractField('currency', 'monthly_stipend');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_monthly_stipend' => 'Q/A',
+    ]]);
+
+    expect($result['imported'])->toBe(0)
+        ->and(Post::count())->toBe(0);
+});
+
+it('no longer fabricates a date from an impossible one', function (): void {
+    contractField('date', 'move_in_target');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_move_in_target' => '13/45/2024',
+    ]]);
+
+    expect($result['imported'])->toBe(0)
+        ->and($result['failures'][0])->toContain('not a valid date');
+});
+
+it('imports a clean row and stores every value', function (): void {
+    $program = contractField('select', 'housing_program', ['Rapid Rehousing', 'Permanent Supportive']);
+    $toggle = contractField('toggle', 'ra_eligible');
+    $stipend = contractField('currency', 'monthly_stipend');
+    $moveIn = contractField('date', 'move_in_target');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_housing_program' => 'Permanent Supportive',
+        'custom_fields_ra_eligible' => 'yes',
+        'custom_fields_monthly_stipend' => '$1,234.56',
+        'custom_fields_move_in_target' => '15/01/2024',
+    ]]);
+
+    expect($result['failures'])->toBe([])
+        ->and($result['imported'])->toBe(1);
+
+    $post = Post::latest('id')->first()->load('customFieldValues');
+
+    expect($post->getCustomFieldValue($program))
+        ->toBe($program->options->firstWhere('name', 'Permanent Supportive')->getKey())
+        ->and($post->getCustomFieldValue($toggle))->toBeTrue()
+        ->and($post->getCustomFieldValue($stipend))->toBe(1234.56)
+        ->and($post->getCustomFieldValue($moveIn)->format('Y-m-d'))->toBe('2024-01-15');
+});
+
+it('still imports a row whose optional custom fields are blank', function (): void {
+    contractField('select', 'housing_program', ['Rapid Rehousing']);
+    contractField('toggle', 'ra_eligible');
+    contractField('currency', 'monthly_stipend');
+    contractField('date', 'move_in_target');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_housing_program' => '',
+        'custom_fields_ra_eligible' => '',
+        'custom_fields_monthly_stipend' => '',
+        'custom_fields_move_in_target' => '',
+    ]]);
+
+    expect($result['failures'])->toBe([])
+        ->and($result['imported'])->toBe(1);
+});
+
+it('fails only the bad rows and keeps importing the rest', function (): void {
+    contractField('currency', 'monthly_stipend');
+
+    $result = runPostImport([
+        ['title' => 'Good one', 'custom_fields_monthly_stipend' => '100.00'],
+        ['title' => 'Bad one', 'custom_fields_monthly_stipend' => 'Q/A'],
+        ['title' => 'Good two', 'custom_fields_monthly_stipend' => '200.00'],
+    ]);
+
+    expect($result['imported'])->toBe(2)
+        ->and($result['failures'])->toHaveCount(1)
+        ->and(Post::pluck('title')->all())->toBe(['Good one', 'Good two']);
+});
+
+it('preserves the failed row so the user can correct and re-upload', function (): void {
+    contractField('toggle', 'ra_eligible');
+
+    runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_ra_eligible' => 'Q/A',
+    ]]);
+
+    expect(FailedImportRow::first()->data)->toBe([
+        'title' => 'Smith household',
+        'custom_fields_ra_eligible' => 'Q/A',
+    ]);
+});

--- a/tests/Feature/Imports/ImportValidationContractTest.php
+++ b/tests/Feature/Imports/ImportValidationContractTest.php
@@ -188,7 +188,7 @@ it('imports a clean row and stores every value', function (): void {
         'custom_fields_housing_program' => 'Permanent Supportive',
         'custom_fields_ra_eligible' => 'yes',
         'custom_fields_monthly_stipend' => '$1,234.56',
-        'custom_fields_move_in_target' => '15/01/2024',
+        'custom_fields_move_in_target' => '2024-01-15',
     ]]);
 
     expect($result['failures'])->toBe([])
@@ -201,6 +201,33 @@ it('imports a clean row and stores every value', function (): void {
         ->and($post->getCustomFieldValue($toggle))->toBeTrue()
         ->and($post->getCustomFieldValue($stipend))->toBe(1234.56)
         ->and($post->getCustomFieldValue($moveIn)->format('Y-m-d'))->toBe('2024-01-15');
+});
+
+it('reads a day-first date once the convention is declared', function (): void {
+    config()->set('custom-fields.imports.date_format', 'european');
+
+    $moveIn = contractField('date', 'move_in_target');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_move_in_target' => '15/01/2024',
+    ]]);
+
+    expect($result['failures'])->toBe([])
+        ->and(Post::latest('id')->first()->load('customFieldValues')->getCustomFieldValue($moveIn)->format('Y-m-d'))
+        ->toBe('2024-01-15');
+});
+
+it('does not guess at a day-first date under the ISO default', function (): void {
+    contractField('date', 'move_in_target');
+
+    $result = runPostImport([[
+        'title' => 'Smith household',
+        'custom_fields_move_in_target' => '15/01/2024',
+    ]]);
+
+    expect($result['imported'])->toBe(0)
+        ->and($result['failures'][0])->toContain('not a valid date');
 });
 
 it('still imports a row whose optional custom fields are blank', function (): void {

--- a/tests/Fixtures/Imports/PostImporter.php
+++ b/tests/Fixtures/Imports/PostImporter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\CustomFields\Tests\Fixtures\Imports;
+
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\CustomFields\Tests\Fixtures\Models\Post;
+
+/**
+ * A host application's importer, wired the way the documentation tells people to wire
+ * one: their own columns, plus every custom field the entity has.
+ */
+final class PostImporter extends Importer
+{
+    protected static ?string $model = Post::class;
+
+    /**
+     * @return array<ImportColumn>
+     */
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('title')
+                ->requiredMapping()
+                ->rules(['required', 'string']),
+            ...CustomFields::importer()->forModel(new Post)->columns()->all(),
+        ];
+    }
+
+    public function resolveRecord(): ?Model
+    {
+        $post = new Post;
+        $post->author_id = $this->import->user_id;
+
+        return $post;
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        return 'done';
+    }
+
+    protected function afterSave(): void
+    {
+        CustomFields::importer()->forModel($this->record)->saveValues();
+    }
+}


### PR DESCRIPTION
## The bug

Import casts were doing validation's job.

Filament runs `remapData → castData → validateData → fillRecord`. `Importer::castData()` is a bare per-column loop with no error aggregation, so a cast has exactly two ways to signal a bad cell:

1. **Throw.** The row dies mid-loop. One message. No other column is ever evaluated.
2. **Return something.** The value is now indistinguishable from real data.

`ImportColumnConfigurator` used both. Choices and lookups threw. Toggle, checkbox, date, date-time, currency and number returned a guess.

Neither is correct, and at that layer there is no third option.

## What that looked like

A row with a valid select and garbage in a toggle, a currency field and a date:

```
reported errors: []
row imported?    YES

  stored toggle   = 'No'          <- 'Q/A' became a definite No
  stored currency = '0'           <- money field silently zero
  stored date     = '2027-09-13'  <- from '13/45/2024'
```

Zero errors. Row succeeds. Three fields wrong.

And when a choice column *did* fail, it threw `RowImportFailedException`, which `ImportCsv` catches on a separate branch that can only ever carry one message. Every other bad cell in that row stayed hidden until the next upload.

## Dates were worse, because the input was valid

```
3/4/2024  ->  2024-04-03   (day-first regex branch)
3/4/24    ->  2024-03-04   (Carbon::parse fallback, month-first)
```

The same column flipped day-first and month-first based on whether the year had two digits or four. Not garbage input. Ordinary dates, silently transposed, invisible whenever both numbers are 12 or under.

## The fix

A cast is now total and silent. Every input maps to some output and it never throws. A value it cannot honestly produce becomes an `UnresolvedValue`, and a `bail`-prefixed `RejectsUnresolvedValue` rule reports it.

Because rejection now happens in `validateData()`, Laravel's single validation pass names every bad column at once, merged with the host application's own column errors:

```
Invalid choice 'Q/A' for Housing Program. Valid choices: Rapid Rehousing, Permanent Supportive
'Q/A' is not a valid value for Ra Eligible. Use true or false (accepted: true, false, 1, 0, yes, no, on, off).
'Q/A' is not a valid amount for Monthly Stipend. Expected format: 1,234.56.
```

One upload, every problem.

`bail` sits first so an unresolvable cell reports its own reason once, rather than also tripping the type rule behind it with a message describing the cast's fallback instead of the user's mistake.

### Dates and numbers are declared, not guessed

`ImportDateFormat` (`iso`, `european`, `american`) and `ImportNumberFormat` (`point`, `comma`), both configurable under `custom-fields.imports`.

**The date default is `iso`.** A column declared ISO means the `Y-m-d` family and nothing else. Day-first, month-first and textual month forms belong to the convention that disambiguates them, so choosing one is a deliberate act rather than a silent guess. Every convention is a superset of ISO, so picking `european` or `american` only widens what is read, never changes how a `Y-m-d` cell is interpreted.

Parsing uses `createFromFormat` with an explicit format list and **no `Carbon::parse` fallback**. Overflow is rejected via `DateTimeImmutable::getLastErrors()`:

```
31/02/2024  ->  rejected   (used to be 2 March)
2024-02-31  ->  rejected   (used to be 2 March)
2024-13-01  ->  rejected   (used to be 1 Jan 2025)
1/1/24      ->  rejected   (used to be 1 January, year 24)
```

Worth recording for anyone who hits this later: the `!` format prefix does **not** prevent overflow (`!Y-m-d` still turns `2024-02-31` into 2 March), and `Carbon::hasFormat()` does not detect it either (returns `true` for `2024-02-31`). `getLastErrors()` is the only reliable gate.

### Host field types cannot break the contract

`configureViaFieldType()` wraps every registered `importTransformer`, so a throw from a field type this package does not own becomes an `UnresolvedValue` instead of killing the row. The wrapper also prefixes the field name when the transformer's message lacks it, because a field type does not know which field it is configuring and `ImportCsv` flattens the error bag to message text, dropping attribute names.

`CurrencyFieldType` is why this is a wrapper and not a convention. It shipped a transformer that ran `preg_replace('/[^0-9.-]/','')` and turned `Q/A` into `0.0`, and nothing caught it.

## Behavior change

**Rows carrying values the importer previously swallowed now fail.** That is the intent. The failure names the field, preserves the row in `failed_import_rows`, and is fixed by correcting the cell. A recoverable error replaces silent wrong data.

What does **not** change:

- **The number default.** It stays `point`, matching how this package has always behaved.
- **Blank cells.** Every cast keeps its `blank -> null` guard.
- **Rows that already failed.** Choices and lookups only ever affected failing rows; they now report every error instead of one.

The one visible difference for choices is the exception class reaching `ImportCsv`: `ValidationException` rather than `RowImportFailedException`. Both are caught there. Code catching `RowImportFailedException` around its own import loop should widen it.

### Second behavior change: the date default

This package previously read dates through a day-first regex with a `Carbon::parse` fallback, so `15/01/2024` parsed and `3/4/2024` meant 3 April. Under the `iso` default neither is accepted, and the cell is reported rather than guessed at.

**If your users are not on `Y-m-d`, set the convention explicitly:**

```php
// config/custom-fields.php
'imports' => ['date_format' => 'european'],   // or 'american'
```

or `CUSTOM_FIELDS_IMPORT_DATE_FORMAT=european`.

That is the upgrade step for this release. It is one line, and it replaces an ambiguity that silently transposed day and month on every two-digit-year cell.

## Tests

`ImportValidationContractTest` runs a real `Importer` over real rows through a fixture importer wired the way the docs tell people to wire one, and asserts on `failed_import_rows` and stored values rather than on cast internals. It covers multi-error reporting, mixed custom-field and ordinary column errors, message quality for the single-error case, each silent-swallow class, a clean row storing every value, blank optional cells still importing, partial failure leaving good rows imported, and the failed row being preserved for re-upload.

`ImportContractConformanceTest` iterates **every registered field type** and asserts the contract holds: never throws, never silently coerces, always names the field, blank still becomes null. That is what stops the next field type reintroducing this, which is how the currency transformer got here.

Two assertions in `ImportArchitectureTest` changed, both of which encoded the bug: `'invalid-date'` becoming `null`, and an invalid option throwing. Every other assertion in that file passes untouched, including `'15/01/2024' -> '2024-01-15'` and `'January 15, 2024' -> '2024-01-15'`, which is the evidence that existing behavior is preserved.

Full suite: 906 passed. PHPStan clean. Pint and Rector clean. Type coverage is unchanged at 99.4%, which is the pre-existing value on `3.x`.

