### PR TITLE
fix(ci): make the docs deploy deterministic and gate it on pull requests

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Docs
+
+# Mirrors the build half of deploy-docs.yml so a broken docs dependency tree is
+# caught on the pull request instead of after the merge, when only the deploy runs.
+on:
+  pull_request:
+    branches: [3.x]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Docs build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: 'docs/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./docs
+        run: npm ci
+
+      - name: Build documentation
+        working-directory: ./docs
+        run: npm run generate
+        env:
+          NUXT_APP_BASE_URL: /custom-fields/
+          NUXT_SITE_URL: https://relaticle.github.io
+          DOCS_VERSION: 3.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,14 @@ jobs:
 
       - name: Run Pest
         run: vendor/bin/pest --ci
+
+  gate:
+    name: Tests passed
+    runs-on: ubuntu-latest
+    needs: [actions-pinned, tests]
+    if: always()
+
+    steps:
+      - name: Fail unless every job succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,8 +10,7 @@
                 "@nuxt/scripts": "^1.3.8",
                 "@nuxt/ui": "^4.11.0",
                 "@unhead/vue": "^3.4.0",
-                "better-sqlite3": "^13.0.3",
-                "docus": "*",
+                "docus": "^5.9.0",
                 "nuxt": "^4.5.2",
                 "typescript": "^7.0.2"
             },
@@ -9174,24 +9173,18 @@
             }
         },
         "node_modules/better-sqlite3": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
-            "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+            "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "node-addon-api": "^8.0.0"
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
             },
             "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/better-sqlite3/node_modules/node-addon-api": {
-            "version": "8.9.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
-            "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18 || ^20 || >= 21"
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
             }
         },
         "node_modules/bindings": {
@@ -9210,6 +9203,58 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/body-parser": {
@@ -10153,6 +10198,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -11457,6 +11512,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
         "node_modules/engine.io-client": {
             "version": "6.6.6",
             "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
@@ -11950,6 +12015,16 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/express": {
@@ -12888,6 +12963,13 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -13051,6 +13133,13 @@
             "dependencies": {
                 "git-up": "^8.1.0"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/github-slugger": {
             "version": "2.0.0",
@@ -15983,6 +16072,13 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/mlly": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -16093,6 +16189,13 @@
             "resolved": "https://registry.npmjs.org/nanotar/-/nanotar-0.3.0.tgz",
             "integrity": "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==",
             "license": "MIT"
+        },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -16691,6 +16794,19 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/node-abi": {
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/node-addon-api": {
@@ -18932,6 +19048,34 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19154,6 +19298,17 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -19244,6 +19399,29 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "peer": true,
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -21177,6 +21355,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strip-literal": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -21327,6 +21515,58 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-fs/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC",
+            "peer": true
+        },
+        "node_modules/tar-fs/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/tar-fs/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tar-stream": {
@@ -21533,6 +21773,19 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,8 +11,7 @@
         "@nuxt/scripts": "^1.3.8",
         "@nuxt/ui": "^4.11.0",
         "@unhead/vue": "^3.4.0",
-        "better-sqlite3": "^13.0.3",
-        "docus": "latest",
+        "docus": "^5.9.0",
         "nuxt": "^4.5.2",
         "typescript": "^7.0.2"
     },


### PR DESCRIPTION
The docs deploy has failed on every `3.x` push since 2026-08-08 ([08-08](https://github.com/relaticle/custom-fields/actions/runs/31261551779), [08-12](https://github.com/relaticle/custom-fields/actions/runs/31626192922), [08-19](https://github.com/relaticle/custom-fields/actions/runs/32267508684), [08-20](https://github.com/relaticle/custom-fields/actions/runs/32414769349), [08-30](https://github.com/relaticle/custom-fields/actions/runs/33327585259)). Each failure was patched by hand or left standing; this fixes the causes.

## Why it kept breaking

**`docus` was declared as `latest`.** npm normalises that to `*` in the lockfile, so `npm ci` re-resolved docus against the registry on every run instead of reproducing the lockfile. Its transitive tree then drifted and the install died with `EUSAGE: Missing: oxc-parser@X from lock file`, where X tracked the run date (0.143.0 on 08-08, 0.144.0 on 08-12, 0.146.0 on 08-19). Pinning to `^5.9.0` makes `npm ci` deterministic. The resolved version is unchanged at 5.9.0.

**`better-sqlite3` was pinned to `^13` against a `12.x` peer.** docus 5.9.0 peer-requires `better-sqlite3@12.x`; the 08-29 dependabot group bump took the direct dependency to 13.0.3, so `npm ci` failed with `ERESOLVE`. It is not imported anywhere in `docs/` , it exists only to satisfy that peer, and npm installs peers automatically. Dropping the direct dependency keeps it tracking docus (12.11.1 is now resolved as a peer) and stops dependabot from proposing the conflict again.

**Nothing verified the docs build before merge.** `deploy-docs.yml` only runs `on: push`, so dependabot PRs touching `docs/**` were auto-merged on the strength of the PHP suite alone and the breakage only surfaced afterwards, on the deploy.

## Changes

- `docs/package.json`: pin `docus` to `^5.9.0`, drop the direct `better-sqlite3` dependency; lockfile regenerated.
- `.github/workflows/docs.yml` (new): builds the docs on every pull request to `3.x`, mirroring the build half of the deploy.
- `.github/workflows/tests.yml`: add a `Tests passed` job that aggregates the matrix under a name that survives matrix changes, so it can be a required check without going stale when the PHP/Laravel versions move.
- `.github/workflows/deploy-docs.yml`: Node 20 to 24. nuxt requires `^22.19.0 || ^24.11.0 || >=26.0.0`; the runner was already emitting `EBADENGINE` warnings on 20, which is past EOL.

The two new job names are intended to become required status checks on `3.x`. Without them `gh pr merge --auto` does not wait for anything, which is what let the broken lockfile land.

## Verification

Reproduced the exact `ERESOLVE` failure locally against `3.x`, then on this branch, on Node 24.20.0:

- `rm -rf node_modules && npm ci` succeeds.
- `NUXT_APP_BASE_URL=/custom-fields/ NUXT_SITE_URL=https://relaticle.github.io DOCS_VERSION=3.x npm run generate` succeeds, prerendering 53 routes into `.output/public`.
- `node_modules/better-sqlite3` resolves to 12.11.1 with its native binding built.

The per-page OG image warnings (`[400] Invalid island request hash`) are pre-existing and do not fail the build: the last successful deploy on 2026-07-28 also produced no `_og/` output on `gh-pages`. Not addressed here.
