### PR TITLE
fix(ci): deploy the docs after a token merge

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yml'
+  # A merge performed with GITHUB_TOKEN does not trigger `on: push`, so every
+  # auto-merged docs bump lands without deploying. This reconciles the site with
+  # whatever is on the branch, whoever merged it.
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       version:
@@ -31,11 +36,15 @@ jobs:
     steps:
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "branch=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          # On a schedule GITHUB_REF is the default branch, which is the one to reconcile.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "branch=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+            echo "branch=${GITHUB_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set version config


### PR DESCRIPTION
Follow-up to #217. Enabling auto-merge exposed a gap that was latent before, because nothing was auto-merging.

## The gap, measured

A merge performed with `GITHUB_TOKEN` does not create a new workflow run. `deploy-docs.yml` is `on: push` only, so an auto-merged docs bump lands and the site never rebuilds.

Three PRs merged by `github-actions` today, and none of them produced a single check run:

```
$ gh api repos/relaticle/custom-fields/commits/<sha>/check-runs --jq '[.check_runs[].name]'
c2c35820 (#215): NO RUNS
7868af17 (#218): NO RUNS
36745e0a (#220): NO RUNS
```

`7868af17` changed `docs/package-lock.json`. The last `Deploy Docs` run is `06f27f5` at 12:32, the merge of #217, which was merged by a human. Everything after it is invisible to the deploy.

## Fix

A daily `schedule` reconcile, which fires regardless of who merged.

`schedule` was chosen over a GitHub App token because it needs no new secret, no app install, and no privileged credential in a public repository. The tradeoff is latency: a docs bump merged by the token now deploys within a day rather than within a minute. The push trigger is unchanged, so human merges still deploy immediately.

Cost of a quiet day is one no-op run. The deploy step already ends with:

```
if git diff --staged --quiet; then
  echo "No changes to deploy"
```

so an unchanged build commits and pushes nothing.

On a scheduled run `GITHUB_REF` is the default branch, which is exactly the branch to reconcile, so `Determine version` needed no new case. Per GitHub's docs: "Scheduled workflows will only run on the default branch."

## Also

`Determine version` stops interpolating `github.event_name` and `inputs.version` directly into the shell, moving both into `env:`. That clears the last two `template-injection` findings on this file. `zizmor --no-online-audits` reports 0 findings across `.github/workflows` on this branch.

## Sibling repos

`comments`, `flowforge` and `activity-log` have the same push-only deploy and the same exposure. Their hardening PRs (relaticle/comments#35, relaticle/flowforge#184, relaticle/activity-log#46) are still open; this trigger goes in once those land, to keep each PR reviewable on its own.